### PR TITLE
[KAIZEN-0] oppdaterte format på audit-logger

### DIFF
--- a/tilgangskontroll/src/main/java/no/nav/sbl/dialogarena/naudit/Audit.kt
+++ b/tilgangskontroll/src/main/java/no/nav/sbl/dialogarena/naudit/Audit.kt
@@ -6,7 +6,8 @@ import org.slf4j.LoggerFactory
 
 private val tjenestekallLogg = LoggerFactory.getLogger("SecureLog")
 val cefLogger = ArchSightCEFLogger(CEFLoggerConfig(
-        applicationName = "modiapersonoversikt-api",
+        applicationName = "modia",
+        logName = "personoversikt",
         filter = { (action: Audit.Action, resource: Audit.AuditResource) ->
             action != Audit.Action.READ || resource == AuditResources.Person.Personalia
         }

--- a/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/naudit/ArchSightCEFLogger.kt
+++ b/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/naudit/ArchSightCEFLogger.kt
@@ -1,0 +1,22 @@
+package no.nav.sbl.dialogarena.naudit
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+internal class ArchSightCEFLoggerTest {
+    @Test
+    fun `CEF-format`() {
+        val time = Instant.now().toEpochMilli()
+        val expected = String.format("CEF:0|modia|personoversikt|1.0|audit:access|SporingsLogger|INFO|end=%s act=UPDATE suid=Z999999 sproc=saksbehandler.valgtenhet", time.toString())
+        val message = cefLogger.create(CEFEvent(
+                action = Audit.Action.UPDATE,
+                resource = AuditResources.Saksbehandler.ValgtEnhet,
+                subject = "Z999999",
+                time = time,
+                identifiers = arrayOf()
+        ))
+
+        assertEquals(expected, message)
+    }
+}


### PR DESCRIPTION
Endret på forespørsel fra ArchSight-folkene.

- endret `name` til `sproc`, `name` er ikke en godkjent CEF-key
- endret appname til `modia`, har tidligere vært `modia` så gjør ting lettere for de.
- endret logname til `personoversikt`, for å bevare informasjon om hvilket system det kommer fra