### PR TITLE
[OPP-1103] legge til sperre for at saksbehandlere tar allerede tildelte oppgaver

### DIFF
--- a/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
+++ b/api/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/api/service/OppgaveBehandlingService.java
@@ -13,7 +13,7 @@ public interface OppgaveBehandlingService {
 
     OpprettOppgaveResponse opprettSkjermetOppgave(OpprettSkjermetOppgaveRequest request);
 
-    void tilordneOppgaveIGsak(String oppgaveId, Temagruppe temagruppe, String saksbehandlersValgteEnhet) throws FikkIkkeTilordnet;
+    void tilordneOppgaveIGsak(String oppgaveId, Temagruppe temagruppe, String saksbehandlersValgteEnhet, boolean tvungenTilordning) throws FikkIkkeTilordnet;
 
     @Deprecated
     List<Oppgave> finnTildelteOppgaverIGsak();
@@ -39,6 +39,11 @@ public interface OppgaveBehandlingService {
     class FikkIkkeTilordnet extends Exception {
         public FikkIkkeTilordnet(Throwable cause) {
             super(cause);
+        }
+    }
+    class AlleredeTildeltAnnenSaksbehandler extends Exception {
+        public AlleredeTildeltAnnenSaksbehandler(String message) {
+            super(message);
         }
     }
 }

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/config/service/ServiceConfig.java
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/config/service/ServiceConfig.java
@@ -18,8 +18,6 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.HenvendelseLesServic
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.HenvendelseUtsendingService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.OppgaveBehandlingService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.arbeidsfordeling.ArbeidsfordelingV1Service;
-import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.saker.GsakKodeverk;
-import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.saker.SakerService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.kodeverk.StandardKodeverk;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.ldap.LDAPService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.norg.AnsattService;
@@ -27,6 +25,8 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.oppfolgingsinfo.Oppf
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.organisasjonsEnhetV2.OrganisasjonEnhetV2Service;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.pdl.PdlOppslagService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.psak.PsakService;
+import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.saker.GsakKodeverk;
+import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.saker.SakerService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.config.endpoint.kodeverksmapper.Kodeverksmapper;
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.*;
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.arbeidsfordeling.ArbeidsfordelingClient;
@@ -46,6 +46,7 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.organisasjonenh
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.pdl.PdlOppslagServiceImpl;
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.saker.SakerServiceImpl;
 import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.saker.mediation.SakApiGatewayImpl;
+import no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.unleash.UnleashService;
 import no.nav.sbl.dialogarena.modiabrukerdialog.tilgangskontroll.Tilgangskontroll;
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v1.behandlehenvendelse.BehandleHenvendelsePortType;
 import no.nav.tjeneste.domene.brukerdialog.henvendelse.v1.senduthenvendelse.SendUtHenvendelsePortType;
@@ -119,19 +120,23 @@ public class ServiceConfig {
     }
 
     @Bean
-    public OppgaveBehandlingService oppgaveBehandlingService(KodeverksmapperService kodeverksmapperService,
-                                                             FodselnummerAktorService fodselnummerAktorService,
-                                                             AnsattService ansattService,
-                                                             ArbeidsfordelingV1Service arbeidsfordelingV1Service,
-                                                             Tilgangskontroll tilgangskontroll,
-                                                             SystemUserTokenProvider stsService) {
+    public OppgaveBehandlingService oppgaveBehandlingService(
+            KodeverksmapperService kodeverksmapperService,
+            FodselnummerAktorService fodselnummerAktorService,
+            AnsattService ansattService,
+            ArbeidsfordelingV1Service arbeidsfordelingV1Service,
+            Tilgangskontroll tilgangskontroll,
+            SystemUserTokenProvider stsService,
+            UnleashService unleashService
+    ) {
         return RestOppgaveBehandlingServiceImpl.create(
                 kodeverksmapperService,
                 fodselnummerAktorService,
                 ansattService,
                 arbeidsfordelingV1Service,
                 tilgangskontroll,
-                stsService
+                stsService,
+                unleashService
         );
     }
 

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -181,7 +181,7 @@ class RestOppgaveBehandlingServiceImpl(
         if (tvungenTilordning) {
             tjenestekallLogg.warn("[OPPGAVE] $ident gjorde en tvungen tilordning av $oppgaveId, som allerede var tildelt ${oppgave.tilordnetRessurs}")
         } else if (oppgave.tilordnetRessurs != null && oppgave.tilordnetRessurs != ident) {
-            throw AlleredeTildeltAnnenSaksbehandler("Oppgaven er allerede tildelt " + oppgave.tilordnetRessurs)
+            throw AlleredeTildeltAnnenSaksbehandler("Oppgaven er allerede tildelt ${oppgave.tilordnetRessurs}. Vil du overstyre dette?")
         }
 
         apiClient.endreOppgave(

--- a/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/unleash/Feature.kt
+++ b/consumer/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/unleash/Feature.kt
@@ -1,5 +1,6 @@
 package no.nav.sbl.dialogarena.modiabrukerdialog.consumer.service.unleash
 
 enum class Feature(val propertyKey: String) {
-    SAMPLE_FEATURE("feature.samplerfeature")
+    SAMPLE_FEATURE("feature.samplerfeature"),
+    STOPP_OPPGAVE_STJELING("modiabrukerdialog.stopp-oppgave-stjeling")
 }

--- a/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/consumer/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/consumer/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -16,6 +16,7 @@ import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.oppgave.toPostOppgave
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.oppgave.toPutOppgaveRequestJsonDTO
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.domain.oppgave.toPutOppgaveResponseJsonDTO
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.*
+import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.OppgaveBehandlingService.AlleredeTildeltAnnenSaksbehandler
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.arbeidsfordeling.ArbeidsfordelingV1Service
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.service.norg.AnsattService
 import no.nav.sbl.dialogarena.modiabrukerdialog.api.utils.http.SubjectHandlerUtil
@@ -189,7 +190,8 @@ class RestOppgaveBehandlingServiceImplTest {
                 oppgaveBehandlingService.tilordneOppgaveIGsak(
                     "1234",
                     Temagruppe.FMLI,
-                    "4110"
+                    "4110",
+                    false
                 )
             }
 
@@ -215,7 +217,8 @@ class RestOppgaveBehandlingServiceImplTest {
                 oppgaveBehandlingService.tilordneOppgaveIGsak(
                     "1234",
                     Temagruppe.ANSOS,
-                    "4110"
+                    "4110",
+                    false
                 )
             }
 
@@ -226,6 +229,53 @@ class RestOppgaveBehandlingServiceImplTest {
                     1234,
                     dummyOppgave.toPutOppgaveRequestJsonDTO().copy(
                         endretAvEnhetsnr = "4110",
+                        tilordnetRessurs = "Z999999"
+                    )
+                )
+            }
+        }
+
+        @Test
+        fun `skal kaste exception om oppgaven allerede er tilordnet saksbehandler`() {
+            every { apiClient.hentOppgave(any(), any()) } returns dummyOppgave
+                .copy(tilordnetRessurs = "Z999998")
+                .toGetOppgaveResponseJsonDTO()
+
+            assertThatThrownBy {
+                withIdent("Z999999") {
+                    oppgaveBehandlingService.tilordneOppgaveIGsak(
+                        "1234",
+                        Temagruppe.ANSOS,
+                        "4110",
+                        false
+                    )
+                }
+            }.isExactlyInstanceOf(AlleredeTildeltAnnenSaksbehandler::class.java)
+        }
+
+        @Test
+        fun `skal ignorere allerede-tilordnet sjekk om tvungen tilordner er satt til true`() {
+            every { apiClient.hentOppgave(any(), any()) } returns dummyOppgave
+                .copy(tilordnetRessurs = "Z999998")
+                .toGetOppgaveResponseJsonDTO()
+            every { apiClient.endreOppgave(any(), any(), any()) } returns dummyOppgave.toPutOppgaveResponseJsonDTO()
+
+            withIdent("Z999999") {
+                oppgaveBehandlingService.tilordneOppgaveIGsak(
+                    "1234",
+                    Temagruppe.FMLI,
+                    "4110",
+                    true
+                )
+            }
+
+            verifySequence {
+                apiClient.hentOppgave(any(), 1234)
+                apiClient.endreOppgave(
+                    any(),
+                    1234,
+                    dummyOppgave.toPutOppgaveRequestJsonDTO().copy(
+                        endretAvEnhetsnr = "4100",
                         tilordnetRessurs = "Z999999"
                     )
                 )


### PR DESCRIPTION
Legger til sperre som hindrer at saksbehandlere "stjeler" hverandres oppgaver når de klikker på "Ny melding" i modia.
Det vil fortsatt være mulig å overstyre dette, men vil nå kreve ett ekstra felt for å gjøre dette.