### PR TITLE
[KAIZEN-0] legge til null-sjekk før konvertering fra Boolean til boolean

### DIFF
--- a/kjerneinfo/sykmeldingsperioder-consumer/src/main/java/no/nav/sykmeldingsperioder/consumer/foreldrepenger/mapping/ForeldrepengerMapper.java
+++ b/kjerneinfo/sykmeldingsperioder-consumer/src/main/java/no/nav/sykmeldingsperioder/consumer/foreldrepenger/mapping/ForeldrepengerMapper.java
@@ -171,8 +171,12 @@ public class ForeldrepengerMapper {
         Foreldrepengeperiode periode = new Foreldrepengeperiode();
 
         periode.setFodselsnummer(null);
-        periode.setHarAleneomsorgFar(source.getHarAleneomsorgFar());
-        periode.setHarAleneomsorgMor(source.getHarAleneomsorgMor());
+        if (source.getHarAleneomsorgFar() != null) {
+            periode.setHarAleneomsorgFar(source.getHarAleneomsorgFar());
+        }
+        if (source.getHarAleneomsorgMor() != null) {
+            periode.setHarAleneomsorgMor(source.getHarAleneomsorgMor());
+        }
         if (source.getArbeidsprosentMor() != null) {
             periode.setArbeidsprosentMor(source.getArbeidsprosentMor().doubleValue());
         }


### PR DESCRIPTION
Boxed-versionen Boolean kan være satt til null, dette er ikke mulig for
den primitive typen boolean. Vi kan derfor få NullPointerException her om vi ikke sjekker