### PR TITLE
[OPP-1368] endrer abac-url for prod

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -67,7 +67,7 @@ spec:
     - name: SECURITYTOKENSERVICE_URL
       value: "https://sts.adeo.no/SecurityTokenServiceProvider/"
     - name: ABAC_PDP_ENDPOINT_URL
-      value: "https://wasapp.adeo.no/asm-pdp/authorize"
+      value: "https://abac-modia.dev.intern.nav.no/application/authorize"
     - name: AKTOER_V1_ENDPOINTURL
       value: "https://app.adeo.no/aktoerregister/ws/Aktoer/v1"
     - name: AKTOER_V2_ENDPOINTURL


### PR DESCRIPTION
Denne var tidligere en del av `dev`, men ble revertert siden abac-modia ikke var i prod og for fjerne blokkering av den PRen til prod.