### PR TITLE
[KAIZEN-0] sette limit for uthenting til 50

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -180,7 +180,7 @@ class RestOppgaveBehandlingServiceImpl(
             tilordnetRessurs = ident,
             aktivDatoTom = LocalDate.now(clock).toString(),
             statuskategori = "AAPEN",
-            limit = 1000
+            limit = 50
         )
 
         val oppgaver = (response.oppgaver ?: emptyList())

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -267,7 +267,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
             }
         }
@@ -306,7 +306,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 1000
+                    limit = 50
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -350,7 +350,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 1000
+                    limit = 50
                 )
             }
 
@@ -398,7 +398,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -454,7 +454,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
             }
         }


### PR DESCRIPTION
Når vi bruker saksbehandlers jwt for kall til oppgave, så gjør oppgave tilgangskontroll mot ABAC.
Denne tilgangskontrollen er begrensen til å maks støtte 50 unike ressurser.

Hvis saksbehandler derfor har mer enn 50 åpne oppgaver risikerer vi derfor at kallet feiler.