### PR TITLE
[KAIZEN-0] logge warning om oppgaver blir lagt tilbake pga manglende tilgang

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
@@ -15,7 +15,10 @@ public interface OppgaveBehandlingService {
 
     void tilordneOppgaveIGsak(String oppgaveId, Temagruppe temagruppe, String saksbehandlersValgteEnhet) throws FikkIkkeTilordnet;
 
+    @Deprecated
     List<Oppgave> finnTildelteOppgaverIGsak();
+    List<Oppgave> finnTildelteOppgaverIGsak(String fnr);
+    List<Oppgave> finnTildelteKNAOppgaverIGsak();
 
     List<Oppgave> plukkOppgaverFraGsak(Temagruppe temagruppe, String saksbehandlersValgteEnhet);
 

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -98,13 +98,6 @@
         </dependency>
         <dependency>
             <groupId>no.nav.sbl.dialogarena</groupId>
-            <artifactId>modiabrukerdialog-api</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.sbl.dialogarena</groupId>
             <artifactId>personsok-consumer</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -289,11 +282,6 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -185,37 +185,54 @@ class RestOppgaveBehandlingServiceImpl(
         val ident: String = SubjectHandler.getIdent().orElseThrow { IllegalStateException("Fant ikke ident") }
         val correlationId = correlationId()
 
-        val response = paginering<GetOppgaverResponseJsonDTO, OppgaveJsonDTO>(
-            total = { it.antallTreffTotalt ?: 0 },
-            data = { it.oppgaver ?: emptyList() },
-            action = { offset ->
-                apiClient.finnOppgaver(
-                    correlationId,
-                    tilordnetRessurs = ident,
-                    aktivDatoTom = LocalDate.now(clock).toString(),
-                    statuskategori = "AAPEN",
-                    limit = LIMIT,
-                    offset = offset
-                )
-            }
-        )
-
-        val oppgaver = response
-            .filter { oppgaveJson ->
-                val erTilknyttetHenvendelse = oppgaveJson.metadata?.containsKey(MetadataKey.EKSTERN_HENVENDELSE_ID.name) ?: false
-                val harAktorId = !oppgaveJson.aktoerId.isNullOrBlank()
-                erTilknyttetHenvendelse && harAktorId
-            }
-
-        val aktorIdTilganger: Map<String?, DecisionEnums> = hentAktorIdTilgang(oppgaver)
-        return SafeListAggregate<OppgaveJsonDTO, OppgaveJsonDTO>(oppgaver)
-            .filter { aktorIdTilganger[it.aktoerId] == DecisionEnums.PERMIT }
-            .fold(
-                transformSuccess = this::mapTilOppgave,
-                transformFailure = { it }
+        return hentOppgaverPaginertOgTilgangskontroll { offset ->
+            apiClient.finnOppgaver(
+                correlationId,
+                tilordnetRessurs = ident,
+                aktivDatoTom = LocalDate.now(clock).toString(),
+                statuskategori = "AAPEN",
+                limit = LIMIT,
+                offset = offset
             )
-            .getWithFailureHandling { failures -> systemLeggTilbakeOppgaver(failures) }
-            .toMutableList()
+        }
+    }
+
+    override fun finnTildelteOppgaverIGsak(fnr: String): MutableList<Oppgave> {
+        val ident: String = SubjectHandler.getIdent().orElseThrow { IllegalStateException("Fant ikke ident") }
+        val aktorId = fodselnummerAktorService.hentAktorIdForFnr(fnr)
+            ?: throw IllegalArgumentException("Fant ikke aktorId for $fnr")
+        val correlationId = correlationId()
+
+        return hentOppgaverPaginertOgTilgangskontroll { offset ->
+            apiClient.finnOppgaver(
+                correlationId,
+                aktoerId = listOf(aktorId),
+                tilordnetRessurs = ident,
+                aktivDatoTom = LocalDate.now(clock).toString(),
+                statuskategori = "AAPEN",
+                limit = LIMIT,
+                offset = offset
+            )
+        }
+    }
+
+    override fun finnTildelteKNAOppgaverIGsak(): MutableList<Oppgave> {
+        val ident: String = SubjectHandler.getIdent().orElseThrow { IllegalStateException("Fant ikke ident") }
+        val correlationId = correlationId()
+        val oppgaveType = kodeverksmapperService.mapOppgavetype(SPORSMAL_OG_SVAR)
+
+        return hentOppgaverPaginertOgTilgangskontroll { offset ->
+            apiClient.finnOppgaver(
+                correlationId,
+                tilordnetRessurs = ident,
+                tema = listOf(Utils.KONTAKT_NAV),
+                oppgavetype = listOf(oppgaveType),
+                aktivDatoTom = LocalDate.now(clock).toString(),
+                statuskategori = "AAPEN",
+                limit = LIMIT,
+                offset = offset
+            )
+        }
     }
 
     override fun plukkOppgaverFraGsak(
@@ -370,6 +387,32 @@ class RestOppgaveBehandlingServiceImpl(
             xminusCorrelationMinusID = correlationId(),
             id = oppgaveId.toLong()
         ).toOppgaveJsonDTO()
+    }
+
+    private fun hentOppgaverPaginertOgTilgangskontroll(action: (offset: Long) -> GetOppgaverResponseJsonDTO): MutableList<Oppgave> {
+        val response = paginering(
+            total = { it.antallTreffTotalt ?: 0 },
+            data = { it.oppgaver ?: emptyList() },
+            action = action
+        )
+
+        val oppgaver = response
+            .filter { oppgaveJson ->
+                val erTilknyttetHenvendelse =
+                    oppgaveJson.metadata?.containsKey(MetadataKey.EKSTERN_HENVENDELSE_ID.name) ?: false
+                val harAktorId = !oppgaveJson.aktoerId.isNullOrBlank()
+                erTilknyttetHenvendelse && harAktorId
+            }
+
+        val aktorIdTilganger: Map<String?, DecisionEnums> = hentAktorIdTilgang(oppgaver)
+        return SafeListAggregate<OppgaveJsonDTO, OppgaveJsonDTO>(oppgaver)
+            .filter { aktorIdTilganger[it.aktoerId] == DecisionEnums.PERMIT }
+            .fold(
+                transformSuccess = this::mapTilOppgave,
+                transformFailure = { it }
+            )
+            .getWithFailureHandling { failures -> systemLeggTilbakeOppgaver(failures) }
+            .toMutableList()
     }
 
     private fun finnAnsvarligEnhet(oppgave: OppgaveJsonDTO, temagruppe: Temagruppe): String {

--- a/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/oppgave/OppgaveController.kt
+++ b/web/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/oppgave/OppgaveController.kt
@@ -60,7 +60,7 @@ class OppgaveController @Autowired constructor(
             .check(Policies.tilgangTilModia)
             .check(Policies.kanPlukkeOppgave)
             .get(Audit.describe(READ, Henvendelse.Oppgave.Plukk, AuditIdentifier.TEMAGRUPPE to temagruppe)) {
-                val tildelteOppgaver = oppgaveBehandlingService.finnTildelteOppgaverIGsak()
+                val tildelteOppgaver = oppgaveBehandlingService.finnTildelteKNAOppgaverIGsak()
                 if (tildelteOppgaver.any { it.erSTOOppgave }) {
                     tildelteOppgaver
                 } else {
@@ -73,12 +73,22 @@ class OppgaveController @Autowired constructor(
             }.map { mapOppgave(it) }
     }
 
+    @Deprecated("Ønsker å bytte om til å bare hente tildelte oppgaver gitt en person")
     @GetMapping("/tildelt")
     fun finnTildelte() =
         tilgangkontroll
             .check(Policies.tilgangTilModia)
             .get(Audit.describe(READ, Henvendelse.Oppgave.Tildelte)) {
                 oppgaveBehandlingService.finnTildelteOppgaverIGsak()
+                    .map { mapOppgave(it) }
+            }
+
+    @GetMapping("/tildelt/{fnr}")
+    fun finnTildelte(@PathVariable("fnr") fnr: String): List<OppgaveDTO> =
+        tilgangkontroll
+            .check(Policies.tilgangTilModia)
+            .get(Audit.describe(READ, Henvendelse.Oppgave.Tildelte)) {
+                oppgaveBehandlingService.finnTildelteOppgaverIGsak(fnr)
                     .map { mapOppgave(it) }
             }
 

--- a/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/oppgave/OppgaveControllerTest.kt
+++ b/web/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/web/rest/oppgave/OppgaveControllerTest.kt
@@ -87,7 +87,7 @@ internal class OppgaveControllerTest {
             Oppgave(OPPGAVE_ID_2, "fnr", "traadId", true)
         )
 
-        every { oppgavebehandlingService.finnTildelteOppgaverIGsak() } returns mutableListOf()
+        every { oppgavebehandlingService.finnTildelteKNAOppgaverIGsak() } returns mutableListOf()
         every { plukkOppgaveService.plukkOppgaver(any(), any()) } returns oppgaver
 
         val resultat = SubjectHandlerUtil.withIdent(
@@ -109,7 +109,7 @@ internal class OppgaveControllerTest {
             Oppgave(OPPGAVE_ID_1, "fnr", "id", true),
             Oppgave("2", "1234", "id", true)
         )
-        every { oppgavebehandlingService.finnTildelteOppgaverIGsak() } returns oppgaveliste
+        every { oppgavebehandlingService.finnTildelteKNAOppgaverIGsak() } returns oppgaveliste
 
         val resultat = SubjectHandlerUtil.withIdent(
             SAKSBEHANDLERS_IDENT,
@@ -128,7 +128,7 @@ internal class OppgaveControllerTest {
     @Test
     fun `Returnerer tom liste hvis tjenesten returnerer tom liste`() {
         val httpRequest = HttpRequestUtil.mockHttpServletRequestMedCookie(SAKSBEHANDLERS_IDENT, VALGT_ENHET)
-        every { oppgavebehandlingService.finnTildelteOppgaverIGsak() } returns mutableListOf()
+        every { oppgavebehandlingService.finnTildelteKNAOppgaverIGsak() } returns mutableListOf()
         every { plukkOppgaveService.plukkOppgaver(any(), any()) } returns mutableListOf()
 
         val resultat = SubjectHandlerUtil.withIdent(


### PR DESCRIPTION
oppgave gjør en del tilgangskontroll før oppgaven er returnert til oss.
Ifølge oppgave-teamet skal dette inkludere geografisk-tilgang, men for å være på den sikre siden logger vi nå hvilke oppgaver vi legger tilbake.
På den måten får vi ett bilde av hvorvidt vi trenger å gjøre ekstra tilgangskontroll på vår side.

**NB** Bygger videre på https://github.com/navikt/modiapersonoversikt-api/pull/322