### PR TITLE
[FAGSYSTEM-149428] bedre null-håndtering av WSSak

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/GsakSaker.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/GsakSaker.kt
@@ -63,19 +63,19 @@ internal class GsakSaker(val sakV1: SakV1, val behandleSakWS: BehandleSakV1) : S
                 opprettetDato = wsSak.opprettelsetidspunkt
                 saksId = wsSak.sakId
                 fagsystemSaksId = getFagsystemSakId(wsSak)
-                temaKode = wsSak.fagomraade.value
+                temaKode = wsSak.fagomraade?.value
                 sakstype = getSakstype(wsSak)
-                fagsystemKode = wsSak.fagsystem.value
+                fagsystemKode = wsSak.fagsystem?.value
                 finnesIGsak = true
             }
         }
 
-        private fun getSakstype(wsSak: WSSak): String {
-            return if (VEDTAKSLOSNINGEN == wsSak.fagsystem.value) Sak.SAKSTYPE_MED_FAGSAK else wsSak.sakstype.value
+        private fun getSakstype(wsSak: WSSak): String? {
+            return if (VEDTAKSLOSNINGEN == wsSak.fagsystem?.value) Sak.SAKSTYPE_MED_FAGSAK else wsSak.sakstype?.value
         }
 
-        private fun getFagsystemSakId(wsSak: WSSak): String {
-            return if (VEDTAKSLOSNINGEN == wsSak.fagsystem.value) wsSak.sakId else wsSak.fagsystemSakId
+        private fun getFagsystemSakId(wsSak: WSSak): String? {
+            return if (VEDTAKSLOSNINGEN == wsSak.fagsystem?.value) wsSak.sakId else wsSak.fagsystemSakId
         }
     }
 }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImplTest.java
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImplTest.java
@@ -51,6 +51,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.joda.time.DateTime.now;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -335,6 +336,14 @@ public class SakerServiceImplTest {
         when(behandleSak.opprettSak(any(WSOpprettSakRequest.class))).thenReturn(new WSOpprettSakResponse().withSakId(SAKS_ID));
 
         assertThrows(IllegalArgumentException.class, () -> sakerService.knyttBehandlingskjedeTilSak("", BEHANDLINGSKJEDEID, lagSak(), "1337"));
+    }
+
+    @Test
+    void skalHandtereMangledeGagsystemSakId() {
+        WSSak wsSak = new WSSak();
+        assertDoesNotThrow(() -> {
+            GsakSaker.TIL_SAK.invoke(wsSak);
+        });
     }
 
     private ArrayList<WSSak> createSaksliste() {


### PR DESCRIPTION
WSSak er en java-klasse, og alle felter kan derfor være null uten at kotlin klager. e.g har typen (String!)