### PR TITLE
[REVERT-0][OPP-1001] Vises feil dato på samtalereferat

### DIFF
--- a/saksoversikt/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapper.kt
+++ b/saksoversikt/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapper.kt
@@ -46,7 +46,7 @@ private fun getDato(journalpost: Journalpost): LocalDateTime? =
     when (journalpost.journalposttype) {
         JOURNALPOSTTYPE_INN -> getRelevantDatoForType(DATOTYPE_REGISTRERT, journalpost)
         JOURNALPOSTTYPE_UT -> getDatoSendt(journalpost)
-        JOURNALPOSTTYPE_INTERN -> getRelevantDatoForType(DATOTYPE_REGISTRERT, journalpost)
+        JOURNALPOSTTYPE_INTERN -> getRelevantDatoForType(DATOTYPE_JOURNALFOERT, journalpost)
         else -> now()
     } ?: now()
 

--- a/saksoversikt/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapperKtTest.kt
+++ b/saksoversikt/src/test/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapperKtTest.kt
@@ -452,18 +452,13 @@ internal class SafDokumentMapperKtTest {
     }
 
     @Test
-    fun `Bruker mottatt dato for Intern`() {
+    fun `Bruker journalfoert dato for Intern`() {
         val journalFoertDato = LocalDateTime.parse("2018-11-11T13:23:57", DateTimeFormatter.ISO_DATE_TIME)
-        val mottattDato = LocalDateTime.parse("2017-10-10T09:23:57", DateTimeFormatter.ISO_DATE_TIME)
         val journalpost = lagJournalpost().copy(
             relevanteDatoer = listOf(
                 RelevantDato(
                     datotype = DATOTYPE_JOURNALFOERT,
                     dato = journalFoertDato
-                ),
-                RelevantDato(
-                    datotype = DATOTYPE_REGISTRERT,
-                    dato = mottattDato
                 )
             ),
             journalposttype = JOURNALPOSTTYPE_INTERN
@@ -471,7 +466,7 @@ internal class SafDokumentMapperKtTest {
 
         val dokumentMetadata = DokumentMetadata().fraSafJournalpost(journalpost)
 
-        assertEquals(mottattDato, dokumentMetadata.dato)
+        assertEquals(journalFoertDato, dokumentMetadata.dato)
     }
 }
 


### PR DESCRIPTION
Samtalereferat blir nå vist som opprettet på dagens dato i modia selvom dette ikke er tilfelle. Dette skaper forvirring for veilederene, så endringene reverteres.