### PR TITLE
[KAIZEN-0] fjerner ubrukt avhengighet til common-time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
             </dependency>
             <dependency>
                 <groupId>no.nav.common</groupId>
-                <artifactId>time</artifactId>
-                <version>${common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>no.nav.common</groupId>
                 <artifactId>nais</artifactId>
                 <version>${common.version}</version>
             </dependency>


### PR DESCRIPTION
time-modulen er på tur ut fra common, se PR: https://github.com/navikt/common-java-modules/pull/315