### PR TITLE
[KAIZEN-0] disable sync av pdl.graphqls

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -102,16 +102,16 @@
                 <artifactId>graphql-kotlin-maven-plugin</artifactId>
                 <version>${graphql-kotlin.version}</version>
                 <executions>
-                    <execution>
-                        <id>download schema from github</id>
-                        <goals>
-                            <goal>download-sdl</goal>
-                        </goals>
-                        <configuration>
-                            <endpoint>https://navikt.github.io/pdl/pdl-api-sdl.graphqls</endpoint>
-                            <outputDirectory>src/main/resources/pdl</outputDirectory>
-                        </configuration>
-                    </execution>
+<!--                    <execution>-->
+<!--                        <id>download schema from github</id>-->
+<!--                        <goals>-->
+<!--                            <goal>download-sdl</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <endpoint>https://navikt.github.io/pdl/pdl-api-sdl.graphqls</endpoint>-->
+<!--                            <outputDirectory>src/main/resources/pdl</outputDirectory>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
                     <execution>
                         <id>generate kotlin classes from schema + queries</id>
                         <goals>


### PR DESCRIPTION
Mistenker at introduksjonen av private-pages i github har truffet pdl på en sånn måte at vi nå ikke får ut filen uten å sende med tokens for login.
For å fikse `dev` og byggene rundt omkring så disabler vi denne derfor for nå