### PR TITLE
[KAIZEN-0] bumpe graphql-kotlin versjon

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>modiabrukerdialog-api</artifactId>
 
     <properties>
-        <graphql-kotlin.version>3.5.0</graphql-kotlin.version>
+        <graphql-kotlin.version>3.6.8</graphql-kotlin.version>
     </properties>
 
     <dependencies>

--- a/api/src/main/resources/pdl/queries/hentPerson.graphql
+++ b/api/src/main/resources/pdl/queries/hentPerson.graphql
@@ -92,9 +92,6 @@ query($ident: ID!){
                 gyldighetstidspunkt
                 opphoerstidspunkt
             }
-            metadata {
-                opplysningsId
-            }
         }
         foreldreansvar {
             ansvar

--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/person/DoedsboMapping.kt
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/person/DoedsboMapping.kt
@@ -66,16 +66,6 @@ object DoedsboMapping {
             "organisasjonsnummer" to adressat.organisasjonsnummer
         )
 
-    private fun personNavn(personNavn: HentPerson.Personnavn2?): Map<String, Any?> {
-        return personNavn(
-            HentPerson.Personnavn(
-                fornavn = personNavn?.fornavn ?: "",
-                mellomnavn = personNavn?.mellomnavn,
-                etternavn = personNavn?.etternavn ?: ""
-            )
-        )
-    }
-
     private fun personNavn(personNavn: HentPerson.Personnavn?): Map<String, Any?> {
         val sammensatNavn = "${personNavn?.fornavn.textOrEmpty()} ${personNavn?.mellomnavn.textOrEmpty()} ${personNavn?.etternavn.textOrEmpty()}"
         return mapOf(

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerIntTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerIntTest.kt
@@ -26,7 +26,7 @@ internal class PersonControllerIntTest {
         val pdlMock: PdlOppslagService = mock()
         val standardKodeverk: StandardKodeverk = mock()
         val advokatSomKontakt = HentPerson.KontaktinformasjonForDoedsboAdvokatSomKontakt(
-            HentPerson.Personnavn2(
+            HentPerson.Personnavn(
                 fornavn = "Ola",
                 mellomnavn = null,
                 etternavn = "Nordmann"
@@ -53,13 +53,12 @@ internal class PersonControllerIntTest {
             type = null,
             embete = null,
             vergeEllerFullmektig = HentPerson.VergeEllerFullmektig(
-                navn = HentPerson.Personnavn2("Fornavn", "Mellomnavn", "Etternavn"),
+                navn = HentPerson.Personnavn("Fornavn", "Mellomnavn", "Etternavn"),
                 motpartsPersonident = null,
                 omfang = null,
                 omfangetErInnenPersonligOmraade = false
             ),
-            folkeregistermetadata = null,
-            metadata = HentPerson.Metadata2(null)
+            folkeregistermetadata = null
         )
         val vergemalMedMotpartsIdent = vergemal.copy(
             vergeEllerFullmektig = vergemal.vergeEllerFullmektig.copy(
@@ -75,7 +74,7 @@ internal class PersonControllerIntTest {
                 ansvar = "felles",
                 ansvarlig = null,
                 ansvarligUtenIdentifikator = HentPerson.RelatertBiPerson(
-                    navn = HentPerson.Personnavn2("Fornavn", "Mellomnavn", "Etternavn"),
+                    navn = HentPerson.Personnavn("Fornavn", "Mellomnavn", "Etternavn"),
                     foedselsdato = null,
                     kjoenn = null,
                     statsborgerskap = null


### PR DESCRIPTION
Nyeste versjon er 3.7.0, men denne medfører en del større endringer.
Bumper derfor i første omgang til 3.6.8 da denne fikser litt bugs rundt generering av kotlin-klasser.

Mest merkbart er de-duplisering av data-klasser med samme innhold.
F.eks ble det tidligere laget `Tolk` og `Tolk2`, som refererte til akkurat samme schema-element,
og hentet ut akkurat samme informasjon.
Disse klassene blir nå slått sammen, slik at det blir litt lettere å håndtere.