### PR TITLE
[KAIZEN-0] gjøre scientist istand til å sammenligne ulike datatyper

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/scientist/Scientist.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/scientist/Scientist.kt
@@ -40,14 +40,14 @@ object Scientist {
     data class Result<T>(
         val experimentRun: Boolean,
         val controlValue: T,
-        val experimentValue: T? = null,
+        val experimentValue: Any? = null,
         val experimentException: Throwable? = null
     )
     class Experiment<T> internal constructor(private val config: Config) {
         private val timer = Timer()
         fun runIntrospected(
             control: () -> T,
-            experiment: () -> T
+            experiment: () -> Any?
         ): Result<T> {
             if (Random.nextDouble() < config.experimentRate) {
                 val fields = mutableMapOf<String, Any?>()
@@ -88,7 +88,7 @@ object Scientist {
             }
         }
 
-        fun run(control: () -> T, experiment: () -> T): T =
+        fun run(control: () -> T, experiment: () -> Any?): T =
             runIntrospected(control, experiment).controlValue
     }
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
@@ -95,4 +95,39 @@ internal class ScientistTest {
             )
         ).run({ controlResult }, { experimentResult })
     }
+
+    private data class Dataholder(val id: String, val count: Int, val isDone: Boolean)
+
+    @Test
+    fun `experiment should compare untyped maps to typed objects correctly`() {
+        val controlResult = listOf(
+            mapOf(
+                "id" to "123",
+                "count" to 4,
+                "isDone" to false
+            ),
+            mapOf(
+                "id" to "126",
+                "count" to 6,
+                "isDone" to true
+            )
+        )
+        val experimentResult = listOf(
+            Dataholder("123", 4, false),
+            Dataholder("126", 6, true)
+        )
+        Scientist.createExperiment<List<Map<String, Any?>>>(
+            Scientist.Config(
+                name = "DummyExperiment",
+                experimentRate = 1.0,
+                reporter = { header, fields ->
+                    assertThat(fields).containsEntry("ok", true)
+                    assertThat(fields).containsKey("control")
+                    assertThat(fields).containsKey("controlTime")
+                    assertThat(fields).containsKey("experiment")
+                    assertThat(fields).containsKey("experimentTime")
+                }
+            )
+        ).run({ controlResult }, { experimentResult })
+    }
 }


### PR DESCRIPTION
Så lenge resultatet fra eksperimentet serialiseres til samme json som kontrollen, så kan vi anta at ting er greit.

Det gir oss muligheten til å bruke `Scientist` når vi type-setter api-er som idag har veldig løse typer, e.g `Map<String, Any?>`
