### PR TITLE
[FAGSYSTEM-178851] legge til oppfolging-felt som kan være null

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
@@ -45,7 +45,8 @@ class OppfolgingController @Autowired constructor(
                 val oppfolging = service.hentOppfolgingsinfo(fodselsnummer, ldapService)
 
                 mapOf(
-                    "erUnderOppfølging" to oppfolging.erUnderOppfolging,
+                    "erUnderOppfølging" to oppfolging.erUnderOppfolging, // TODO skal fjernes når frontend er oppdatert
+                    "erUnderOppfolging" to oppfolging.erUnderOppfolging,
                     "veileder" to hentVeileder(oppfolging.veileder),
                     "enhet" to hentEnhet(oppfolging.oppfolgingsenhet)
                 )
@@ -65,9 +66,11 @@ class OppfolgingController @Autowired constructor(
                     lagOppfolgingskontraktRequest(fodselsnummer, start, slutt)
                 )
                 val ytelserResponse = ytelseskontraktService.hentYtelseskontrakter(lagYtelseRequest(fodselsnummer, start, slutt))
+                val oppfolgingstatus = runCatching { hent(fodselsnummer) }
 
                 mapOf(
-                    "oppfølging" to hent(fodselsnummer),
+                    "oppfølging" to oppfolgingstatus.getOrThrow(), // TODO denne skal fjernes såfort frontend er oppdatert
+                    "oppfolging" to oppfolgingstatus.getOrNull(),
                     "meldeplikt" to kontraktResponse.bruker?.meldeplikt,
                     "formidlingsgruppe" to kontraktResponse.bruker?.formidlingsgruppe,
                     "innsatsgruppe" to kontraktResponse.bruker?.innsatsgruppe,


### PR DESCRIPTION
Pga tilgangskontroll i veilarboppfolging så kan man havne i en situasjon hvor vi ikke får hentet ut informasjon derifra selvom saksbehandler har tilgang.

For å håndtere dette på en bedre måte legger vi til nytt felt (`oppfolging`) som kan være `null`.
Om feltet er null så håndteres dette fra frontend-koden våres.

Når frontend-koden er oppdatert så kan vi rydde unna de gamle feltene.
