### PR TITLE
[FAGSYSTEM-163212] hente ut alle tildelte oppgaver for saksbehandler

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -179,7 +179,8 @@ class RestOppgaveBehandlingServiceImpl(
             correlationId(),
             tilordnetRessurs = ident,
             aktivDatoTom = LocalDate.now(clock).toString(),
-            statuskategori = "AAPEN"
+            statuskategori = "AAPEN",
+            limit = Long.MAX_VALUE
         )
 
         val oppgaver = (response.oppgaver ?: emptyList())

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -266,7 +266,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     xminusCorrelationMinusID = any(),
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
-                    aktivDatoTom = now(fixedClock).toString()
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = Long.MAX_VALUE
                 )
             }
         }
@@ -304,7 +305,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     xminusCorrelationMinusID = any(),
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    statuskategori = "AAPEN"
+                    statuskategori = "AAPEN",
+                    limit = Long.MAX_VALUE
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -347,7 +349,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     xminusCorrelationMinusID = any(),
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    statuskategori = "AAPEN"
+                    statuskategori = "AAPEN",
+                    limit = Long.MAX_VALUE
                 )
             }
 
@@ -394,7 +397,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     xminusCorrelationMinusID = any(),
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
-                    aktivDatoTom = now(fixedClock).toString()
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = Long.MAX_VALUE
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -449,7 +453,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     xminusCorrelationMinusID = any(),
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
-                    aktivDatoTom = now(fixedClock).toString()
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = Long.MAX_VALUE
                 )
             }
         }


### PR DESCRIPTION
Noen saksbehandlere har veldig mange oppgaver tildelt seg selv, og om vi ikke spesifiserer hvor mange vi vil hente ut så får vi maksimalt 10 fra oppgave.

**Scenario;**
Saksbehandler har 15 tildelte oppgaver av ymse sort.
Saksbehandler ser en ny oppgave av type VURD_HENV, som hen kan besvare i modiapersonoversikt.
Saksbehandler tilordner seg oppgave i gosys/pesys, og klikker på "les/bevar i modia"
    
Modia laster inn, og henter ut saksbehandlers tildelte oppgaver. Denne listen vil da ikke inkludere den nylige tildelte oppgaver.
Og valget om å avslutte denne oppgaven blir derfor heller ikke tilgjengeliggjort for saksbehandler.