### PR TITLE
[KAIZEN-0] bytte til pdl-q0/1 miljøene

### DIFF
--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -287,7 +287,7 @@ spec:
     - name: HENVENDELSE_LES_API_URL
       value: "https://modapp-q0.adeo.no/henvendelse-les/api"
     - name: PDL_API_URL
-      value: "https://pdl-api.nais.preprod.local/graphql"
+      value: "https://pdl-api-q0.dev.intern.nav.no/graphql"
     - name: PERSONFORVALTER_URL
       value: "https://pdl-web.dev.intern.nav.no/endreperson"
     - name: OPPGAVE_BASEURL

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -283,7 +283,7 @@ spec:
     - name: HENVENDELSE_LES_API_URL
       value: "https://modapp-q1.adeo.no/henvendelse-les/api"
     - name: PDL_API_URL
-      value: "https://pdl-api.nais.preprod.local/graphql"
+      value: "https://pdl-api-q1.dev.intern.nav.no/graphql"
     - name: PERSONFORVALTER_URL
       value: "https://pdl-web.dev.intern.nav.no/endreperson"
     - name: OPPGAVE_BASEURL

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlSyntetiskMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlSyntetiskMapper.kt
@@ -1,13 +1,11 @@
 package no.nav.modiapersonoversikt.service.pdl
 
-import no.nav.common.utils.EnvironmentUtils
-import no.nav.modiapersonoversikt.service.unleash.strategier.ByEnvironmentStrategy
 import org.slf4j.LoggerFactory
 
 internal data class TpsFnr(val tpsIdent: String)
 internal data class PdlFnr(val pdlIdent: String)
 
-internal val enableMapper = "p" != EnvironmentUtils.getOptionalProperty(ByEnvironmentStrategy.ENVIRONMENT_PROPERTY).orElse("p")
+internal val enableMapper = false // "p" != EnvironmentUtils.getOptionalProperty(ByEnvironmentStrategy.ENVIRONMENT_PROPERTY).orElse("p")
 internal val log = LoggerFactory.getLogger(PdlSyntetiskMapper::class.java)
 
 object PdlSyntetiskMapper {


### PR DESCRIPTION
Forhåpentligvis stemmer disse miljøene bedre overens med TPS, slik at aktørid/fnr mapping stemmer med data fra henvendelse
