### PR TITLE
[KAIZEN-0] fjerne refresh-config for fpsak authenticator

### DIFF
--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/config/LoginContext.java
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/config/LoginContext.java
@@ -42,9 +42,7 @@ public class LoginContext {
                 .withClientId(fpsakClientId)
                 .withDiscoveryUrl(issoDiscoveryUrl)
                 .withIdTokenCookieName(Constants.OPEN_AM_ID_TOKEN_COOKIE_NAME)
-                .withIdentType(IdentType.InternBruker)
-                .withRefreshUrl(issoRefreshUrl)
-                .withRefreshTokenCookieName(Constants.REFRESH_TOKEN_COOKIE_NAME);
+                .withIdentType(IdentType.InternBruker);
 
         return OidcAuthenticator.fromConfig(config);
     }


### PR DESCRIPTION
veilarblogin (`issoRefreshUrl`) kan ikke refreshe tokens utstedt til fpsak. Fjerner derfor konfigurasjonen for refresh-tokens fra fpsak-authenticatoren slik at vi ikke skaper støy i loggene.