### PR TITLE
fix/sak integrasjon tidsobjekt

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/http/OkHttpUtils.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/http/OkHttpUtils.kt
@@ -2,6 +2,7 @@ package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.http
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -22,6 +23,7 @@ object OkHttpUtils {
         .registerModule(Jdk8Module())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         .apply {
             setVisibility(
                 serializationConfig

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/RestGsakSaker.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/RestGsakSaker.kt
@@ -9,7 +9,7 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.saker.mediation
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.saker.mediation.SakDto
 import org.joda.time.DateTime
 import java.time.Clock
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 
 class RestGsakSaker(
     private val sakApiGateway: SakApiGateway,
@@ -35,7 +35,7 @@ class RestGsakSaker(
                 orgnr = null,
                 fagsakNr = sak.fagsystemSaksId,
                 opprettetAv = ident,
-                opprettetTidspunkt = ZonedDateTime.now(clock)
+                opprettetTidspunkt = OffsetDateTime.now(clock)
             )
         )
 
@@ -81,7 +81,7 @@ class RestGsakSaker(
             return if (GsakSaker.VEDTAKSLOSNINGEN == sakDto.applikasjon) sakDto.id.toString() else sakDto.fagsakNr
         }
 
-        private fun convertJavaDateTimeToJoda(dateTime: ZonedDateTime): DateTime {
+        private fun convertJavaDateTimeToJoda(dateTime: OffsetDateTime): DateTime {
             return DateTime(dateTime.toInstant().toEpochMilli())
         }
     }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/mediation/SakApiGateway.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/mediation/SakApiGateway.kt
@@ -12,7 +12,7 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.http.XCorrelationIdInte
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
-import java.time.ZonedDateTime
+import java.time.OffsetDateTime
 
 interface SakApiGateway {
     fun hentSaker(aktorId: String): List<SakDto>
@@ -84,6 +84,6 @@ data class SakDto(
     val orgnr: String? = null, //Orgnr til foretaket saken gjelder
     val fagsakNr: String? = null, //Fagsaknr for den aktuelle saken - hvis aktuelt
     val opprettetAv: String? = null, //Brukerident til den som opprettet saken
-    val opprettetTidspunkt: ZonedDateTime? = null
+    val opprettetTidspunkt: OffsetDateTime? = null
 )
 

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/RestGsakSakerTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/kilder/gsak/RestGsakSakerTest.kt
@@ -18,10 +18,7 @@ import org.joda.time.DateTime
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.time.*
 
 
 class RestGsakSakerTest {
@@ -100,7 +97,7 @@ class RestGsakSakerTest {
                     aktoerId = "123",
                     fagsakNr = FagsystemSakId_1,
                     opprettetAv = "Z999999",
-                    opprettetTidspunkt = ZonedDateTime.now(fixedClock)
+                    opprettetTidspunkt = OffsetDateTime.now(fixedClock)
                 )
             )
         }
@@ -166,6 +163,6 @@ class RestGsakSakerTest {
         }
     }
 
-    fun earlierDateTimeWithOffSet(offset: Long): ZonedDateTime = ZonedDateTime.now().minusDays(offset)
+    fun earlierDateTimeWithOffSet(offset: Long): OffsetDateTime = OffsetDateTime.now().minusDays(offset)
 }
 

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/mediation/SakApiGatewayTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/mediation/SakApiGatewayTest.kt
@@ -1,14 +1,15 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.saker.mediation
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.matching.AnythingPattern
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import no.nav.common.log.MDCConstants
 import no.nav.common.sts.SystemUserTokenProvider
-import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentIdent
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.utils.RestConstants
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.Is.`is`
@@ -16,79 +17,119 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.slf4j.MDC
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 internal class SakApiGatewayTest {
     @MockK
     private lateinit var stsService: SystemUserTokenProvider
 
     private val AKTOERID = "11111"
-    private val response = """
-                            [{
-                                "id": 141481247,
-                                "tema": "BAR",
-                                "applikasjon": "IT01",
-                                "aktoerId": 1000006766539,
-                                "orgnr": null,
-                                "fagsakNr": "0326A02",
-                                "opprettetAv": "srvRuting",
-                                "opprettetTidspunkt": "2019-10-23T17:45:12.529+02:00"
-                              }]""".trimIndent()
-
-    private val withHeader = {
-        verify(getRequestedFor(urlEqualTo("/api/v1/saker?aktoerId=$AKTOERID"))
-                .withHeader("X-Correlation-ID", AnythingPattern())
-                .withHeader(RestConstants.AUTHORIZATION, AnythingPattern())
-                .withHeader("accept", matching("application/json")))
-    }
+    private val opprettetDato = OffsetDateTime.of(
+        2019, 10, 23,
+        15, 45, 12, 529000000,
+        ZoneOffset.UTC
+    )
+    private val sakDto = SakDto(
+        id = "141481247",
+        tema = "BAR",
+        applikasjon = "IT01",
+        aktoerId = "1000006766539",
+        fagsakNr = "0326A02",
+        opprettetAv = "srvRuting",
+        opprettetTidspunkt = opprettetDato
+    )
+    private val sakDtoJson = """
+        {
+            "id": 141481247,
+            "tema": "BAR",
+            "applikasjon": "IT01",
+            "aktoerId": 1000006766539,
+            "orgnr": null,
+            "fagsakNr": "0326A02",
+            "opprettetAv": "srvRuting",
+            "opprettetTidspunkt": "2019-10-23T17:45:12.529+02:00"
+        }
+    """.trimIndent()
+    private val sakDtoListe = "[$sakDtoJson]"
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
-
-        val identer = listOf(
-                HentIdent.IdentInformasjon(AKTOERID, HentIdent.IdentGruppe.AKTORID)
-        )
-
         every { stsService.systemUserToken } returns ("TOKEN")
         MDC.put(MDCConstants.MDC_CALL_ID, "MDC_CALL_ID")
-
     }
 
     @Test
     fun `hent saker som list av data objects fra SakApi`() {
-        withMockGateway(statusCode = 200, body = response) { sakApiGateway ->
+        withMockGateway(stub = getWithBody(statusCode = 200, body = sakDtoListe)) { sakApiGateway ->
             val response = sakApiGateway.hentSaker(AKTOERID)
             assertThat(response.size, `is`(1))
-
+            assertThat(response[0].opprettetTidspunkt, `is`(opprettetDato))
         }
     }
 
     @Test
     fun `handterer status coder utenfor 200-299 rangen`() {
-        withMockGateway(statusCode = 404, body = response) { sakApiGateway ->
+        withMockGateway(stub = getWithBody(statusCode = 404, body = sakDtoListe)) { sakApiGateway ->
             assertThrows<IllegalStateException> {
                 sakApiGateway.hentSaker(AKTOERID)
             }
         }
 
-        withMockGateway(statusCode = 500) { sakApiGateway ->
+        withMockGateway(stub = getWithBody(statusCode = 500)) { sakApiGateway ->
             assertThrows<IllegalStateException> {
                 sakApiGateway.hentSaker(AKTOERID)
             }
         }
     }
 
-    private fun withMockGateway(statusCode: Int = 200,
-                                 body: String? = null,
-                                 verify: (() -> Unit)? = withHeader,
-                                 test: (SakApiGateway) -> Unit) {
+    @Test
+    fun `skal kunne opprette Sak og parse resultatet`() {
+        withMockGateway(
+            verify = verifyHeaders(postRequestedFor(urlEqualTo("/api/v1/saker"))),
+            stub = postWithBody(statusCode = 200, body = sakDtoJson)
+        ) { sakApiGateway ->
+            val opprettetDto = sakApiGateway.opprettSak(sakDto)
+            assertThat(opprettetDto.opprettetTidspunkt, `is`(sakDto.opprettetTidspunkt))
+        }
+    }
+
+    private fun getWithBody(statusCode: Int = 200, body: String? = null): WireMockServer.() -> Unit = {
+        this.stubFor(get(anyUrl()).withBody(statusCode, body))
+    }
+
+    private fun postWithBody(statusCode: Int = 200, body: String? = null): WireMockServer.() -> Unit = {
+        this.stubFor(post(anyUrl()).withBody(statusCode, body))
+    }
+
+    private fun MappingBuilder.withBody(statusCode: Int = 200, body: String? = null): MappingBuilder {
+        this.willReturn(
+            aResponse()
+                .withStatus(statusCode)
+                .withHeader("Content-Type", "application/json")
+                .withBody(body)
+        )
+        return this
+    }
+
+    private fun verifyHeaders(call: RequestPatternBuilder): () -> Unit = {
+        verify(
+            call
+                .withHeader("X-Correlation-ID", AnythingPattern())
+                .withHeader(RestConstants.AUTHORIZATION, AnythingPattern())
+                .withHeader("accept", matching("application/json"))
+        )
+    }
+
+    private fun withMockGateway(
+        stub: WireMockServer.() -> Unit = { },
+        verify: (() -> Unit)? = verifyHeaders(getRequestedFor(urlEqualTo("/api/v1/saker?aktoerId=$AKTOERID"))),
+        test: (SakApiGateway) -> Unit
+    ) {
         val wireMockServer = WireMockServer()
-        try{
-            wireMockServer.stubFor(get(anyUrl())
-                    .willReturn(aResponse()
-                            .withStatus(statusCode)
-                            .withHeader("Content-Type", "application/json")
-                            .withBody(body)))
+        try {
+            stub(wireMockServer)
             wireMockServer.start()
 
             val client = SakApiGatewayImpl("http://localhost:${wireMockServer.port()}", stsService)


### PR DESCRIPTION
- [KAIZEN-0] configurere jackson til å bruke ISO8601 377fcee
- [KAIZEN-0] byttet til OffsetDateTime og la til tester for opprett sak 7ebbe9c
OppsetDateTime bruker formated "+02:00" for tidssone, mens ZonedDateTime kan finne på bruke "[europe/oslo]".