### PR TITLE
[OPP-1308] fikse ident-sammenligning ved tilbakelegging

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
@@ -255,7 +255,7 @@ class RestOppgaveBehandlingServiceImpl(
         val ident: String = SubjectHandler.getIdent().orElseThrow { IllegalStateException("Fant ikke ident") }
         val oppgave = hentOppgaveJsonDTO(request.oppgaveId)
 
-        if (oppgave.tilordnetRessurs !== ident) {
+        if (oppgave.tilordnetRessurs != ident) {
             val feilmelding = "Innlogget saksbehandler $ident er ikke tilordnet oppgave ${request.oppgaveId}, den er tilordnet: ${oppgave.tilordnetRessurs}"
             throw ResponseStatusException(HttpStatus.FORBIDDEN, feilmelding)
         }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -496,8 +496,10 @@ class RestOppgaveBehandlingServiceImplTest {
 
         @Test
         fun `skal legge tilbake oppgave`() {
+            // Bygger opp `tilordnetRessurs` vha buildString for å sikre at jvm string-pool ikke gjenbruker instansen
+            val tilordnetRessurs = buildString { append("Z999999") }
             val testoppgave = dummyOppgave
-                .copy(tilordnetRessurs = "Z999999", aktoerId = "00007063000250000")
+                .copy(tilordnetRessurs = tilordnetRessurs, aktoerId = "00007063000250000")
             every { apiClient.hentOppgave(any(), any()) } returns testoppgave.toGetOppgaveResponseJsonDTO()
             every { apiClient.endreOppgave(any(), any(), any()) } returns testoppgave.toPutOppgaveResponseJsonDTO()
             every { ansattService.hentAnsattNavn(eq("Z999999")) } returns "Fornavn Etternavn"


### PR DESCRIPTION
`!=` i kotlin bruker "structural equality", e.g tilsvarende `!str.equals(str2)` i java, mens `!==` bruker `referential equality` som er tilsvarende `str1 != str2` i java.

Siden JVM'en forsøker å deduplisere strings, slik at man ikke har mange String-instanser med samme verdi så har testene fungert. Men oppdateringen til testen tvinger JVM'en til å lage to versjoner slik at vi får verifisert at sjekken bruker structural equality fremover.