### PR TITLE
[OPP-1308] bruke systemClient gjennom hele legg-tilbake flyten

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
@@ -300,7 +300,15 @@ class RestOppgaveBehandlingServiceImpl(
         saksbehandlersValgteEnhet: String?
     ) {
         requireNotNull(oppgaveId)
-        val oppgave = hentOppgaveJsonDTO(oppgaveId)
+        /**
+         * NB Viktig at systemApiClient brukes her.
+         * Vi skal potensielt sett hente en oppgave saksbehandler ikke har tilgang til.
+         */
+        val oppgave = systemApiClient.hentOppgave(
+            xminusCorrelationMinusID = correlationId(),
+            id = oppgaveId.toLong()
+        ).toOppgaveJsonDTO()
+
         systemApiClient
             .endreOppgave(
                 correlationId(),

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -610,7 +610,7 @@ class RestOppgaveBehandlingServiceImplTest {
     inner class LeggTilbakeOppgave {
         @Test
         fun `systemet legger tilbake oppgave uten endringer`() {
-            every { apiClient.hentOppgave(any(), any()) } returns dummyOppgave
+            every { systemApiClient.hentOppgave(any(), any()) } returns dummyOppgave
                 .copy(tilordnetRessurs = "Z999999")
                 .toGetOppgaveResponseJsonDTO()
             every {
@@ -628,7 +628,7 @@ class RestOppgaveBehandlingServiceImplTest {
             )
 
             verifySequence {
-                apiClient.hentOppgave(any(), 1234)
+                systemApiClient.hentOppgave(any(), 1234)
                 systemApiClient.endreOppgave(
                     any(), 1234,
                     dummyOppgave.toPutOppgaveRequestJsonDTO().copy(


### PR DESCRIPTION
Viktig at systemApiClient blir brukt gjennom hele legg-tilbake-flyten,
siden vi her kan være i setting hvor saksbehandler ikke har tilgang til oppgaven.

Ett forsøk på å hente ut oppgaven via `apiClient` vil derfor feile, og da feiler tilbakeleggingen, og saksbehandler blir stuck med den oppgaven