### PR TITLE
[FAGSYSTEM-178851] fjerne ubrukte felter fra api

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
@@ -45,7 +45,6 @@ class OppfolgingController @Autowired constructor(
                 val oppfolging = service.hentOppfolgingsinfo(fodselsnummer, ldapService)
 
                 mapOf(
-                    "erUnderOppfølging" to oppfolging.erUnderOppfolging, // TODO skal fjernes når frontend er oppdatert
                     "erUnderOppfolging" to oppfolging.erUnderOppfolging,
                     "veileder" to hentVeileder(oppfolging.veileder),
                     "enhet" to hentEnhet(oppfolging.oppfolgingsenhet)
@@ -69,7 +68,6 @@ class OppfolgingController @Autowired constructor(
                 val oppfolgingstatus = runCatching { hent(fodselsnummer) }
 
                 mapOf(
-                    "oppfølging" to oppfolgingstatus.getOrThrow(), // TODO denne skal fjernes såfort frontend er oppdatert
                     "oppfolging" to oppfolgingstatus.getOrNull(),
                     "meldeplikt" to kontraktResponse.bruker?.meldeplikt,
                     "formidlingsgruppe" to kontraktResponse.bruker?.formidlingsgruppe,


### PR DESCRIPTION
ønsker i minst mulig grad å viderføre bruken av æøå i api/kode.

Avhengig av https://github.com/navikt/modiapersonoversikt/pull/1595 før denne kan gå til produksjon
