### PR TITLE
[FAGSYSTEM-178062] legge til audit-logger for tilgangssjekken

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/AuditResources.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/AuditResources.kt
@@ -80,6 +80,7 @@ class AuditResources {
 
             @JvmField
             val Personalia = AuditResource("person.personalia")
+            val Tilgang = AuditResource("person.tilgang")
             val Saker = AuditResource("person.saker")
 
             @JvmField


### PR DESCRIPTION
Gjort for å enklere kunne feilsøke probelmer i fremtiden.
Per idag stopper frontend opp om tilgangskontroll-sjekken sier at veileder ikke har tilgang. Det havner derfor veldig lite i loggen som kan forklare hvorfor.