### PR TITLE
[PROD][OPP-1308] slutte å fristille oppgaver tilknyttet orgnr

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/rest/RestOppgaveBehandlingServiceImpl.kt
@@ -300,7 +300,15 @@ class RestOppgaveBehandlingServiceImpl(
         saksbehandlersValgteEnhet: String?
     ) {
         requireNotNull(oppgaveId)
-        val oppgave = hentOppgaveJsonDTO(oppgaveId)
+        /**
+         * NB Viktig at systemApiClient brukes her.
+         * Vi skal potensielt sett hente en oppgave saksbehandler ikke har tilgang til.
+         */
+        val oppgave = systemApiClient.hentOppgave(
+            xminusCorrelationMinusID = correlationId(),
+            id = oppgaveId.toLong()
+        ).toOppgaveJsonDTO()
+
         systemApiClient
             .endreOppgave(
                 correlationId(),

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -610,7 +610,7 @@ class RestOppgaveBehandlingServiceImplTest {
     inner class LeggTilbakeOppgave {
         @Test
         fun `systemet legger tilbake oppgave uten endringer`() {
-            every { apiClient.hentOppgave(any(), any()) } returns dummyOppgave
+            every { systemApiClient.hentOppgave(any(), any()) } returns dummyOppgave
                 .copy(tilordnetRessurs = "Z999999")
                 .toGetOppgaveResponseJsonDTO()
             every {
@@ -628,7 +628,7 @@ class RestOppgaveBehandlingServiceImplTest {
             )
 
             verifySequence {
-                apiClient.hentOppgave(any(), 1234)
+                systemApiClient.hentOppgave(any(), 1234)
                 systemApiClient.endreOppgave(
                     any(), 1234,
                     dummyOppgave.toPutOppgaveRequestJsonDTO().copy(


### PR DESCRIPTION
Vi har hatt en i overkant aggresiv tilgangskontroll når vi henter ut saksbehandlers tildelte oppgaver.
Denne listen kan inneholde alle mulige oppgaver, også typer som er tilknyttet orgnr og ikke aktorID.
I disse tilfellene slo vår tilgangskontroll inn, og regnet manglende aktorID som manglende tilgang.
Dette førte til at alle oppgaver uten aktorID automatisk ble fristilt fra saksbehandler om de åpnet modiapersonoversikt.

Endringen i denne PRen filtrerer bort alle oppgaver uten aktorID (og flytter sjekken for oppgaver uten henvendelse tilknyttning) når vi henter ut saksbehandlers tildelte oppgaver.
På den måten unngår vi å prosessere disse og dermed legger vi de ikke tilbake.

Dette betyr også at orgnr oppgaver ikke blir sendt til frontend-appen.
Dette regnes som ok siden disse tidligere ble filtrert ut basert på manglende henvendelseId.