### PR TITLE
[KAIZEN-0] fjerne hentNavn-graphql-operasjon

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/pdl/PdlOppslagService.kt
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/pdl/PdlOppslagService.kt
@@ -1,13 +1,11 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.api.service.pdl
 
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentIdent
-import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentNavn
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentNavnBolk
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentPerson
 
 interface PdlOppslagService {
     fun hentPerson(fnr: String): HentPerson.Person?
-    fun hentNavn(fnr: String): HentNavn.Person?
-    fun hentNavnBolk(fnrs: List<String>): Map<String, HentNavnBolk.Navn?>?
     fun hentIdent(fnr: String): HentIdent.Identliste?
+    fun hentNavnBolk(fnrs: List<String>): Map<String, HentNavnBolk.Navn?>?
 }

--- a/api/src/main/resources/pdl/queries/hentNavn.graphql
+++ b/api/src/main/resources/pdl/queries/hentNavn.graphql
@@ -1,9 +1,0 @@
-query($ident: ID!){
-    hentPerson(ident: $ident) {
-        navn {
-            fornavn
-            mellomnavn
-            etternavn
-        }
-    }
-}

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/pdl/PdlOppslagServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/pdl/PdlOppslagServiceImpl.kt
@@ -11,7 +11,6 @@ import no.nav.common.oidc.SystemUserTokenProvider
 import no.nav.log.MDCConstants
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.pdl.PdlOppslagService
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentIdent
-import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentNavn
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentNavnBolk
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentPerson
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.unleash.strategier.ByEnvironmentStrategy.ENVIRONMENT_PROPERTY
@@ -38,10 +37,6 @@ class PdlOppslagServiceImpl : PdlOppslagService {
 
     override fun hentPerson(fnr: String): HentPerson.Person? = doRequest(fnr) { pdlFnr, httpHeaders ->
         HentPerson(graphQLClient).execute(HentPerson.Variables(pdlFnr), httpHeaders)
-    }?.data?.hentPerson
-
-    override fun hentNavn(fnr: String): HentNavn.Person? = doRequest(fnr) { pdlFnr, httpHeaders ->
-        HentNavn(graphQLClient).execute(HentNavn.Variables(pdlFnr), httpHeaders)
     }?.data?.hentPerson
 
     override fun hentNavnBolk(fnrs: List<String>): Map<String, HentNavnBolk.Navn?>? {


### PR DESCRIPTION
Bruken er erstattet med bolk oppslag som gjør at det går færre kall til pdl