### PR TITLE
[PROD][OPP-1308] legge til paginering ved uthenting av tildelte oppgaver

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -180,7 +180,7 @@ class RestOppgaveBehandlingServiceImpl(
             tilordnetRessurs = ident,
             aktivDatoTom = LocalDate.now(clock).toString(),
             statuskategori = "AAPEN",
-            limit = 1000
+            limit = 50
         )
 
         val oppgaver = (response.oppgaver ?: emptyList())

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/Utils.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/Utils.kt
@@ -48,4 +48,23 @@ object Utils {
             "$leggTil\n\n$gammelBeskrivelse"
         }
     }
+
+    fun <RESPONSE, DATA> paginering(
+        total: (response: RESPONSE) -> Long,
+        data: (response: RESPONSE) -> List<DATA>,
+        action: (offset: Long) -> RESPONSE
+    ): List<DATA> {
+        var offset: Long = 0
+        val buffer = mutableListOf<DATA>()
+
+        do {
+            val response: RESPONSE = action(offset)
+            val inTotal: Long = total(response)
+            val actionData: List<DATA> = data(response)
+            buffer.addAll(actionData)
+            offset += actionData.size
+        } while (offset < inTotal)
+
+        return buffer
+    }
 }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -267,7 +267,66 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 50
+                    limit = 49,
+                    offset = 0
+                )
+            }
+        }
+
+        @Test
+        fun `skal finne tildelte oppgaver når det er flere enn 50`() {
+            val antallTreffTotalt = 111
+            val forventetSvarFraOppgave = List(antallTreffTotalt) {
+                dummyOppgave.copy(
+                    id = (1234 + it).toLong(),
+                    aktoerId = "00007063000250000",
+                    metadata = mapOf(MetadataKey.EKSTERN_HENVENDELSE_ID.name to "henvid")
+                )
+            }.chunked(49)
+            every { apiClient.finnOppgaver(allAny()) } returnsMany forventetSvarFraOppgave.map { oppgaveListe ->
+                GetOppgaverResponseJsonDTO(
+                    antallTreffTotalt = antallTreffTotalt.toLong(),
+                    oppgaver = oppgaveListe
+                )
+            }
+            every { tilgangskontrollContext.checkAbac(any()) } returns AbacResponse(
+                listOf(Response(Decision.Permit, null))
+            )
+
+            val result: List<Oppgave> = withIdent("Z999999") {
+                oppgaveBehandlingService.finnTildelteOppgaverIGsak()
+            }
+            val oppgave: Oppgave = result[0]
+
+            assertThat(oppgave.oppgaveId).isEqualTo("1234")
+            assertThat(oppgave.fnr).isEqualTo("07063000250")
+            assertThat(oppgave.henvendelseId).isEqualTo("henvid")
+            assertThat(oppgave.erSTOOppgave).isEqualTo(true)
+
+            verifySequence {
+                apiClient.finnOppgaver(
+                    xminusCorrelationMinusID = any(),
+                    statuskategori = "AAPEN",
+                    tilordnetRessurs = "Z999999",
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = 49,
+                    offset = 0
+                )
+                apiClient.finnOppgaver(
+                    xminusCorrelationMinusID = any(),
+                    statuskategori = "AAPEN",
+                    tilordnetRessurs = "Z999999",
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = 49,
+                    offset = 49
+                )
+                apiClient.finnOppgaver(
+                    xminusCorrelationMinusID = any(),
+                    statuskategori = "AAPEN",
+                    tilordnetRessurs = "Z999999",
+                    aktivDatoTom = now(fixedClock).toString(),
+                    limit = 49,
+                    offset = 98
                 )
             }
         }
@@ -306,7 +365,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 50
+                    limit = 49,
+                    offset = 0
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -350,7 +410,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 50
+                    limit = 49,
+                    offset = 0
                 )
             }
 
@@ -398,7 +459,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 50
+                    limit = 49,
+                    offset = 0
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -454,7 +516,8 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 50
+                    limit = 49,
+                    offset = 0
                 )
             }
         }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -267,7 +267,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
             }
         }
@@ -306,7 +306,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 1000
+                    limit = 50
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -350,7 +350,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
                     statuskategori = "AAPEN",
-                    limit = 1000
+                    limit = 50
                 )
             }
 
@@ -398,7 +398,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
                 systemApiClient.endreOppgave(
                     any(),
@@ -454,7 +454,7 @@ class RestOppgaveBehandlingServiceImplTest {
                     statuskategori = "AAPEN",
                     tilordnetRessurs = "Z999999",
                     aktivDatoTom = now(fixedClock).toString(),
-                    limit = 1000
+                    limit = 50
                 )
             }
         }


### PR DESCRIPTION
Oppgave støtter egentlig uthenting av 1000 oppgaver, men når man bruker usertoken så er dette begrenset til 50 pga kall til ABAC.
Det blir her satt til 49, og dette skyldes en off-by-one error i oppgave, e.g antall < 50 vs antall <= 50 sannsynligvis.

Per i dag, og for å være api-kompatible med soap-integrasjonen, trenger vi uansett å hente alle oppgavene.
Og vi ser spor av saksbehandlere som har mer enn 150 tildelte oppgaver.

Introduserer derfor paginering, for å sikre at vi får alle oppgave her.