### PR TITLE
[KAIZEN-0] hindre paginering i å hanve i evig løkke

### DIFF
--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -21,6 +21,7 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.arbeidsfordeling.Arb
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.norg.AnsattService
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.kodeverksmapper.KodeverksmapperService
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.kodeverksmapper.domain.Behandling
+import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.oppgavebehandling.Utils.OPPGAVE_MAX_LIMIT
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.oppgavebehandling.Utils.SPORSMAL_OG_SVAR
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.oppgavebehandling.Utils.beskrivelseInnslag
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.oppgavebehandling.Utils.defaultEnhetGittTemagruppe
@@ -55,12 +56,6 @@ class RestOppgaveBehandlingServiceImpl(
 ) : OppgaveBehandlingService {
 
     companion object {
-        /**
-         * Maks 50 om man bruker userToken mot oppgave.
-         * En liten off-by-one bug i oppgave gjør at vi per nå må sette den til 49
-         */
-        val LIMIT: Long = 49
-
         @JvmStatic
         fun create(
             kodeverksmapperService: KodeverksmapperService,
@@ -194,7 +189,7 @@ class RestOppgaveBehandlingServiceImpl(
                     tilordnetRessurs = ident,
                     aktivDatoTom = LocalDate.now(clock).toString(),
                     statuskategori = "AAPEN",
-                    limit = LIMIT,
+                    limit = OPPGAVE_MAX_LIMIT,
                     offset = offset
                 )
             }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/UtilsTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/UtilsTest.kt
@@ -1,0 +1,20 @@
+package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.oppgavebehandling
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+data class Response(val total: Long, val data: List<String>)
+internal class UtilsTest {
+    @Test
+    fun `skal ikke havne i evig loop`() {
+        Utils.paginering<Response, String>(
+            total = { it.total },
+            data = { it.data },
+            action = { offset ->
+                Response(total = 1, data = emptyList())
+            }
+        )
+
+        assertTrue(true)
+    }
+}


### PR DESCRIPTION
`antallTreffTotalt` refererer til antall oppgaver før evt filtering basert på tilgangskontroll.
Vi kan derfor få tilbake en response uten data som sier `antalLTreffTotalt` og dermed havne i en evig løkke, siden vi forventer å få hentet ut mer informasjon en hva vi får fra oppgave.

Endringen her endrer på hvordan vi gjør pagineringen fra å være offset-orientert, til å være page-orientert.
Dvs at vi ikke lengre forsøker å holde styr på offset, men forholder oss til "pages" av "LIMIT"-størrelse.
Vi bruker deretter `antallTreffTotalt` til å kalkulere hvor mange pages vi må hente ut, og henter deretter ut alle pages.
Uavhengig av hva slags filtrering oppgave gjør så henter vi derfor ut all informasjonen som vi har lov til via dette kallet