### PR TITLE
[KAIZEN-0] bruker system-klient for opprettelse av skjermet oppgave

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
@@ -103,7 +103,7 @@ class RestOppgaveBehandlingServiceImpl(
         val aktorId = fodselnummerAktorService.hentAktorIdForFnr(request.fnr)
             ?: throw IllegalArgumentException("Fant ikke aktorId for ${request.fnr}")
 
-        val response = apiClient.opprettOppgave(
+        val response = systemApiClient.opprettOppgave(
             xminusCorrelationMinusID = correlationId(),
             postOppgaveRequestJsonDTO = PostOppgaveRequestJsonDTO(
                 opprettetAvEnhetsnr = request.opprettetavenhetsnummer.coerceBlankToNull(),

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -138,7 +138,7 @@ class RestOppgaveBehandlingServiceImplTest {
 
         @Test
         fun `skal opprette skjermet oppgave`() {
-            every { apiClient.opprettOppgave(any(), any()) } returns dummyOppgave.toPostOppgaveResponseJsonDTO()
+            every { systemApiClient.opprettOppgave(any(), any()) } returns dummyOppgave.toPostOppgaveResponseJsonDTO()
             every { ansattService.hentAnsattNavn(eq("Z999999")) } returns "Fornavn Etternavn"
 
 
@@ -162,7 +162,7 @@ class RestOppgaveBehandlingServiceImplTest {
 
             assertThat(response.id).isEqualTo("1234")
             verifySequence {
-                apiClient.opprettOppgave(
+                systemApiClient.opprettOppgave(
                     xminusCorrelationMinusID = any(),
                     postOppgaveRequestJsonDTO = PostOppgaveRequestJsonDTO(
                         aktoerId = "00007063000250000",


### PR DESCRIPTION
I tilfeller hvor man oppretter en skjermet oppgave er dette fordi saksbehandler ikke har tilgang til brukeren. Vi kan derfor ikke bruke den vanlig `apiClient` siden dette vil forsøke å opprette oppgaven ved hjelp av saksbehandlers token.
Ved å bytte til systemApiClient brukes modia sitt systemToken som skal ha tilgang til å opprette oppgaver på alle brukere.