### PR TITLE
[KAIZEN-0] fikse UnleashProxySwitcher etter merge med dev

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/OppgaveBehandlingServiceSwitcher.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/OppgaveBehandlingServiceSwitcher.kt
@@ -48,7 +48,7 @@ fun createOppgaveBehandlingSwitcher(
     return UnleashProxySwitcher.createSwitcher(
         featureToggle = Feature.USE_REST_OPPGAVE_IMPL,
         unleashService = unleashService,
-        ftEnabledImpl = restClient,
-        ftDisabledImpl = soapClient
+        ifEnabled = restClient,
+        ifDisabled = soapClient
     )
 }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/GsakSaker.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/GsakSaker.kt
@@ -33,8 +33,8 @@ interface GsakSaker : SakerKilde {
             return UnleashProxySwitcher.createSwitcher(
                 featureToggle = Feature.USE_REST_SAK_IMPL,
                 unleashService = unleashService,
-                ftEnabledImpl = restClient,
-                ftDisabledImpl = soapClient
+                ifEnabled = restClient,
+                ifDisabled = soapClient
             )
         }
     }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/util/UnleashProxySwitcher.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/util/UnleashProxySwitcher.kt
@@ -2,29 +2,55 @@ package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.util
 
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.unleash.Feature
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.unleash.UnleashService
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
 import java.lang.reflect.Proxy
+import kotlin.reflect.KClass
+
+@PublishedApi
+internal class UnleashHandler<T : Any>(
+    val type: KClass<T>,
+    val feature: Feature,
+    val unleashService: UnleashService,
+    val ifEnabled: T,
+    val ifDisabled: T
+) : InvocationHandler {
+    val log: Logger = LoggerFactory.getLogger(UnleashHandler::class.java)
+    val name: String = type.java.simpleName
+
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
+        val nullsafeArgs = args ?: arrayOfNulls<Any>(0)
+        return try {
+            if (unleashService.isEnabled(feature)) {
+                log.warn("[UnleashProxySwitcher] $name is enabled")
+                method.invoke(ifEnabled, *nullsafeArgs)
+            } else {
+                method.invoke(ifDisabled, *nullsafeArgs)
+            }
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
+    }
+}
 
 object UnleashProxySwitcher {
-    val log = LoggerFactory.getLogger(UnleashProxySwitcher::class.java)
-
     inline fun <reified T : Any> createSwitcher(
         featureToggle: Feature,
         unleashService: UnleashService,
         ftDisabledImpl: T,
         ftEnabledImpl: T
     ): T {
-        val name = T::class.java.simpleName
-        val invocationHandler = InvocationHandler { _, method, args ->
-            val nullsafeArgs = args ?: arrayOfNulls<Any>(0)
-            if (unleashService.isEnabled(featureToggle)) {
-                method.invoke(ftEnabledImpl, *nullsafeArgs)
-                log.warn("[UnleashProxySwitcher] $name is enabled")
-            } else {
-                method.invoke(ftDisabledImpl, *nullsafeArgs)
-            }
-        }
+        val invocationHandler = UnleashHandler(
+            type = T::class,
+            feature = featureToggle,
+            unleashService = unleashService,
+            ifEnabled = ftEnabledImpl,
+            ifDisabled = ftDisabledImpl
+        )
+
         val proxy = Proxy.newProxyInstance(
             T::class.java.classLoader,
             arrayOf(T::class.java),

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/util/UnleashProxySwitcher.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/util/UnleashProxySwitcher.kt
@@ -40,15 +40,15 @@ object UnleashProxySwitcher {
     inline fun <reified T : Any> createSwitcher(
         featureToggle: Feature,
         unleashService: UnleashService,
-        ftDisabledImpl: T,
-        ftEnabledImpl: T
+        ifEnabled: T,
+        ifDisabled: T
     ): T {
         val invocationHandler = UnleashHandler(
             type = T::class,
             feature = featureToggle,
             unleashService = unleashService,
-            ifEnabled = ftEnabledImpl,
-            ifDisabled = ftDisabledImpl
+            ifEnabled = ifEnabled,
+            ifDisabled = ifDisabled
         )
 
         val proxy = Proxy.newProxyInstance(


### PR DESCRIPTION
Lagt til try-catch som fanger opp `InvocationTargetException` og pakker ut disse slik at man unngår `UndeclaredException`-feil og får penere stacktraces i loggene.

Trukket ut `InvocationHandler` til en egen klasse istedetfor en lambda. På den måten kommer man unna trøbbel med implisitt returns i kotlin.

Return-typen er også satt til `Any?` slik at proxyen støtter funksjoner som ikke returnerer noe eller returnerer `null`