### PR TITLE
[OPP-1308] hente ovrg-oppgaver fra 4100

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/Utils.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/Utils.kt
@@ -17,7 +17,7 @@ object Utils {
             DEFAULT_ENHET
         } else if (temagruppe == FMLI && valgtEnhet == STORD_ENHET) {
             STORD_ENHET
-        } else if (listOf(ARBD, HELSE, FMLI, FDAG, ORT_HJE, PENS, UFRT, PLEIEPENGERSY, UTLAND).contains(temagruppe)) {
+        } else if (listOf(ARBD, HELSE, FMLI, FDAG, ORT_HJE, PENS, UFRT, PLEIEPENGERSY, UTLAND, OVRG).contains(temagruppe)) {
             DEFAULT_ENHET
         } else {
             valgtEnhet ?: throw IllegalStateException("Kunne ikke utlede endretAvEnhet gitt $temagruppe og $valgtEnhet")


### PR DESCRIPTION
plukk på øvrige ble lagt til i soap-implementasjonen 28.01.2021 ([se github blame her](https://github.com/navikt/modiapersonoversikt-api/blame/dev/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/OppgaveBehandlingServiceImpl.java#L346))
men ikke oppdatert i rest-koden. 

resultatet er at plukk på OVRG prøver å plukke fra saksbehandlers-enhet benken (f.eks 4119) istedet for 4100 hvor oppgavene ligger