### PR TITLE
[OPP-1384] åpne for integrasjon mot felleskodeverk

### DIFF
--- a/tjenestespesifikasjoner/kodeverk-api/pom.xml
+++ b/tjenestespesifikasjoner/kodeverk-api/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>dkif-api</artifactId>
+    <artifactId>kodeverk-api</artifactId>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -53,10 +53,10 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.basedir}/src/main/resources/dkif/openapi.json</inputSpec>
+                            <inputSpec>${project.basedir}/src/main/resources/kodeverk/openapi.json</inputSpec>
                             <generatorName>kotlin</generatorName>
                             <library>jvm-okhttp3</library>
-                            <packageName>no.nav.modiapersonoversikt.legacy.api.domain.dkif.generated</packageName>
+                            <packageName>no.nav.modiapersonoversikt.legacy.api.domain.kodeverk.generated</packageName>
                             <modelNameSuffix>DTO</modelNameSuffix>
                             <templateDirectory>${project.basedir}/../openapi-templates</templateDirectory>
                             <configOptions>
@@ -79,7 +79,8 @@
                         </goals>
                         <configuration>
                             <sourceDirs>
-                                <sourceDir>${project.build.directory}/generated-sources/openapi/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.build.directory}/generated-sources/openapi/src/main/kotlin
+                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>

--- a/tjenestespesifikasjoner/kodeverk-api/src/main/resources/kodeverk/openapi.json
+++ b/tjenestespesifikasjoner/kodeverk-api/src/main/resources/kodeverk/openapi.json
@@ -1,0 +1,459 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "REST-grensesnittet som er tilgjengelig for konsumering av andre applikasjoner og komponenter, for å hente informasjon om kodeverkene som finnes.",
+    "title": "API versjon 1"
+  },
+  "host": "kodeverk.nais.preprod.local",
+  "basePath": "/",
+  "tags": [
+    {
+      "name": "hierarki",
+      "description": "Endepunkt for å hente hierarki"
+    },
+    {
+      "name": "kodeverk",
+      "description": "Endepunkt for å hente kodeverk"
+    }
+  ],
+  "paths": {
+    "/api/v1/hierarki": {
+      "get": {
+        "tags": [
+          "hierarki"
+        ],
+        "summary": "Returnerer en liste med navnene på alle hierarkiene som er registrert.",
+        "operationId": "hierarkiUsingGET",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Nav-Call-Id",
+            "in": "header",
+            "description": "En ID som identifiserer kallkjeden som dette kallet er en del av.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Nav-Consumer-Id",
+            "in": "header",
+            "description": "ID'en på systemet som gjør kallet, som regel service brukeren til applikasjonen, for eksempel \"srvmedl2\".",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetHierarkiResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/api/v1/hierarki/{hierarkinavn}/noder": {
+      "get": {
+        "tags": [
+          "hierarki"
+        ],
+        "summary": "Returnerer to lister som viser informasjon om et hierarki. Første liste er nivåer, andre liste er hierarkiet.",
+        "operationId": "noderTilHierarkiUsingGET",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Nav-Call-Id",
+            "in": "header",
+            "description": "En ID som identifiserer kallkjeden som dette kallet er en del av.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Nav-Consumer-Id",
+            "in": "header",
+            "description": "Nav-Consumer-Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "hierarkinavn",
+            "in": "path",
+            "description": "Hvilket hierarki man skal hente.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "spraak",
+            "in": "query",
+            "description": "En liste over de språkene som termene skal returneres på. Tjenesten vil hente ut alle termene på norsk. Om du ønsker flere spraak kan du angi det. Eksempelverdier er \"nb\" og \"nn\" for henholdsvis bokmål og nynorsk.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "allowEmptyValue": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetHierarkiNoderResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/api/v1/kodeverk": {
+      "get": {
+        "tags": [
+          "kodeverk"
+        ],
+        "summary": "Returnerer en liste med navnene på alle kodeverkene som er registrert.",
+        "operationId": "kodeverkUsingGET",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Nav-Call-Id",
+            "in": "header",
+            "description": "En ID som identifiserer kallkjeden som dette kallet er en del av.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Nav-Consumer-Id",
+            "in": "header",
+            "description": "ID'en på systemet som gjør kallet, som regel service brukeren til applikasjonen, for eksempel \"srvmedl2\".",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetKodeverkResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/api/v1/kodeverk/{kodeverksnavn}/koder": {
+      "get": {
+        "tags": [
+          "kodeverk"
+        ],
+        "summary": "Returnerer en liste med de kodene som er registrert under det angitte kodeverket.",
+        "operationId": "koderUsingGET",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Nav-Call-Id",
+            "in": "header",
+            "description": "En ID som identifiserer kallkjeden som dette kallet er en del av.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Nav-Consumer-Id",
+            "in": "header",
+            "description": "Nav-Consumer-Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "kodeverksnavn",
+            "in": "path",
+            "description": "Hvilket kodeverk man skal hente koder fra.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetKodeverkKoderResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/api/v1/kodeverk/{kodeverksnavn}/koder/betydninger": {
+      "get": {
+        "tags": [
+          "kodeverk"
+        ],
+        "summary": "Returnerer informasjon om betydningene av kodene som finnes i et gitt kodeverk.",
+        "operationId": "betydningUsingGET",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Nav-Call-Id",
+            "in": "header",
+            "description": "En ID som identifiserer kallkjeden som dette kallet er en del av.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Nav-Consumer-Id",
+            "in": "header",
+            "description": "Nav-Consumer-Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ekskluderUgyldige",
+            "in": "query",
+            "description": "Kan brukes for filtrering av betydninger basert på gyldighetsperiodene. Er denne satt til \"false\" så vil alle betydningene for alle kodene i kodeverket returneres, og er den \"true\" så vil kun de betydningene som er gyldige på den angitte \"oppslagsdato\" inkluderes. Dersom denne ikke er spesifisert vil den settes til \"true\".",
+            "required": false,
+            "type": "boolean",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "kodeverksnavn",
+            "in": "path",
+            "description": "Hvilket kodeverk man skal hente koders betydninger fra.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "oppslagsdato",
+            "in": "query",
+            "description": "Den funksjonelle datoen man henter betydninger for, på YYYY-MM-DD format. Denne parameteren har ingen effekt med mindre \"ekskluderUgyldige\" er satt til \"true\". Dersom denne ikke er spesifisert vil dagens dato brukes.",
+            "required": false,
+            "type": "string",
+            "format": "date",
+            "allowEmptyValue": false
+          },
+          {
+            "name": "spraak",
+            "in": "query",
+            "description": "En liste over de språkene som beskrivelsene skal returneres på. Tjenesten vil ikke feile dersom de angitte språkene er utilgjengelige, men beskrivelsene vil komme på bokmål isteden. Eksempelverdier er \"nb\" og \"nn\" for henholdsvis bokmål og nynorsk.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "allowEmptyValue": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetKodeverkKoderBetydningerResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "Beskrivelse": {
+      "type": "object",
+      "required": [
+        "tekst",
+        "term"
+      ],
+      "properties": {
+        "tekst": {
+          "type": "string",
+          "description": "En mer utfyllende versjon av beskrivelsen, og derfor passer denne verdien bedre som ledetekster der antall tegn ikke er et like stort problem. Ikke alle beskrivelser har en utfyllende versjon, og i de tilfellene vil kortversjonen gå igjen i dette feltet."
+        },
+        "term": {
+          "type": "string",
+          "description": "En kort versjon av beskrivelsen, og passer derfor godt til fremvisning i GUI-elementer."
+        }
+      },
+      "title": "Beskrivelse",
+      "description": "En beskrivelse er den tekstlige delen av betydningen til en kode, og den kan derfor komme på flere språk. For eksempel, landkoden \"NOR\" kan ha beskrivelsen \"Norge\" på norsk, men \"Norway\" på engelsk. Dersom man ber om å få beskrivelsene på et språk som ikke finnes, så vil bokmålsversjonen brukes isteden."
+    },
+    "Betydning": {
+      "type": "object",
+      "required": [
+        "beskrivelser",
+        "gyldigFra",
+        "gyldigTil"
+      ],
+      "properties": {
+        "beskrivelser": {
+          "type": "object",
+          "description": "En samling beskrivelser for denne betydningen, mappet til en språkkode.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Beskrivelse"
+          }
+        },
+        "gyldigFra": {
+          "type": "string",
+          "format": "date",
+          "description": "Når denne betydningen trådte i kraft, på YYYY-MM-DD format."
+        },
+        "gyldigTil": {
+          "type": "string",
+          "format": "date",
+          "description": "Når denne betydningen slutter å være gyldig, på YYYY-MM-DD format."
+        }
+      },
+      "title": "Betydning",
+      "description": "En betydning er en tidsbegrenset periode hvor en gitt kode har en reell betydning. For eksempel kunne koden \"OSLO\" hatt to betydninger: en fra 1048 til 1624, og en fra 1925. Dette er fordi Oslo ble omdøpt til Christiania i en periode."
+    },
+    "GetHierarkiNoderResponse": {
+      "type": "object",
+      "required": [
+        "hierarkinivaaer",
+        "noder"
+      ],
+      "properties": {
+        "hierarkinivaaer": {
+          "type": "array",
+          "description": "En liste over kodeverk som tilsvarer nivåene i hierarkiet. ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "noder": {
+          "type": "object",
+          "description": "Et map med alle de gyldige nodene i et hierarki. ",
+          "additionalProperties": {
+            "$ref": "#/definitions/Hierarkinode"
+          }
+        }
+      },
+      "title": "GetHierarkiNoderResponse",
+      "description": "Responsen fra GET /api/v1/hierarki/{hierarkinavn}/noder/."
+    },
+    "GetHierarkiResponse": {
+      "type": "object",
+      "required": [
+        "hierarkinavn"
+      ],
+      "properties": {
+        "hierarkinavn": {
+          "type": "array",
+          "description": "En liste med navnene på alle eksisterende hierarki.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "GetHierarkiResponse",
+      "description": "Responsen fra GET /api/v1/hierarki."
+    },
+    "GetKodeverkKoderBetydningerResponse": {
+      "type": "object",
+      "required": [
+        "betydninger"
+      ],
+      "properties": {
+        "betydninger": {
+          "type": "object",
+          "description": "Et map med alle eksisterende koder for kodeverket og alle tilhørende betydninger som passer søkekriteriene.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Betydning"
+            }
+          }
+        }
+      },
+      "title": "GetKodeverkKoderBetydningerResponse",
+      "description": "Responsen fra GET /api/v1/kodeverk/{kodeverksnavn}/koder/betydninger."
+    },
+    "GetKodeverkKoderResponse": {
+      "type": "object",
+      "required": [
+        "koder"
+      ],
+      "properties": {
+        "koder": {
+          "type": "array",
+          "description": "En liste med alle de eksisterende kodene som tilhører kodeverket.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "GetKodeverkKoderResponse",
+      "description": "Responsen fra GET /api/v1/kodeverk/{kodeverksnavn}/koder."
+    },
+    "GetKodeverkResponse": {
+      "type": "object",
+      "required": [
+        "kodeverksnavn"
+      ],
+      "properties": {
+        "kodeverksnavn": {
+          "type": "array",
+          "description": "En liste med navnene på alle eksisterende kodeverk.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "GetKodeverkResponse",
+      "description": "Responsen fra GET /api/v1/kodeverk."
+    },
+    "Hierarkinode": {
+      "type": "object",
+      "required": [
+        "kode"
+      ],
+      "properties": {
+        "kode": {
+          "type": "string",
+          "description": "Kode er navn på kode i et kodeverk og vil være navnet til en node."
+        },
+        "termer": {
+          "type": "object",
+          "description": "Termene er er beskrivelsen for noden, mappet til en språkkode.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Hierarkinode",
+      "description": "Et hierarki inneholder kodeverk og koder som er fremstilt på en hierarkisk måte. For eksempel, hierarkiet Geografi, inneholder flere nivåer av kodeverk som inneholder koder. "
+    }
+  }
+}

--- a/tjenestespesifikasjoner/openapi-templates/libraries/jvm-okhttp/api.mustache
+++ b/tjenestespesifikasjoner/openapi-templates/libraries/jvm-okhttp/api.mustache
@@ -79,17 +79,17 @@ import okhttp3.OkHttpClient
                 {{#queryParams}}
                 {{^required}}
                 if ({{{paramName}}} != null) {
-                    put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
+                    put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}client.parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}client.parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
                 }
                 {{/required}}
                 {{#required}}
                 {{#isNullable}}
                 if ({{{paramName}}} != null) {
-                    put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
+                    put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}client.parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}client.parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
                 }
                 {{/isNullable}}
                 {{^isNullable}}
-                put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
+                put("{{baseName}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}client.parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}client.parseDateToQueryString({{{paramName}}}){{/isDate}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}){{/isContainer}})
                 {{/isNullable}}
                 {{/required}}
                 {{/queryParams}}

--- a/tjenestespesifikasjoner/openapi-templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/tjenestespesifikasjoner/openapi-templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -354,7 +354,7 @@ import org.threeten.bp.OffsetTime
         else -> value.toString()
     }
 
-    protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {
+    inline fun <reified T: Any> parseDateToQueryString(value : T): String {
         {{#toJson}}
         /*
         .replace("\"", "") converts the json object string to an actual string for the query parameter.

--- a/tjenestespesifikasjoner/pom.xml
+++ b/tjenestespesifikasjoner/pom.xml
@@ -36,6 +36,7 @@
         <module>saf-api</module>
         <module>bisys-api</module>
         <module>dkif-api</module>
+        <module>kodeverk-api</module>
     </modules>
 
     <dependencyManagement>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -209,6 +209,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.sbl.dialogarena</groupId>
+            <artifactId>kodeverk-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>no.nav.tjenestespesifikasjoner</groupId>
             <artifactId>nav-fim-personsok-v1-tjenestespesifikasjon</artifactId>
         </dependency>

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
@@ -1,12 +1,23 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk
 
+import org.slf4j.LoggerFactory
+
 object EnhetligKodeverk {
     interface Service {
         fun hentKodeverk(kodeverkNavn: KodeverkConfig): Kodeverk
     }
 
-    class Kodeverk(private val kodeverk: Map<String, String>) {
-        fun hentBeskrivelse(kodeRef: String): String? = kodeverk[kodeRef]
+    class Kodeverk(private val navn: String, private val kodeverk: Map<String, String>) {
+        private val log = LoggerFactory.getLogger(Kodeverk::class.java)
+
+        fun hentBeskrivelse(kodeRef: String): String {
+            val beskrivelse = kodeverk[kodeRef]
+            if (beskrivelse == null) {
+                log.warn("Ukjent kodeRef $kodeRef i kodeverk $navn")
+                return kodeRef
+            }
+            return beskrivelse
+        }
     }
 
     interface Kilde {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
@@ -1,0 +1,16 @@
+package no.nav.modiapersonoversikt.service.enhetligkodeverk
+
+object EnhetligKodeverk {
+    interface Service {
+        fun hentKodeverk(kodeverkNavn: KodeverkConfig): Kodeverk
+    }
+
+    class Kodeverk(private val kodeverk: Map<String, String>) {
+
+        fun hentBeskrivelse(kodeRef: String): String? = kodeverk[kodeRef]
+    }
+
+    interface Kilde {
+        fun hentKodeverk(providers: KodeverkProviders): Kodeverk
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverk.kt
@@ -6,7 +6,6 @@ object EnhetligKodeverk {
     }
 
     class Kodeverk(private val kodeverk: Map<String, String>) {
-
         fun hentBeskrivelse(kodeRef: String): String? = kodeverk[kodeRef]
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImpl.kt
@@ -1,0 +1,46 @@
+package no.nav.modiapersonoversikt.service.enhetligkodeverk
+
+import java.time.*
+import java.util.*
+import kotlin.concurrent.scheduleAtFixedRate
+
+class EnhetligKodeverkServiceImpl(val providers: KodeverkProviders) : EnhetligKodeverk.Service {
+
+    private val cache: MutableMap<KodeverkConfig, EnhetligKodeverk.Kodeverk> = mutableMapOf()
+    private val scheduler = Timer()
+
+    init {
+        val schedulertDatoTidspunkt = hentScheduleDatoInstant()
+
+        if (schedulertDatoTidspunkt.isAfter(Instant.now())) {
+            prepopulerCache()
+        }
+
+        scheduler.scheduleAtFixedRate(
+            time = Date.from(schedulertDatoTidspunkt),
+            period = Duration.ofHours(24).toMillis()
+        ) {
+            prepopulerCache()
+        }
+    }
+
+    private fun hentScheduleDatoInstant(): Instant {
+        // Kl 01:00 den aktuelle dagen
+        return LocalDate.now().atTime(1, 0)
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+    }
+
+    private fun prepopulerCache() {
+        KodeverkConfig.values().forEach { config ->
+            cache[config] = config.hentKodeverk(providers)
+        }
+        println("Prepoluerte cache")
+    }
+
+    override fun hentKodeverk(kodeverkNavn: KodeverkConfig): EnhetligKodeverk.Kodeverk {
+        return requireNotNull(cache[kodeverkNavn]) {
+            "Fant ikke kodeverkNavn $kodeverkNavn"
+        }
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImpl.kt
@@ -24,6 +24,8 @@ class EnhetligKodeverkServiceImpl(val providers: KodeverkProviders) : EnhetligKo
         }
     }
 
+    fun getCache() = this.cache
+
     private fun hentScheduleDatoInstant(): Instant {
         // Kl 01:00 den aktuelle dagen
         return LocalDate.now().atTime(1, 0)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
@@ -2,7 +2,7 @@ package no.nav.modiapersonoversikt.service.enhetligkodeverk
 
 enum class KodeverkConfig(private val kilde: EnhetligKodeverk.Kilde) {
     LAND(FellesKodeverkKilde("Landkoder")),
-    SFTEMAGRUPPER(SfHenvendelseKodeverkKilde());
+    SF_TEMAGRUPPER(SfHenvendelseKodeverkKilde());
 
     fun hentKodeverk(providers: KodeverkProviders) = kilde.hentKodeverk(providers)
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
@@ -1,0 +1,20 @@
+package no.nav.modiapersonoversikt.service.enhetligkodeverk
+
+enum class KodeverkConfig(private val kilde: EnhetligKodeverk.Kilde) {
+    LAND(FellesKodeverkKilde("Landkoder")),
+    SFTEMAGRUPPER(SfHenvendelseKodeverkKilde());
+
+    fun hentKodeverk(providers: KodeverkProviders) = kilde.hentKodeverk(providers)
+}
+
+class FellesKodeverkKilde(val kodeverkNavn: String) : EnhetligKodeverk.Kilde {
+    override fun hentKodeverk(providers: KodeverkProviders): EnhetligKodeverk.Kodeverk {
+        return providers.fraFellesKodeverk(kodeverkNavn)
+    }
+}
+
+class SfHenvendelseKodeverkKilde() : EnhetligKodeverk.Kilde {
+    override fun hentKodeverk(providers: KodeverkProviders): EnhetligKodeverk.Kodeverk {
+        return providers.fraSfHenvendelseKodeverk()
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
@@ -1,0 +1,48 @@
+package no.nav.modiapersonoversikt.service.enhetligkodeverk
+
+import no.nav.common.log.MDCConstants
+import no.nav.modiapersonoversikt.legacy.api.domain.kodeverk.generated.apis.KodeverkApi
+import no.nav.modiapersonoversikt.legacy.api.domain.kodeverk.generated.models.GetKodeverkKoderBetydningerResponseDTO
+import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.models.TemagruppeDTO
+import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
+import org.slf4j.MDC
+import java.util.*
+import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.apis.KodeverkApi as KodeverkApiSf
+
+class KodeverkProviders(
+    private val fellesKodeverk: KodeverkApi,
+    private val sfHenvendelseKodeverk: KodeverkApiSf
+) {
+    fun fraFellesKodeverk(kodeverkNavn: String): EnhetligKodeverk.Kodeverk {
+        val respons = fellesKodeverk.betydningUsingGET(
+            navCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString(),
+            navConsumerId = RestConstants.MODIABRUKERDIALOG_SYSTEM_USER,
+            kodeverksnavn = kodeverkNavn,
+            spraak = listOf("nb")
+        )
+        return hentKodeverk(respons)
+    }
+
+    fun fraSfHenvendelseKodeverk(): EnhetligKodeverk.Kodeverk {
+        val respons = sfHenvendelseKodeverk.henvendelseKodeverkTemagrupperGet(
+            MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+        )
+
+        return hentKodeverk(respons)
+    }
+
+    private fun hentKodeverk(respons: List<TemagruppeDTO>): EnhetligKodeverk.Kodeverk {
+        val kodeverk = respons.map { (navn, kode) ->
+            kode to navn
+        }.toMap()
+
+        return EnhetligKodeverk.Kodeverk(kodeverk)
+    }
+
+    private fun hentKodeverk(respons: GetKodeverkKoderBetydningerResponseDTO): EnhetligKodeverk.Kodeverk {
+        val kodeverk = respons.betydninger.mapValues { entry ->
+            entry.value.first().beskrivelser["nb"]?.term ?: entry.key
+        }
+        return EnhetligKodeverk.Kodeverk(kodeverk)
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
@@ -20,27 +20,25 @@ class KodeverkProviders(
             kodeverksnavn = kodeverkNavn,
             spraak = listOf("nb")
         )
-        return hentKodeverk(respons)
+        return EnhetligKodeverk.Kodeverk(kodeverkNavn, parseTilKodeverk(respons))
     }
 
     fun fraSfHenvendelseKodeverk(): EnhetligKodeverk.Kodeverk {
         val respons = sfHenvendelseKodeverk.henvendelseKodeverkTemagrupperGet(
             MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
         )
-        return hentKodeverk(respons)
+        return EnhetligKodeverk.Kodeverk("SF_TEMAGRUPPE", parseTilKodeverk(respons))
     }
 
-    private fun hentKodeverk(respons: List<TemagruppeDTO>): EnhetligKodeverk.Kodeverk {
-        val kodeverk = respons.map { (navn, kode) ->
+    private fun parseTilKodeverk(respons: List<TemagruppeDTO>): Map<String, String> {
+        return respons.associate { (navn, kode) ->
             kode to navn
-        }.toMap()
-        return EnhetligKodeverk.Kodeverk(kodeverk)
+        }
     }
 
-    private fun hentKodeverk(respons: GetKodeverkKoderBetydningerResponseDTO): EnhetligKodeverk.Kodeverk {
-        val kodeverk = respons.betydninger.mapValues { entry ->
+    private fun parseTilKodeverk(respons: GetKodeverkKoderBetydningerResponseDTO): Map<String, String> {
+        return respons.betydninger.mapValues { entry ->
             entry.value.first().beskrivelser["nb"]?.term ?: entry.key
         }
-        return EnhetligKodeverk.Kodeverk(kodeverk)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
@@ -27,7 +27,6 @@ class KodeverkProviders(
         val respons = sfHenvendelseKodeverk.henvendelseKodeverkTemagrupperGet(
             MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
         )
-
         return hentKodeverk(respons)
     }
 
@@ -35,7 +34,6 @@ class KodeverkProviders(
         val kodeverk = respons.map { (navn, kode) ->
             kode to navn
         }.toMap()
-
         return EnhetligKodeverk.Kodeverk(kodeverk)
     }
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
@@ -1,0 +1,19 @@
+package no.nav.modiapersonoversikt.service.enhetligkodeverk
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+internal class EnhetligKodeverkServiceImplTest {
+
+    val mock: KodeverkProviders = mockk()
+
+    @Test
+    fun `sikre at kodeverk blir hentet ut`() {
+        every { mock.fraFellesKodeverk(any()) } returns EnhetligKodeverk.Kodeverk(emptyMap())
+
+        val service = EnhetligKodeverkServiceImpl(mock)
+
+        val kodeverk = service.hentKodeverk(KodeverkConfig.LAND)
+    }
+}

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
@@ -1,19 +1,121 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk
 
-import io.mockk.every
-import io.mockk.mockk
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.*
 
 internal class EnhetligKodeverkServiceImplTest {
-
-    val mock: KodeverkProviders = mockk()
-
     @Test
     fun `sikre at kodeverk blir hentet ut`() {
-        every { mock.fraFellesKodeverk(any()) } returns EnhetligKodeverk.Kodeverk(emptyMap())
+        val providers = withProvidersMock()
+        val service = EnhetligKodeverkServiceImpl(providers)
 
-        val service = EnhetligKodeverkServiceImpl(mock)
+        val landkoder = service.hentKodeverk(KodeverkConfig.LAND)
+        assertThat(landkoder).isNotNull
 
-        val kodeverk = service.hentKodeverk(KodeverkConfig.LAND)
+        val temagrupper = service.hentKodeverk(KodeverkConfig.SF_TEMAGRUPPER)
+        assertThat(temagrupper).isNotNull
+
+        val landkode = landkoder.hentBeskrivelse("NO")
+        assertThat(landkode).isEqualTo("Norge")
+
+        val temagruppe = temagrupper.hentBeskrivelse("ARBD")
+        assertThat(temagruppe).isEqualTo("Arbeid")
+    }
+
+    @Test
+    internal fun `skal fange opp endringer i kodeverk`() {
+        val providers = withProvidersMock()
+        val service = EnhetligKodeverkServiceImpl(providers)
+
+        assertThat(service.hentKodeverk(KodeverkConfig.LAND)).isNotNull
+        every { providers.fraFellesKodeverk(any()) } returns EnhetligKodeverk.Kodeverk(
+            "Land",
+            mapOf(
+                "NO" to "Noreg"
+            )
+        )
+        val landkode = service.hentKodeverk(KodeverkConfig.LAND).hentBeskrivelse("NO")
+        assertThat(landkode).isEqualTo("Norge")
+
+        service.prepopulerCache()
+
+        val oppdatertLandkode = service.hentKodeverk(KodeverkConfig.LAND).hentBeskrivelse("NO")
+        assertThat(oppdatertLandkode).isEqualTo("Noreg")
+    }
+
+    @Test
+    internal fun `skal ikke forkaste kodeverk om refreshing feiler`() {
+        val providers = withProvidersMock()
+        val service = EnhetligKodeverkServiceImpl(providers)
+
+        assertThat(service.hentKodeverk(KodeverkConfig.LAND)).isNotNull
+        every { providers.fraFellesKodeverk(any()) } throws IllegalStateException("Noe gikk feil")
+
+        service.prepopulerCache()
+
+        assertThat(service.hentKodeverk(KodeverkConfig.LAND)).isNotNull
+    }
+
+    @Test
+    internal fun `skal kunne starte opp selvom alle avhengiheter er nede`() {
+        val providers: KodeverkProviders = mockk()
+        every { providers.fraFellesKodeverk(any()) } throws IllegalStateException("Noe gikk feil")
+        every { providers.fraSfHenvendelseKodeverk() } throws IllegalStateException("Noe gikk feil")
+
+        val service = EnhetligKodeverkServiceImpl(providers)
+
+        assertThat(service.hentKodeverk(KodeverkConfig.LAND)).isNotNull
+        assertThat(service.hentKodeverk(KodeverkConfig.LAND).hentBeskrivelse("NO")).isEqualTo("NO")
+        assertThat(service.hentKodeverk(KodeverkConfig.SF_TEMAGRUPPER)).isNotNull
+    }
+
+    @Test
+    internal fun `regner ut schedule dato riktig`() {
+        val (timer, dateSlot, periodeSlot) = withTimerMock()
+        val providers = withProvidersMock()
+
+        EnhetligKodeverkServiceImpl(providers, timer)
+
+        assertThat(dateSlot.isCaptured).isTrue()
+        assertThat(dateSlot.captured).hasHourOfDay(1)
+
+        val forventetDato = if (dateSlot.captured.toInstant().isBefore(Instant.now())) {
+            LocalDate.now().dayOfMonth
+        } else {
+            LocalDate.now().plusDays(1).dayOfMonth
+        }
+        assertThat(dateSlot.captured).hasDayOfMonth(forventetDato)
+
+        assertThat(periodeSlot.isCaptured).isTrue()
+        assertThat(periodeSlot.captured).isEqualTo(24 * 3600 * 1000)
+    }
+
+    private fun withTimerMock(): Triple<Timer, CapturingSlot<Date>, CapturingSlot<Long>> {
+        val timer: Timer = mockk()
+        val date = slot<Date>()
+        val periode = slot<Long>()
+        every { timer.scheduleAtFixedRate(any(), capture(date), capture(periode)) } returns Unit
+        return Triple(timer, date, periode)
+    }
+
+    private fun withProvidersMock(): KodeverkProviders {
+        val providers: KodeverkProviders = mockk()
+        every { providers.fraFellesKodeverk(any()) } returns EnhetligKodeverk.Kodeverk(
+            "Land",
+            mapOf(
+                "NO" to "Norge"
+            )
+        )
+        every { providers.fraSfHenvendelseKodeverk() } returns EnhetligKodeverk.Kodeverk(
+            "Temagrupper",
+            mapOf(
+                "ARBD" to "Arbeid"
+            )
+        )
+        return providers
     }
 }


### PR DESCRIPTION
Denne PRen er todelt:
Først er det lagt opp til å integrere mot "Felles kodeverk" vha OpenAPI-specen deres, som skal erstatte dagens SOAP-løsning. Dette gjøres som et steg i prosessen når vi migrerer fra TPS til PDL.
Andre del implementerer en ny KoderverkService som kan ta inn nye kodeverk og hente ut disse fra forskjellige kilder

Endringen innebærer:
- Ny `pom.xml` for kodeverk
- Endring i `api.mustache` for å håndtere feil ved import av `parseDateToQueryString`
- Autogenerert openapi spec
- `EnhetligKodeverk` som holder på Service, Kilde og Kodeverk-klassen vår
- `EnhetligKodeverkServiceImp` som oppretter en cache som holder på kodeverk, og som oppdateres kl 01:00 hvert døgn
- Enum `KodeverkConfig` der man kan legge til flere typer kodeverk og funksjoner for å hente ut disse. Foreløpig er bare Felles-kodeverk og SF-Henvendelse-kodeverk lagt inn her for å vise hvordan det kan gjøres.
- `KodeverkProviders` som gjør de faktiske kallene ut mot APIene (generert kode gitt deres spec)
- Test for uthenting av kodeverk, feilhåndtering ved dette, og test av schedulert refresh av cache (🇬🇧🇳🇴-setning der, ja)