### PR TITLE
Endret InnsynJournal_v2 url fra joark (WAS) til dokarkiv (NAIS)

### DIFF
--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -114,7 +114,7 @@ spec:
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
       value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
-      value: "https://wasapp-q0.adeo.no/joark/InnsynJournal/v2"
+      value: "https://dokarkiv-q0.nais.preprod.local/services/innsynjournal/v2"
     - name: INNSYNJOURNAL_V2_SECURITYTOKEN
       value: "SAML"
     - name: INNSYNJOURNAL_V2_WSDLURL

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -114,7 +114,7 @@ spec:
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
       value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
-      value: "https://wasapp-q1.adeo.no/joark/InnsynJournal/v2"
+      value: "https://dokarkiv-q1.nais.preprod.local/services/innsynjournal/v2"
     - name: INNSYNJOURNAL_V2_SECURITYTOKEN
       value: "SAML"
     - name: INNSYNJOURNAL_V2_WSDLURL

--- a/.nais/nais-q6.yml
+++ b/.nais/nais-q6.yml
@@ -114,7 +114,7 @@ spec:
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
       value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
-      value: "https://wasapp-q6.adeo.no/joark/InnsynJournal/v2"
+      value: "https://dokarkiv-q6.nais.preprod.local/services/innsynjournal/v2"
     - name: INNSYNJOURNAL_V2_SECURITYTOKEN
       value: "SAML"
     - name: INNSYNJOURNAL_V2_WSDLURL

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -114,7 +114,7 @@ spec:
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
       value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
-      value: "https://wasapp.adeo.no/joark/InnsynJournal/v2"
+      value: "https://dokarkiv.nais.adeo.no/services/innsynjournal/v2"
     - name: INNSYNJOURNAL_V2_SECURITYTOKEN
       value: "SAML"
     - name: INNSYNJOURNAL_V2_WSDLURL


### PR DESCRIPTION
Hei

Vi har flyttet InnsynJournal_v2 tjenesten til dokarkiv på NAIS. Tjenesten er identisk og den har vært i bruk i produksjon siden 12. mars i år.

Vi ser at dere har URLer mot joark og ønsker få disse oppdatert. Vi kommer til å sanere tjenesten på joark så snart alle NAIS konsumenter har tatt i bruk ny url.