### PR TITLE
[TEST][KAIZEN-0] bytte til pdl-q0/1 miljøene

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentIdent.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentIdent.graphql
@@ -1,8 +1,9 @@
 query($ident: ID!){
-    hentIdenter(ident: $ident) {
+    hentIdenter(ident: $ident, historikk: true) {
         identer {
             ident
             gruppe
+            historisk
         }
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonController.kt
@@ -8,6 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
+import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentIdent
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPerson
 import no.nav.modiapersonoversikt.legacy.api.service.kodeverk.StandardKodeverk
 import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService
@@ -118,6 +119,11 @@ class PersonController @Autowired constructor(
                     }
                 }
             }
+    }
+
+    @GetMapping("/identer")
+    fun hentIdenter(@PathVariable("fnr") fodselsnummer: String): HentIdent.Identliste? {
+        return pdlOppslagService.hentIdent(fodselsnummer)
     }
 
     data class VergemalDTO(


### PR DESCRIPTION
Forhåpentligvis stemmer disse miljøene bedre overens med TPS, slik at aktørid/fnr mapping stemmer med data fra henvendelse


Og her er en ny linje
