### PR TITLE
[KAIZEN-0] byttet nhaarman-mockito med mockk i tester som er skrevet i kotlin

### DIFF
--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -267,11 +267,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
             <scope>test</scope>

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/pdl/PdlOppslagServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/pdl/PdlOppslagServiceImplTest.kt
@@ -1,14 +1,14 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.pdl
 
 import com.expediagroup.graphql.client.GraphQLClient
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
 import io.ktor.http.*
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.common.auth.subject.IdentType
 import no.nav.common.auth.subject.SsoToken
 import no.nav.common.auth.subject.Subject
@@ -30,11 +30,11 @@ internal class PdlOppslagServiceImplTest {
     @JvmField
     val subject = SubjectRule(Subject("Z999999", IdentType.InternBruker, SsoToken.oidcToken(userToken, emptyMap<String, Any>())))
     val systemuserToken = "RND-STS-TOKEN"
-    val stsMock: SystemUserTokenProvider = mock()
+    val stsMock: SystemUserTokenProvider = mockk()
 
     @Before
     fun before() {
-        whenever(stsMock.systemUserToken).thenReturn(systemuserToken)
+        every { stsMock.systemUserToken } returns systemuserToken
     }
 
     @Test

--- a/kjerneinfo/kjerneinfo-consumer/pom.xml
+++ b/kjerneinfo/kjerneinfo-consumer/pom.xml
@@ -34,8 +34,8 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -393,13 +393,6 @@
                 <artifactId>kotlin-reflect</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>com.nhaarman.mockitokotlin2</groupId>
-                <artifactId>mockito-kotlin</artifactId>
-                <version>${mockito-kotlin.version}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>

--- a/saksoversikt/pom.xml
+++ b/saksoversikt/pom.xml
@@ -135,11 +135,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/sporsmalogsvar/pom.xml
+++ b/sporsmalogsvar/pom.xml
@@ -147,11 +147,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/tilgangskontroll/pom.xml
+++ b/tilgangskontroll/pom.xml
@@ -78,8 +78,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/tilgangskontroll/TilgangskontrollMock.kt
+++ b/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/tilgangskontroll/TilgangskontrollMock.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.sbl.dialogarena.naudit.Audit
 import no.nav.sbl.dialogarena.rsbac.*
 import no.nav.sbl.dialogarena.rsbac.Function
@@ -25,11 +24,11 @@ class TilgangskontrollMock {
     companion object {
         @JvmStatic
         fun get(): Tilgangskontroll {
-            val tilgangskontroll: Tilgangskontroll = mock()
+            val tilgangskontroll: Tilgangskontroll = mockk()
             val rsbacInstance: RSBACInstance<TilgangskontrollContext> = RSBACMock()
-            whenever(tilgangskontroll.check(any<Combinable<TilgangskontrollContext>>())).thenReturn(rsbacInstance)
-            whenever(tilgangskontroll.check(any<Policy<TilgangskontrollContext>>())).thenReturn(rsbacInstance)
-            whenever(tilgangskontroll.check(any<PolicySet<TilgangskontrollContext>>())).thenReturn(rsbacInstance)
+            every { tilgangskontroll.check(any<Combinable<TilgangskontrollContext>>()) } returns rsbacInstance
+            every { tilgangskontroll.check(any<Policy<TilgangskontrollContext>>()) } returns rsbacInstance
+            every { tilgangskontroll.check(any<PolicySet<TilgangskontrollContext>>()) } returns rsbacInstance
 
             return tilgangskontroll
         }

--- a/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/tilgangskontroll/TilgangskontrollTest.kt
+++ b/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/tilgangskontroll/TilgangskontrollTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.common.auth.subject.IdentType
 import no.nav.common.auth.subject.SsoToken
 import no.nav.common.auth.subject.Subject
@@ -60,27 +59,26 @@ private fun mockContext(
     tematilganger: Set<String> = setOf(),
     abacTilgang: Decision = Decision.Permit
 ): TilgangskontrollContext {
-    val context: TilgangskontrollContext = mock()
-    whenever(context.hentSaksbehandlerId()).thenReturn(Optional.of(saksbehandlerIdent))
-    whenever(context.hentTemagrupperForSaksbehandler(any())).thenReturn(tematilganger)
-    whenever(context.checkAbac(any())).thenReturn(
-        AbacResponse(
-            listOf(
-                Response(
-                    abacTilgang,
-                    listOf(
-                        Advice(
-                            NavAttributes.ADVICE_DENY_REASON.attributeId,
-                            listOf(
-                                AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_CAUSE.attributeId, "cause-0001-manglerrolle"),
-                                AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_DENY_POLICY.attributeId, "fp3_behandle_egen_ansatt"),
-                                AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_DENY_RULE.attributeId, "intern_behandle_kode6_mangler_gruppetilgang")
-                            )
+    val context: TilgangskontrollContext = mockk()
+    every { context.hentSaksbehandlerId() } returns Optional.of(saksbehandlerIdent)
+    every { context.hentTemagrupperForSaksbehandler(any()) } returns tematilganger
+    every { context.checkAbac(any()) } returns AbacResponse(
+        listOf(
+            Response(
+                abacTilgang,
+                listOf(
+                    Advice(
+                        NavAttributes.ADVICE_DENY_REASON.attributeId,
+                        listOf(
+                            AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_CAUSE.attributeId, "cause-0001-manglerrolle"),
+                            AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_DENY_POLICY.attributeId, "fp3_behandle_egen_ansatt"),
+                            AttributeAssignment(NavAttributes.ADVICEOROBLIGATION_DENY_RULE.attributeId, "intern_behandle_kode6_mangler_gruppetilgang")
                         )
                     )
                 )
             )
         )
     )
+
     return context
 }

--- a/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/rsbac/RSBACTest.kt
+++ b/tilgangskontroll/src/test/java/no/nav/sbl/dialogarena/rsbac/RSBACTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.rsbac
 
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import io.mockk.spyk
+import io.mockk.verify
 import no.nav.sbl.dialogarena.naudit.Audit
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -120,7 +119,7 @@ internal class RSBACTest {
     @Test
     fun `should log audit-descriptor`() {
         val rsbac = RSBACImpl(null)
-        val auditDescriptor = mock<Audit.AuditDescriptor<String>>()
+        val auditDescriptor: Audit.AuditDescriptor<String> = spyk()
 
         runCatching {
             rsbac
@@ -128,13 +127,15 @@ internal class RSBACTest {
                 .get(auditDescriptor) { "OK" }
         }
 
-        verify(auditDescriptor).log(eq("OK"))
+        verify {
+            auditDescriptor.log("OK")
+        }
     }
 
     @Test
     fun `should log deny-audit-descriptor`() {
         val rsbac = RSBACImpl(null)
-        val auditDescriptor = mock<Audit.AuditDescriptor<String>>()
+        val auditDescriptor: Audit.AuditDescriptor<String> = spyk()
 
         runCatching {
             rsbac
@@ -142,13 +143,15 @@ internal class RSBACTest {
                 .get(auditDescriptor) { "OK" }
         }
 
-        verify(auditDescriptor).denied(eq("Error 1"))
+        verify {
+            auditDescriptor.denied("Error 1")
+        }
     }
 
     @Test
     fun `should log failed-audit-descriptor`() {
         val rsbac = RSBACImpl(null)
-        val auditDescriptor = mock<Audit.AuditDescriptor<String>>()
+        val auditDescriptor: Audit.AuditDescriptor<String> = spyk()
         val exception = IllegalStateException("Something wrong")
 
         val result = runCatching {
@@ -159,7 +162,9 @@ internal class RSBACTest {
 
         assertEquals(result.isFailure, true)
         assertEquals(result.exceptionOrNull(), exception)
-        verify(auditDescriptor).failed(eq(exception))
+        verify {
+            auditDescriptor.failed(exception)
+        }
     }
 
     @Test

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -207,11 +207,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
             <scope>test</scope>

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerIntTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerIntTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.kjerneinfo.consumer.fim.person.PersonKjerneinfoServiceBi
 import no.nav.kjerneinfo.consumer.fim.person.to.HentKjerneinformasjonResponse
 import no.nav.kjerneinfo.domain.person.Fodselsnummer
@@ -22,9 +21,9 @@ internal class PersonControllerIntTest {
     @Test
     fun `verifiserer at informasjon fra pdl blir riktig merget i personcontroller`() {
         val clock = Clock.fixed(Instant.parse("2020-04-20T12:00:00.00Z"), ZoneId.systemDefault())
-        val kjerneinfoMock: PersonKjerneinfoServiceBi = mock()
-        val pdlMock: PdlOppslagService = mock()
-        val standardKodeverk: StandardKodeverk = mock()
+        val kjerneinfoMock: PersonKjerneinfoServiceBi = mockk()
+        val pdlMock: PdlOppslagService = mockk()
+        val standardKodeverk: StandardKodeverk = mockk()
         val advokatSomKontakt = HentPerson.KontaktinformasjonForDoedsboAdvokatSomKontakt(
             HentPerson.Personnavn(
                 fornavn = "Ola",
@@ -83,49 +82,43 @@ internal class PersonControllerIntTest {
             )
         )
 
-        whenever(kjerneinfoMock.hentKjerneinformasjon(any())).thenReturn(
-            HentKjerneinformasjonResponse()
-                .apply {
-                    this.person = Person()
-                        .apply {
-                            this.fodselsnummer = Fodselsnummer("10108000398".trimIndent())
-                        }
-                }
+        every { kjerneinfoMock.hentKjerneinformasjon(any()) } returns HentKjerneinformasjonResponse()
+            .apply {
+                this.person = Person()
+                    .apply {
+                        this.fodselsnummer = Fodselsnummer("10108000398".trimIndent())
+                    }
+            }
+        every { pdlMock.hentNavnBolk(any()) } returns mapOf(
+            "12345678910" to HentNavnBolk.Navn("Verge", "Vergesen", "Olsen")
         )
-        whenever(pdlMock.hentNavnBolk(any())).thenReturn(
-            mapOf(
-                "12345678910" to HentNavnBolk.Navn("Verge", "Vergesen", "Olsen")
-            )
-        )
-        whenever(pdlMock.hentPerson(any())).thenReturn(
-            HentPerson.Person(
-                navn = emptyList(),
-                kontaktinformasjonForDoedsbo = kontaktiformasjonForDoedsbo,
-                tilrettelagtKommunikasjon = emptyList(),
-                fullmakt = emptyList(),
-                telefonnummer = listOf(
-                    HentPerson.Telefonnummer(
-                        "+47",
-                        "10101010",
-                        1,
-                        HentPerson.Metadata(
-                            listOf(
-                                HentPerson.Endring(
-                                    HentPerson.DateTime(LocalDateTime.now(clock)),
-                                    "BRUKER"
-                                )
+        every { pdlMock.hentPerson(any()) } returns HentPerson.Person(
+            navn = emptyList(),
+            kontaktinformasjonForDoedsbo = kontaktiformasjonForDoedsbo,
+            tilrettelagtKommunikasjon = emptyList(),
+            fullmakt = emptyList(),
+            telefonnummer = listOf(
+                HentPerson.Telefonnummer(
+                    "+47",
+                    "10101010",
+                    1,
+                    HentPerson.Metadata(
+                        listOf(
+                            HentPerson.Endring(
+                                HentPerson.DateTime(LocalDateTime.now(clock)),
+                                "BRUKER"
                             )
                         )
                     )
-                ),
-                vergemaalEllerFremtidsfullmakt = vergemaalEllerFremtidsfullmakt,
-                foreldreansvar = foreldreansvar
-            )
+                )
+            ),
+            vergemaalEllerFremtidsfullmakt = vergemaalEllerFremtidsfullmakt,
+            foreldreansvar = foreldreansvar
         )
 
         val personController = PersonController(
             kjerneinfoMock,
-            mock(),
+            mockk(),
             TilgangskontrollMock.get(),
             pdlMock,
             standardKodeverk

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/PersonControllerTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.kjerneinfo.common.domain.Kodeverdi
 import no.nav.kjerneinfo.consumer.fim.person.support.DefaultPersonKjerneinfoService
 import no.nav.kjerneinfo.consumer.fim.person.support.KjerneinfoMapper
@@ -43,43 +42,44 @@ private const val SWIFT = "Taylor"
 private const val LANDKODE = "IOT"
 
 internal class PersonControllerTest {
-
-    private val personV3: PersonV3 = mock()
-    private val pdlOppslagService: PdlOppslagService = mock()
-    private val organisasjonenhetV2Service: OrganisasjonEnhetV2Service = mock()
-    private val kodeverk: KodeverkmanagerBi = mock()
+    private val personV3: PersonV3 = mockk()
+    private val pdlOppslagService: PdlOppslagService = mockk()
+    private val organisasjonenhetV2Service: OrganisasjonEnhetV2Service = mockk()
+    private val kodeverk: KodeverkmanagerBi = mockk()
     private val mapper = KjerneinfoMapper(kodeverk)
-    private val tilgangskontrollUtenTPSContext: TilgangskontrollContext = mock()
+    private val tilgangskontrollUtenTPSContext: TilgangskontrollContext = mockk()
     private val tilgangskontrollUtenTPS = Tilgangskontroll(tilgangskontrollUtenTPSContext)
     private val tilgangskontroll: Tilgangskontroll = TilgangskontrollMock.get()
-    private val standardKodeverk: StandardKodeverk = mock()
+    private val standardKodeverk: StandardKodeverk = mockk()
 
-    private val service = DefaultPersonKjerneinfoService(personV3, mapper, tilgangskontrollUtenTPS, organisasjonenhetV2Service)
+    private val service =
+        DefaultPersonKjerneinfoService(personV3, mapper, tilgangskontrollUtenTPS, organisasjonenhetV2Service)
     private val controller = PersonController(service, kodeverk, tilgangskontroll, pdlOppslagService, standardKodeverk)
 
     @BeforeEach
     fun before() {
-        whenever(organisasjonenhetV2Service.finnNAVKontor(any(), any())).thenReturn(Optional.empty())
+        every { organisasjonenhetV2Service.finnNAVKontor(any(), any()) } returns Optional.empty()
+        every { kodeverk.getBeskrivelseForKode("K", "Kj_c3_b8nnstyper", "nb") } returns "KVINNE"
+        every { kodeverk.getBeskrivelseForKode("???", "Landkoder", "nb") } returns "Ukjent"
+        every { kodeverk.getBeskrivelseForKode("IOT", "Landkoder", "nb") } returns "Det britiske territoriet i Indiahavet"
+        every { kodeverk.getBeskrivelseForKode("SPFO", "Diskresjonskoder", "nb") } returns "Kode7"
+        every { pdlOppslagService.hentPerson(any()) } returns null
+        every { pdlOppslagService.hentNavnBolk(any()) } returns null
     }
 
     @Test
     fun `Kaster 404 hvis personen ikke ble funnet`() {
-        whenever(personV3.hentPerson(any())).thenThrow(HentPersonPersonIkkeFunnet("", PersonIkkeFunnet()))
+        every { personV3.hentPerson(any()) } throws HentPersonPersonIkkeFunnet("", PersonIkkeFunnet())
         val exception = assertThrows<ResponseStatusException> { controller.hent(FNR) }
         assertEquals(HttpStatus.NOT_FOUND, exception.status)
     }
 
     @Test
     fun `Returnerer begrenset innsyn object ved ikke tilgang`() {
-        whenever(personV3.hentPerson(any())).thenThrow(HentPersonSikkerhetsbegrensning("", Sikkerhetsbegrensning()))
-        whenever(personV3.hentSikkerhetstiltak(any()))
-            .thenReturn(
-                HentSikkerhetstiltakResponse()
-                    .withSikkerhetstiltak(
-                        Sikkerhetstiltak()
-                            .withSikkerhetstiltaksbeskrivelse("")
-                    )
-            )
+        every { personV3.hentPerson(any()) } throws HentPersonSikkerhetsbegrensning("", Sikkerhetsbegrensning())
+        every { personV3.hentSikkerhetstiltak(any()) } returns HentSikkerhetstiltakResponse()
+            .withSikkerhetstiltak(Sikkerhetstiltak().withSikkerhetstiltaksbeskrivelse(""))
+
         val o = controller.hent(FNR)
         assertTrue { o.containsKey("begrunnelse") }
     }
@@ -89,7 +89,7 @@ internal class PersonControllerTest {
         val mockPersonResponse = mockPersonResponse().apply {
             person.withStatsborgerskap(Statsborgerskap().withLand(Landkoder().withValue("???")))
         }
-        whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+        every { personV3.hentPerson(any()) } returns mockPersonResponse
 
         val response = controller.hent(FNR)
         val statsborgerskap = response["statsborgerskap"]
@@ -108,8 +108,8 @@ internal class PersonControllerTest {
                 )
             )
         }
-        whenever(kodeverk.getBeskrivelseForKode("NOR", "Land", "nb")).thenReturn("NORGE")
-        whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+        every { kodeverk.getBeskrivelseForKode("NOR", "Land", "nb") } returns "NORGE"
+        every { personV3.hentPerson(any()) } returns mockPersonResponse
 
         val response = controller.hent(FNR)
         val statsborgerskap = response["statsborgerskap"] as Kode
@@ -131,7 +131,7 @@ internal class PersonControllerTest {
             )
         }
 
-        whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+        every { personV3.hentPerson(any()) } returns mockPersonResponse
 
         val response = controller.hent(FNR)
         val relasjoner = response["familierelasjoner"] as ArrayList<*>
@@ -161,7 +161,7 @@ internal class PersonControllerTest {
             val mockPersonResponse = mockPersonResponse().apply {
                 person.withDiskresjonskode(Diskresjonskoder().withValue("SPFO"))
             }
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+            every { personV3.hentPerson(any()) } returns mockPersonResponse
 
             val response = controller.hent(FNR)
             val diskresjonskode = response["diskresjonskode"] as Kode
@@ -171,7 +171,7 @@ internal class PersonControllerTest {
 
         @Test
         fun `Uten diskresjonskode`() {
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse())
+            every { personV3.hentPerson(any()) } returns mockPersonResponse()
 
             val response = controller.hent(FNR)
             val diskresjonskode = response["diskresjonskode"]
@@ -192,7 +192,7 @@ internal class PersonControllerTest {
                 )
             }
 
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+            every { personV3.hentPerson(any()) } returns mockPersonResponse
 
             val response = controller.hent(FNR)
             val relasjoner = response["familierelasjoner"] as ArrayList<*>
@@ -221,11 +221,12 @@ internal class PersonControllerTest {
         @Test
         fun `Med mobil`() {
             val mockPersonResponse = responseMedMobil()
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse)
+            every { personV3.hentPerson(any()) } returns mockPersonResponse
 
             val response = controller.hent(FNR)
             val kontaktinformasjon = response["kontaktinformasjon"] as Map<*, *>
-            val mobil = kontaktinformasjon["mobil"] as no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.person.Telefonnummer
+            val mobil =
+                kontaktinformasjon["mobil"] as no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.person.Telefonnummer
             val retningsnummer = mobil.retningsnummer
             val nummer = mobil.identifikator
 
@@ -246,7 +247,7 @@ internal class PersonControllerTest {
 
         @Test
         fun `Uten mobil`() {
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse())
+            every { personV3.hentPerson(any()) } returns mockPersonResponse()
 
             val response = controller.hent(FNR)
             val kontaktinformasjon = response["kontaktinformasjon"] as Map<*, *>
@@ -261,15 +262,13 @@ internal class PersonControllerTest {
 
         @Test
         fun Mapping() {
-            whenever(kodeverk.getKodeverkList(any(), any())).thenReturn(listOf(Kodeverdi("SV", "Svensk")))
-            whenever(personV3.hentPerson(any())).thenReturn(mockPersonResponse())
-            whenever(pdlOppslagService.hentPerson(any())).thenReturn(
-                mockPdlPerson().copy(
-                    tilrettelagtKommunikasjon = listOf(
-                        HentPerson.TilrettelagtKommunikasjon(
-                            talespraaktolk = HentPerson.Tolk("SV"),
-                            tegnspraaktolk = null
-                        )
+            every { kodeverk.getKodeverkList(any(), any()) } returns listOf(Kodeverdi("SV", "Svensk"))
+            every { personV3.hentPerson(any()) } returns mockPersonResponse()
+            every { pdlOppslagService.hentPerson(any()) } returns mockPdlPerson().copy(
+                tilrettelagtKommunikasjon = listOf(
+                    HentPerson.TilrettelagtKommunikasjon(
+                        talespraaktolk = HentPerson.Tolk("SV"),
+                        tegnspraaktolk = null
                     )
                 )
             )
@@ -300,8 +299,8 @@ internal class PersonControllerTest {
 
         @Test
         fun `Norsk konto`() {
-            whenever(personV3.hentPerson(any())).thenReturn(
-                mockPersonResponse().apply {
+            every { personV3.hentPerson(any()) } returns mockPersonResponse()
+                .apply {
                     (person as Bruker)
                         .withBankkonto(
                             BankkontoNorge()
@@ -312,7 +311,6 @@ internal class PersonControllerTest {
                                 )
                         )
                 }
-            )
 
             val response = controller.hent(FNR)["bankkonto"] as Map<*, *>
 
@@ -322,8 +320,8 @@ internal class PersonControllerTest {
 
         @Test
         fun `Utenlandsk konto`() {
-            whenever(personV3.hentPerson(any())).thenReturn(
-                mockPersonResponse().apply {
+            every { personV3.hentPerson(any()) } returns mockPersonResponse()
+                .apply {
                     (person as Bruker)
                         .withBankkonto(
                             BankkontoUtland()
@@ -336,7 +334,6 @@ internal class PersonControllerTest {
                                 )
                         )
                 }
-            )
 
             val response = controller.hent(FNR)["bankkonto"] as Map<*, *>
 

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/enhet/EnhetControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/enhet/EnhetControllerTest.kt
@@ -1,30 +1,29 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.enhet
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.organisasjonsEnhetV2.OrganisasjonEnhetV2Service
 import no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll.TilgangskontrollMock
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import java.util.*
 import kotlin.test.assertEquals
 
 class EnhetControllerTest {
-    private val organisasjonEnhetV2Service: OrganisasjonEnhetV2Service = mock()
+    private val organisasjonEnhetV2Service: OrganisasjonEnhetV2Service = mockk()
     private val controller = EnhetController(
-        mock(),
+        mockk(),
         organisasjonEnhetV2Service,
-        mock(),
-        mock(),
+        mockk(),
+        mockk(),
         TilgangskontrollMock.get()
     )
 
     @Test
     fun `Kaster 404 hvis enhet ikke ble funnet`() {
-        whenever(organisasjonEnhetV2Service.finnNAVKontor(Mockito.any(), Mockito.any())).thenReturn(Optional.empty())
+        every { organisasjonEnhetV2Service.finnNAVKontor(any(), any()) } returns Optional.empty()
         val exception = assertThrows<ResponseStatusException> {
             controller.finnEnhet("", "")
         }

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/kontaktinformasjon/KontaktinformasjonControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/kontaktinformasjon/KontaktinformasjonControllerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.kontaktinformasjon
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.dkif.consumer.DkifService
 import no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll.TilgangskontrollMock
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.informasjon.WSEpostadresse
@@ -26,7 +26,7 @@ private const val RESERVASJON = "Reservert"
 
 class KontaktinformasjonControllerTest {
 
-    private val dkifService: DkifService = mock()
+    private val dkifService: DkifService = mockk()
     private val controller = KontaktinformasjonController(dkifService, TilgangskontrollMock.get())
 
     @BeforeEach
@@ -38,15 +38,12 @@ class KontaktinformasjonControllerTest {
         val epost = WSEpostadresse().withValue(EPOST).withSistOppdatert(lagDato(SIST_OPPDATERT))
         val mobiltelefon = WSMobiltelefonnummer().withValue(MOBILTELEFON).withSistOppdatert(lagDato(SIST_OPPDATERT))
 
-        whenever(dkifService.hentDigitalKontaktinformasjon(FNR))
-            .thenReturn(
-                WSHentDigitalKontaktinformasjonResponse()
-                    .withDigitalKontaktinformasjon(
-                        WSKontaktinformasjon()
-                            .withReservasjon(RESERVASJON)
-                            .withEpostadresse(epost)
-                            .withMobiltelefonnummer(mobiltelefon)
-                    )
+        every { dkifService.hentDigitalKontaktinformasjon(FNR) } returns WSHentDigitalKontaktinformasjonResponse()
+            .withDigitalKontaktinformasjon(
+                WSKontaktinformasjon()
+                    .withReservasjon(RESERVASJON)
+                    .withEpostadresse(epost)
+                    .withMobiltelefonnummer(mobiltelefon)
             )
     }
 
@@ -73,10 +70,9 @@ class KontaktinformasjonControllerTest {
 
     @Test
     fun `Når bruker ikke har epost eller mobil`() {
-        whenever(dkifService.hentDigitalKontaktinformasjon(FNR)).thenReturn(
+        every { dkifService.hentDigitalKontaktinformasjon(FNR) } returns
             WSHentDigitalKontaktinformasjonResponse()
                 .withDigitalKontaktinformasjon(WSKontaktinformasjon())
-        )
 
         val response = controller.hentKontaktinformasjon(FNR)
         val epost = response["epost"]

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/utbetaling/UtbetalingControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/utbetaling/UtbetalingControllerTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.utbetaling
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.modig.core.exception.ApplicationException
 import no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll.TilgangskontrollMock
 import no.nav.sbl.dialogarena.utbetaling.service.UtbetalingService
@@ -17,13 +16,13 @@ private const val FEIL_DATO_FORMAT = "234-14-7"
 
 internal class UtbetalingControllerTest {
 
-    private val service: UtbetalingService = mock()
+    private val service: UtbetalingService = mockk()
 
     private val controller: UtbetalingController = UtbetalingController(service, TilgangskontrollMock.get())
 
     @Test
     fun `Kaster ApplicationException`() {
-        whenever(service.hentWSUtbetalinger(any(), any(), any())).thenThrow(ApplicationException(""))
+        every { service.hentWSUtbetalinger(any(), any(), any()) } throws ApplicationException("")
         assertFailsWith<ApplicationException> { controller.hent(FNR, DATO_START, DATO_SLUTT) }
     }
 

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/vergemal/VergemalControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/vergemal/VergemalControllerTest.kt
@@ -1,15 +1,13 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.vergemal
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.kjerneinfo.consumer.fim.person.vergemal.VergemalService
 import no.nav.kjerneinfo.consumer.fim.person.vergemal.domain.Periode
 import no.nav.kjerneinfo.consumer.fim.person.vergemal.domain.Verge
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.pdl.generated.HentNavnBolk
 import no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll.TilgangskontrollMock
 import org.junit.jupiter.api.Test
-import java.util.*
 import kotlin.test.assertEquals
 
 private const val FNR = "10108000398"
@@ -17,7 +15,7 @@ private const val VERGES_IDENT = "123"
 
 class VergemalControllerTest {
 
-    private val vergemalService: VergemalService = mock()
+    private val vergemalService: VergemalService = mockk()
     private val controller: VergemalController = VergemalController(
         vergemalService,
         TilgangskontrollMock.get()
@@ -25,13 +23,11 @@ class VergemalControllerTest {
 
     @Test
     fun `Henter vergemål`() {
-        whenever(vergemalService.hentVergemal(any())).thenReturn(
-            listOf(
-                Verge()
-                    .withIdent(VERGES_IDENT)
-                    .withVirkningsperiode(Periode(null, null))
-                    .withPersonnavn(HentNavnBolk.Navn("", null, ""))
-            )
+        every { vergemalService.hentVergemal(any()) } returns listOf(
+            Verge()
+                .withIdent(VERGES_IDENT)
+                .withVirkningsperiode(Periode(null, null))
+                .withPersonnavn(HentNavnBolk.Navn("", null, ""))
         )
 
         val response = controller.hent(FNR)

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/ForeldrepengerUttrekkTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/ForeldrepengerUttrekkTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.ytelse
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.modig.core.exception.AuthorizationException
 import no.nav.sykmeldingsperioder.consumer.foreldrepenger.DefaultForeldrepengerService
 import no.nav.sykmeldingsperioder.consumer.foreldrepenger.mapping.ForeldrepengerMapper
@@ -21,7 +20,7 @@ private const val FNR = "10108000398"
 
 internal class ForeldrepengerUttrekkTest {
 
-    private val foreldrepengerServiceV2: ForeldrepengerV2 = mock()
+    private val foreldrepengerServiceV2: ForeldrepengerV2 = mockk()
 
     private val service = DefaultForeldrepengerService()
 
@@ -35,14 +34,14 @@ internal class ForeldrepengerUttrekkTest {
 
     @Test
     fun `Kaster Auth exception`() {
-        whenever(foreldrepengerServiceV2.hentForeldrepengerettighet(any())).thenThrow(HentForeldrepengerettighetSikkerhetsbegrensning())
+        every { foreldrepengerServiceV2.hentForeldrepengerettighet(any()) } throws HentForeldrepengerettighetSikkerhetsbegrensning()
 
         assertFailsWith<AuthorizationException> { uttrekk.hent(FNR) }
     }
 
     @Test
     fun `Test på om felter blir satt`() {
-        whenever(foreldrepengerServiceV2.hentForeldrepengerettighet(any())).thenReturn(mockResponse())
+        every { foreldrepengerServiceV2.hentForeldrepengerettighet(any()) } returns mockResponse()
 
         val response = uttrekk.hent(FNR)
         val foreldrepengerListe = response.get("foreldrepenger") as List<*>
@@ -53,7 +52,7 @@ internal class ForeldrepengerUttrekkTest {
 
     @Test
     fun `Tester datosetting`() {
-        whenever(foreldrepengerServiceV2.hentForeldrepengerettighet(any())).thenReturn(mockResponse())
+        every { foreldrepengerServiceV2.hentForeldrepengerettighet(any()) } returns mockResponse()
 
         val response = uttrekk.hent(FNR)
         val foreldrepengerListe = response.get("foreldrepenger") as List<*>

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/PleiepengerUttrekkTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/PleiepengerUttrekkTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.ytelse
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.kjerneinfo.consumer.organisasjon.OrganisasjonService
 import no.nav.modig.core.exception.AuthorizationException
 import no.nav.sykmeldingsperioder.consumer.pleiepenger.PleiepengerServiceImpl
@@ -22,24 +21,24 @@ private const val BARNETS_FNR = "01010012345"
 
 internal class PleiepengerUttrekkTest {
 
-    private val pleiepengerV1: PleiepengerV1 = mock()
+    private val pleiepengerV1: PleiepengerV1 = mockk()
     private val service = PleiepengerServiceImpl(pleiepengerV1)
 
-    private val org: OrganisasjonV4 = mock()
-    private val orgService: OrganisasjonService = mock()
+    private val org: OrganisasjonV4 = mockk()
+    private val orgService: OrganisasjonService = mockk()
 
     private val uttrekk = PleiepengerUttrekk(service, orgService)
 
     @Test
     fun `Kaster Auth exception`() {
-        whenever(pleiepengerV1.hentPleiepengerettighet(any())).thenThrow(HentPleiepengerettighetSikkerhetsbegrensning())
+        every { pleiepengerV1.hentPleiepengerettighet(any()) } throws HentPleiepengerettighetSikkerhetsbegrensning()
 
         assertFailsWith<AuthorizationException> { uttrekk.hent(FNR) }
     }
 
     @Test
     fun `Tom liste returnerer null`() {
-        whenever(pleiepengerV1.hentPleiepengerettighet(any())).thenReturn(WSHentPleiepengerettighetResponse())
+        every { pleiepengerV1.hentPleiepengerettighet(any()) } returns WSHentPleiepengerettighetResponse()
 
         val response = uttrekk.hent(FNR)
         val pleiepenger = response.get("pleiepenger")
@@ -49,7 +48,7 @@ internal class PleiepengerUttrekkTest {
 
     @Test
     fun `Test på om felter blir satt`() {
-        whenever(pleiepengerV1.hentPleiepengerettighet(any())).thenReturn(mockResponse())
+        every { pleiepengerV1.hentPleiepengerettighet(any()) } returns mockResponse()
 
         val response = uttrekk.hent(FNR)
         val pleiepengerListe = response.get("pleiepenger") as List<*>

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/SykepengerUttrekkTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/ytelse/SykepengerUttrekkTest.kt
@@ -1,8 +1,7 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.web.rest.ytelse
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.modig.core.exception.AuthorizationException
 import no.nav.sykmeldingsperioder.consumer.sykepenger.DefaultSykepengerService
 import no.nav.sykmeldingsperioder.consumer.sykepenger.mapping.SykepengerMapper
@@ -24,7 +23,7 @@ private const val STANS = "STANS"
 
 internal class SykepengerUttrekkTest {
 
-    private val sykepengerV2: SykepengerV2 = mock()
+    private val sykepengerV2: SykepengerV2 = mockk()
 
     private val service = DefaultSykepengerService()
 
@@ -38,14 +37,14 @@ internal class SykepengerUttrekkTest {
 
     @Test
     fun`Kaster Auth exception`() {
-        whenever(sykepengerV2.hentSykepengerListe(any())).thenThrow(HentSykepengerListeSikkerhetsbegrensning())
+        every { sykepengerV2.hentSykepengerListe(any()) } throws HentSykepengerListeSikkerhetsbegrensning()
 
         assertFailsWith<AuthorizationException> { uttrekk.hent(FNR) }
     }
 
     @Test
     fun`Test på om felter blir satt`() {
-        whenever(sykepengerV2.hentSykepengerListe(any())).thenReturn(mockResponse())
+        every { sykepengerV2.hentSykepengerListe(any()) } returns mockResponse()
 
         val sykmeldingsperiode = unwrapResponse()
 
@@ -54,7 +53,7 @@ internal class SykepengerUttrekkTest {
 
     @Test
     fun `Riktig dato formattering`() {
-        whenever(sykepengerV2.hentSykepengerListe(any())).thenReturn(mockResponse())
+        every { sykepengerV2.hentSykepengerListe(any()) } returns mockResponse()
 
         val sykmeldingsperiode = unwrapResponse()
 


### PR DESCRIPTION
Forskjellen mellom de to er minimal, og det er derfor unødvendig å bruke begge to.
Mockk virker som en mer standard-løsning i kotlin-verden, så derfor falt valget på denne.