### PR TITLE
[KAIZEN-0] kaste feil ved ferdigstilling og oppgave allerede er ferdi…

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/HenvendelseUtsendingService.java
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/HenvendelseUtsendingService.java
@@ -22,7 +22,4 @@ public interface HenvendelseUtsendingService {
     void oppdaterTemagruppe(String behandlingsId, String temagruppe);
 
     String slaaSammenTraader(List<String> traadIder);
-
-    class OppgaveErFerdigstilt extends Exception {
-    }
 }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/ApplicationFeilType.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/ApplicationFeilType.kt
@@ -4,7 +4,9 @@ import no.nav.apiapp.feil.Feil
 import javax.ws.rs.core.Response
 
 enum class ApplikasjonsFeilType(private val status: Response.Status) : Feil.Type {
-    JOURNALFORING_FEILET(Response.Status.INTERNAL_SERVER_ERROR);
+    JOURNALFORING_FEILET(Response.Status.INTERNAL_SERVER_ERROR),
+    INGEN_MELDINGER(Response.Status.INTERNAL_SERVER_ERROR),
+    OPPGAVE_ER_FERDIGSTILT(Response.Status.INTERNAL_SERVER_ERROR);
 
     override fun getName(): String {
         return name
@@ -17,3 +19,8 @@ enum class ApplikasjonsFeilType(private val status: Response.Status) : Feil.Type
 }
 
 internal class JournalforingFeiletException(t: Throwable) : Feil(ApplikasjonsFeilType.JOURNALFORING_FEILET, t)
+internal class OppgaveErFerdigstiltException : Feil(ApplikasjonsFeilType.OPPGAVE_ER_FERDIGSTILT)
+internal class IngenMeldingerException(fnr: String?, traadId: String?) : Feil(
+        ApplikasjonsFeilType.INGEN_MELDINGER,
+        "Fant ingen meldinger for fnr: $fnr med traadId: $traadId"
+)

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -83,10 +83,13 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     }
 
     @Override
-    public String sendHenvendelse(Melding melding, Optional<String> oppgaveId,
-                                  Optional<Sak> sak, String saksbehandlersValgteEnhet) {
-        if (oppgaveId.isPresent() && oppgaveBehandlingService
-                .oppgaveErFerdigstilt(oppgaveId.get())) {
+    public String sendHenvendelse(
+            Melding melding,
+            Optional<String> oppgaveId,
+            Optional<Sak> sak,
+            String saksbehandlersValgteEnhet
+    ) {
+        if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
             throw new OppgaveErFerdigstiltException();
         }
 
@@ -99,8 +102,13 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
                         .withAny(xmlHenvendelse));
 
         try {
-            fullbyrdeSendtInnHenvendelse(melding, oppgaveId, sak,
-                    wsSendUtHenvendelseResponse.getBehandlingsId(), saksbehandlersValgteEnhet);
+            fullbyrdeSendtInnHenvendelse(
+                    melding,
+                    oppgaveId,
+                    sak,
+                    wsSendUtHenvendelseResponse.getBehandlingsId(),
+                    saksbehandlersValgteEnhet
+            );
             return wsSendUtHenvendelseResponse.getBehandlingsId();
         } catch (Exception e) {
             throw new JournalforingFeiletException(e);
@@ -157,8 +165,9 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
         if (sak.isPresent()) {
             sakerService.knyttBehandlingskjedeTilSak(melding.fnrBruker, melding.traadId, sak.get(), saksbehandlersValgteEnhet);
         }
-        oppgaveId.ifPresent(s -> oppgaveBehandlingService
-                .ferdigstillOppgaveIGsak(s, temagruppe, saksbehandlersValgteEnhet));
+        oppgaveId.ifPresent(s ->
+                oppgaveBehandlingService.ferdigstillOppgaveIGsak(s, temagruppe, saksbehandlersValgteEnhet)
+        );
         if (temagruppe == ANSOS) {
             merkSomKontorsperret(melding.fnrBruker, singletonList(melding.id));
         }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -6,7 +6,6 @@ import no.nav.kjerneinfo.domain.person.Person;
 import no.nav.melding.domene.brukerdialog.behandlingsinformasjon.v1.XMLHenvendelse;
 import no.nav.melding.domene.brukerdialog.behandlingsinformasjon.v1.XMLHenvendelseType;
 import no.nav.modig.content.ContentRetriever;
-import no.nav.modig.core.exception.ApplicationException;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.Temagruppe;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.gsak.Sak;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.henvendelse.Fritekst;
@@ -85,10 +84,10 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
 
     @Override
     public String sendHenvendelse(Melding melding, Optional<String> oppgaveId,
-                                  Optional<Sak> sak, String saksbehandlersValgteEnhet) throws Exception {
+                                  Optional<Sak> sak, String saksbehandlersValgteEnhet) {
         if (oppgaveId.isPresent() && oppgaveBehandlingService
                 .oppgaveErFerdigstilt(oppgaveId.get())) {
-            throw new OppgaveErFerdigstilt();
+            throw new OppgaveErFerdigstiltException();
         }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);
@@ -117,7 +116,7 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     public void ferdigstillHenvendelse(Melding melding, Optional<String> oppgaveId, Optional<Sak> sak, String behandlingsId, String saksbehandlersValgteEnhet) throws Exception {
         if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
             logger.error("Oppgaven er ferdigstilt med id: {}", oppgaveId);
-            throw new OppgaveErFerdigstilt();
+            throw new OppgaveErFerdigstiltException();
         }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);
@@ -180,7 +179,7 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
                         .collect(toList());
 
         if (meldinger.isEmpty()) {
-            throw new ApplicationException(String.format("Fant ingen meldinger for fnr: %s med traadId: %s", fnr, traadId));
+            throw new IngenMeldingerException(fnr, traadId);
         }
 
         gjorTilgangSjekk(valgtEnhet, meldinger);

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -122,7 +122,7 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     public void ferdigstillHenvendelse(Melding melding, Optional<String> oppgaveId, Optional<Sak> sak, String behandlingsId, String saksbehandlersValgteEnhet) throws Exception {
         if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
             logger.error("Oppgaven er ferdigstilt med id: {}", oppgaveId);
-            throw new BadRequestException("Oppgaven er ferdigstilt med id: " + oppgaveId);
+            throw new OppgaveErFerdigstilt();
         }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/HenvendelseUtsendingServiceImpl.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.ws.rs.BadRequestException;
+
 import no.nav.kjerneinfo.consumer.fim.person.PersonKjerneinfoServiceBi;
 import no.nav.kjerneinfo.consumer.fim.person.to.HentKjerneinformasjonRequest;
 import no.nav.kjerneinfo.domain.person.Person;
@@ -120,7 +122,7 @@ public class HenvendelseUtsendingServiceImpl implements HenvendelseUtsendingServ
     public void ferdigstillHenvendelse(Melding melding, Optional<String> oppgaveId, Optional<Sak> sak, String behandlingsId, String saksbehandlersValgteEnhet) throws Exception {
         if (oppgaveId.isPresent() && oppgaveBehandlingService.oppgaveErFerdigstilt(oppgaveId.get())) {
             logger.error("Oppgaven er ferdigstilt med id: {}", oppgaveId);
-            return;
+            throw new BadRequestException("Oppgaven er ferdigstilt med id: " + oppgaveId);
         }
 
         XMLHenvendelse xmlHenvendelse = lagXMLHenvendelseOgSettEnhet(melding);


### PR DESCRIPTION
Fikser opp i en potensiell feil hvor saksbehandler prøver å sende svar,
og tilknyttet oppgave allerede er ferdigstilt. Vi endret på oppførsel her tilbake i starten av april (https://github.com/navikt/modiapersonoversikt-api/pull/53).

Problemet som ble introdusert er at saksbehandler nå får 200 OK tilbake når `/ferdigstill` sendes, men ferdigstill-kallet til henvendelse skjer etter denne sjekken. Og dermed blir meldingen aldri lagret.