### PR TITLE
[KAIZEN-0] ferdigstill endepunkt logger feil ved allerede ferdigstilt…

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -107,8 +107,9 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     @Override
     public void ferdigstillHenvendelse(Melding melding, Optional<String> oppgaveId, Optional<Sak> sak, String behandlingsId, String saksbehandlersValgteEnhet) throws Exception {
         if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
-            logger.info("Oppgaven er ferdigstilt med id: {}", oppgaveId);
-            return;        }
+            logger.error("Oppgaven er ferdigstilt med id: {}", oppgaveId);
+            return;
+        }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);
 

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -29,6 +29,8 @@ import no.nav.tjeneste.domene.brukerdialog.henvendelse.v1.senduthenvendelse.meld
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v1.senduthenvendelse.meldinger.WSSendUtHenvendelseResponse;
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v2.henvendelse.HenvendelsePortType;
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v2.meldinger.WSHentHenvendelseListeRequest;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -57,6 +59,7 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     private final PersonKjerneinfoServiceBi kjerneinfo;
     private final LDAPService ldapService;
     private final Tilgangskontroll tilgangskontroll;
+    private static final Logger logger = LoggerFactory.getLogger(HenvendelseUtsendingServiceImpl.class);
 
     @Inject
     public HenvendelseUtsendingServiceImpl(HenvendelsePortType henvendelsePortType,
@@ -104,8 +107,8 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     @Override
     public void ferdigstillHenvendelse(Melding melding, Optional<String> oppgaveId, Optional<Sak> sak, String behandlingsId, String saksbehandlersValgteEnhet) throws Exception {
         if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
-            throw new OppgaveErFerdigstilt();
-        }
+            logger.info("Oppgaven er ferdigstilt med id: {}", oppgaveId);
+            return;        }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);
 


### PR DESCRIPTION
…, legger inn en warning istedenfor


Jeg og Ankur gikk igjennom post feil i prod og fant veldig mange ferdigstill post feil som skaper støy. Det ser ut som at dersom oppgaven allerede er ferdigstilt når man sender inn svar (som også muligens skjer flere kall på) så kaster vi en exception. Dette kan være en måte å logge hva som skjer men ikke potensielt gi bruker feil info dersom oppgaven allerede er ferdigstilt
