### PR TITLE
Slette depricated method for henting av saker

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/saker/SakerService.kt
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/saker/SakerService.kt
@@ -10,12 +10,6 @@ interface SakerService {
 
     fun hentSakSaker(fnr: String): Resultat
 
-    @Deprecated("")
-    fun hentSammensatteSaker(fnr: String): List<Sak>
-
-    @Deprecated("")
-    fun hentPensjonSaker(fnr: String): List<Sak>
-
     @Throws(JournalforingFeilet::class)
     fun knyttBehandlingskjedeTilSak(fnr: String?, behandlingskjede: String?, sak: Sak, enhet: String?)
 }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImpl.kt
@@ -81,16 +81,6 @@ class SakerServiceImpl : SakerService {
         return slaSammenGsakPesysSaker(restSakSaker, pesysSaker)
     }
 
-    override fun hentSammensatteSaker(fnr: String): List<Sak> {
-        requireFnrNotNullOrBlank(fnr)
-        return hentSammensatteSakerResultat(fnr).saker
-    }
-
-    override fun hentPensjonSaker(fnr: String): List<Sak> {
-        requireFnrNotNullOrBlank(fnr)
-        return hentPensjonSakerResultat(fnr).saker
-    }
-
     fun hentSammensatteSakerResultat(fnr: String?): SakerService.Resultat {
         requireFnrNotNullOrBlank(fnr)
         val resultat = SakerService.Resultat()

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/saker/SakerServiceImplTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.slf4j.MDC
 import java.time.OffsetDateTime
 import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.contracts.ExperimentalContracts
 import kotlin.streams.toList
 
@@ -101,6 +102,8 @@ class SakerServiceImplTest {
 
     @Test
     fun `transformerer response til saksliste pensjon`() {
+        every { sakApiGateway.hentSaker(any()) } returns listOf()
+        every { arbeidOgAktivitet.hentSakListe(any()) } returns WSHentSakListeResponse()
         val pensjon = Sak()
         pensjon.temaKode = "PENS"
         val ufore = Sak()
@@ -108,8 +111,8 @@ class SakerServiceImplTest {
         val pensjonssaker = listOf(pensjon, ufore)
         every { psakService.hentSakerFor(FNR) } returns pensjonssaker
 
-        val saksliste = sakerService.hentPensjonSaker(FNR)
-        assertThat(saksliste.size, `is`(2))
+        val saksliste = sakerService.hentSaker(FNR).saker
+        assertThat(saksliste.size, `is`(3))
         assertThat(saksliste[0].temaNavn, `is`("PENS"))
         assertThat(saksliste[1].temaNavn, `is`("UFO"))
     }

--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/JournalforingController.java
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/JournalforingController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.List;
 
 import static java.util.Arrays.asList;
 import static no.nav.sbl.dialogarena.modiabrukerdialog.api.utils.RestUtils.hentValgtEnhet;
@@ -46,20 +45,6 @@ public class JournalforingController {
         return tilgangskontroll
                 .check(tilgangTilBruker.with(fnr))
                 .get(Audit.describe(READ, Person.GsakSaker, new Pair<>(AuditIdentifier.FNR, fnr)), () ->  sakerService.hentSaker(fnr));
-    }
-
-    @GetMapping("/saker/sammensatte")
-    public List<Sak> hentSammensatteSaker(@PathVariable("fnr") String fnr) {
-        return tilgangskontroll
-                .check(tilgangTilBruker.with(fnr))
-                .get(Audit.describe(READ, Person.GsakSaker, new Pair<>(AuditIdentifier.FNR, fnr)), () -> sakerService.hentSammensatteSaker(fnr));
-    }
-
-    @GetMapping("/saker/pensjon")
-    public List<Sak> hentPensjonSaker(@PathVariable("fnr") String fnr) {
-        return tilgangskontroll
-                .check(tilgangTilBruker.with(fnr))
-                .get(Audit.describe(READ, Person.PesysSaker, new Pair<>(AuditIdentifier.FNR, fnr)), () -> sakerService.hentPensjonSaker(fnr));
     }
 
     @PostMapping("/{traadId}")


### PR DESCRIPTION
Slettet depricated method i SakerService interface blir erstattet med hentSaker(fnr) som henter et samlet saker fra Arena, Sak Api, Bidrag, Pensjon kilder i tillegg med oppføring og Generell saker. Fikset test også.