### PR TITLE
[OPP-1001] Endrer dato i saksoversikten

### DIFF
--- a/saksoversikt/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapper.kt
+++ b/saksoversikt/src/main/java/no/nav/sbl/dialogarena/modiabrukerdialog/sak/service/saf/SafDokumentMapper.kt
@@ -46,6 +46,7 @@ private fun getDato(journalpost: Journalpost): LocalDateTime? =
     when (journalpost.journalposttype) {
         JOURNALPOSTTYPE_INN -> getRelevantDatoForType(DATOTYPE_REGISTRERT, journalpost)
         JOURNALPOSTTYPE_UT -> getDatoSendt(journalpost)
+        /* Her kan man ikke sortere notat på dato fordi dataene finnes ikke */
         JOURNALPOSTTYPE_INTERN -> getRelevantDatoForType(DATOTYPE_JOURNALFOERT, journalpost)
         else -> now()
     } ?: now()


### PR DESCRIPTION
Denne oppgaven kunne ikke løses pga. manglende data, så har lagt til en kommentar i koden på dette slik at vi vet hvorfor valgt datotype blir brukt på notat.