### PR TITLE
[PROD][KAIZEN-0] flipper tråd-tilknyttning-sjekken

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
@@ -2,12 +2,13 @@ package no.nav.sbl.dialogarena.modiabrukerdialog.api.service;
 
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.Oppgave;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.Temagruppe;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface OppgaveBehandlingService {
-    Oppgave hentOppgave(String oppgaveId);
+    Oppgave hentOppgave(@NotNull String oppgaveId);
 
     void tilordneOppgaveIGsak(String oppgaveId, Temagruppe temagruppe, String saksbehandlersValgteEnhet) throws FikkIkkeTilordnet;
 

--- a/sporsmalogsvar/src/main/java/no/nav/sbl/dialogarena/sporsmalogsvar/consumer/henvendelse/domain/Traad.java
+++ b/sporsmalogsvar/src/main/java/no/nav/sbl/dialogarena/sporsmalogsvar/consumer/henvendelse/domain/Traad.java
@@ -40,9 +40,9 @@ public class Traad {
                 .orElseThrow(IllegalStateException::new);
     }
 
-    public boolean harTilknyttningTilOppgave(@Nullable Oppgave oppgave) {
+    public boolean besvaringKanFerdigstilleOppgave(@Nullable Oppgave oppgave) {
         if (oppgave == null) {
-            return false;
+            return true;
         }
         return meldinger
                 .stream()

--- a/sporsmalogsvar/src/main/java/no/nav/sbl/dialogarena/sporsmalogsvar/consumer/henvendelse/domain/Traad.java
+++ b/sporsmalogsvar/src/main/java/no/nav/sbl/dialogarena/sporsmalogsvar/consumer/henvendelse/domain/Traad.java
@@ -1,13 +1,12 @@
 package no.nav.sbl.dialogarena.sporsmalogsvar.consumer.henvendelse.domain;
 
+import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.Oppgave;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.henvendelse.Melding;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.utils.henvendelse.delsvar.DelsvarSammenslaaer;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.utils.henvendelse.delsvar.DelsvarUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 public class Traad {
 
@@ -41,12 +40,12 @@ public class Traad {
                 .orElseThrow(IllegalStateException::new);
     }
 
-    public boolean harTilknyttningTilOppgave(@Nullable String oppgaveId) {
-        List<String> oppgaveIdTilknyttetTrad = meldinger
+    public boolean harTilknyttningTilOppgave(@Nullable Oppgave oppgave) {
+        if (oppgave == null) {
+            return false;
+        }
+        return meldinger
                 .stream()
-                .map((melding) -> melding.oppgaveId)
-                .collect(toList());
-
-        return oppgaveIdTilknyttetTrad.contains(oppgaveId);
+                .anyMatch((melding) -> melding.id.contains(oppgave.henvendelseId));
     }
 }

--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/dialog/DialogController.kt
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/dialog/DialogController.kt
@@ -175,7 +175,7 @@ class DialogController @Autowired constructor(
                             .find { it.traadId == fortsettDialogRequest.traadId }
                             ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Fant ingen tråd med id: ${fortsettDialogRequest.traadId}")
 
-                    if (!traad.harTilknyttningTilOppgave(oppgave)) {
+                    if (!traad.besvaringKanFerdigstilleOppgave(oppgave)) {
                         throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Feil oppgaveId fra client. Forventet: ${traad.getEldsteMelding().oppgaveId} men oppdaget: ${fortsettDialogRequest.oppgaveId}")
                     }
 

--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/dialog/DialogController.kt
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/dialog/DialogController.kt
@@ -168,13 +168,14 @@ class DialogController @Autowired constructor(
                 .check(Policies.tilgangTilBruker.with(fnr))
                 .get(Audit.describe(UPDATE, Person.Henvendelse.Ferdigstill, *auditIdentifier)) {
                     val context = lagSendHenvendelseContext(fnr, fortsettDialogRequest.enhet, request)
+                    val oppgave = fortsettDialogRequest.oppgaveId?.let(oppgaveBehandlingService::hentOppgave)
                     val traad = henvendelseService
                             .hentMeldinger(fnr, context.enhet)
                             .traader
                             .find { it.traadId == fortsettDialogRequest.traadId }
                             ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Fant ingen tråd med id: ${fortsettDialogRequest.traadId}")
 
-                    if (!traad.harTilknyttningTilOppgave(fortsettDialogRequest.oppgaveId)) {
+                    if (!traad.harTilknyttningTilOppgave(oppgave)) {
                         throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Feil oppgaveId fra client. Forventet: ${traad.getEldsteMelding().oppgaveId} men oppdaget: ${fortsettDialogRequest.oppgaveId}")
                     }
 


### PR DESCRIPTION
Sjekket tidligere om det fantes en melding som referete til oppgaven, men ved manuell opprettelse av oppgave så vil ikke dette fungere.

Snur derfor om til å sjekke hvorvidt meldingen som blir referert til fra oppgaven finnes i tråden.

Hypotesen er at det er denne sjekken som gjør at disse feiler;
- FAGSYSTEM-142466
- FAGSYSTEM-142344

https://github.com/navikt/modiapersonoversikt-api/pull/210 utvider audit-loggeren slik at vi får bedre logger i disse situasjonene