### PR TITLE
[OPP-1308] filtrere bort oppgaver som ikke har henvendelse-tilknytning

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
@@ -168,10 +168,14 @@ class RestOppgaveBehandlingServiceImpl(
         return SafeListAggregate<OppgaveJsonDTO, OppgaveJsonDTO>(oppgaver)
             .filter { aktorIdTilganger[it.aktoerId] == DecisionEnums.PERMIT }
             .fold(
-                transformSuccess = this::mapTilOppgave,
+                transformSuccess = { it to this.mapTilOppgave(it) },
                 transformFailure = { it }
             )
             .getWithFailureHandling { failures -> systemLeggTilbakeOppgaver(failures) }
+            .filter { (oppgaveJson, _) ->
+                oppgaveJson.metadata?.containsKey(MetadataKey.EKSTERN_HENVENDELSE_ID.name) ?: false
+            }
+            .map { (_, oppgave) -> oppgave }
             .toMutableList()
     }
 


### PR DESCRIPTION
Gjøres for å gjøre rest-implementasjonen api-kompatible med tidligere soap-integrasjon.

I [OppgaveBehandlingServiceImpl.java::122](https://github.com/navikt/modiapersonoversikt-api/blob/dev/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/OppgaveBehandlingServiceImpl.java#L122) filtrerer man ut alle oppgaver som har henvendelseId == null,
og på den måten vil tildelteOppgaver bare returnere oppgaver vi i modiapersonoversikt har ett forhold til.