### PR TITLE
[KAIZEN-0] sikre bedre auditlogger

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontrakter/consumer/fim/oppfolgingskontrakt/support/DefaultOppfolgingskontraktService.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontrakter/consumer/fim/oppfolgingskontrakt/support/DefaultOppfolgingskontraktService.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 
 /**
  * Vår standardimplementasjonen av den eksterne tjenesten for oppfolgingskontraker.
@@ -26,7 +27,7 @@ public class DefaultOppfolgingskontraktService implements OppfolgingskontraktSer
     private static Audit.AuditDescriptor<WSHentOppfoelgingskontraktListeRequest> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Kontrakter,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getPersonidentifikator()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person).map(WSHentOppfoelgingskontraktListeRequest::getPersonidentifikator).orElse("--")))
     );
 
     private OppfoelgingPortType oppfolgingskontraktService = null;

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/personsok/consumer/fim/personsok/support/DefaultPersonsokService.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/personsok/consumer/fim/personsok/support/DefaultPersonsokService.java
@@ -11,11 +11,13 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources;
 import no.nav.tjeneste.virksomhet.personsoek.v1.FinnPersonFault;
 import no.nav.tjeneste.virksomhet.personsoek.v1.FinnPersonFault1;
 import no.nav.tjeneste.virksomhet.personsoek.v1.PersonsokPortType;
+import no.nav.tjeneste.virksomhet.personsoek.v1.informasjon.NorskIdent;
 import no.nav.tjeneste.virksomhet.personsoek.v1.informasjon.Person;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 
 /**
  * Vår standardimplementasjonen av den eksterne tjenesten.
@@ -24,7 +26,11 @@ public class DefaultPersonsokService implements PersonsokServiceBi {
     private static Audit.AuditDescriptor<Person> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Personalia,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getIdent().getIdent()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person)
+                    .map(Person::getIdent)
+                    .map(NorskIdent::getIdent)
+                    .orElse("--")
+            ))
     );
 
     private PersonsokPortType personsokService;

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/foreldrepenger/DefaultForeldrepengerService.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/foreldrepenger/DefaultForeldrepengerService.java
@@ -16,7 +16,10 @@ import no.nav.tjeneste.virksomhet.foreldrepenger.v2.meldinger.FimHentForeldrepen
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
+
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 
 /**
  * Vår standardimplementasjonen av den eksterne tjenesten for foreldrepenger.
@@ -25,7 +28,7 @@ public class DefaultForeldrepengerService implements ForeldrepengerServiceBi {
     private static Audit.AuditDescriptor<FimPerson> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Foreldrepenger,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getIdent()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person).map(FimPerson::getIdent).orElse("--")))
     );
     private static final Logger logger = LoggerFactory.getLogger(DefaultForeldrepengerService.class);
     private ForeldrepengerV2 foreldrepengerService;

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/pleiepenger/PleiepengerServiceImpl.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/pleiepenger/PleiepengerServiceImpl.java
@@ -29,7 +29,7 @@ public class PleiepengerServiceImpl implements PleiepengerService {
     private static Audit.AuditDescriptor<WSPerson> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Pleiepenger,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getIdent()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person).map(WSPerson::getIdent).orElse("--")))
     );
     private static final Logger logger = LoggerFactory.getLogger(PleiepengerServiceImpl.class);
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/sykepenger/DefaultSykepengerService.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/sykmeldingsperioder/consumer/sykepenger/DefaultSykepengerService.java
@@ -8,6 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources;
 import no.nav.modiapersonoversikt.consumer.sykmeldingsperioder.consumer.sykepenger.mapping.SykepengerMapper;
 import no.nav.modiapersonoversikt.consumer.sykmeldingsperioder.consumer.sykepenger.mapping.to.SykepengerRequest;
 import no.nav.modiapersonoversikt.consumer.sykmeldingsperioder.consumer.sykepenger.mapping.to.SykepengerResponse;
+import no.nav.tjeneste.virksomhet.foreldrepenger.v2.informasjon.FimPerson;
 import no.nav.tjeneste.virksomhet.sykepenger.v2.HentSykepengerListeSikkerhetsbegrensning;
 import no.nav.tjeneste.virksomhet.sykepenger.v2.SykepengerV2;
 import no.nav.tjeneste.virksomhet.sykepenger.v2.informasjon.FimsykBruker;
@@ -18,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 
 /**
  * Vår standardimplementasjonen av den eksterne tjenesten for sykmeldingsperioder.
@@ -26,7 +28,7 @@ public class DefaultSykepengerService implements SykepengerServiceBi {
     private static Audit.AuditDescriptor<FimsykBruker> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Sykepenger,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getIdent()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person).map(FimsykBruker::getIdent).orElse("--")))
     );
     private static final Logger logger = LoggerFactory.getLogger(DefaultSykepengerService.class);
     private SykepengerV2 sykepengerService;

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/kjerneinfo/consumer/fim/person/support/HentPersonService.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/kjerneinfo/consumer/fim/person/support/HentPersonService.java
@@ -1,6 +1,7 @@
 package no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.fim.person.support;
 
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 
 import java.util.Iterator;
 import java.util.Optional;
@@ -9,6 +10,7 @@ import kotlin.Pair;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.fim.person.to.HentKjerneinformasjonRequest;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.fim.person.to.HentKjerneinformasjonResponse;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.mdc.MDCUtils;
+import no.nav.modiapersonoversikt.legacy.kjerneinfo.domain.person.Fodselsnummer;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.domain.person.GeografiskTilknytning;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.domain.person.GeografiskTilknytningstyper;
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.domain.person.Person;
@@ -47,7 +49,11 @@ public class HentPersonService {
     private static Audit.AuditDescriptor<Person> auditLogger = Audit.describe(
             Audit.Action.READ,
             AuditResources.Person.Personalia,
-            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, person.getFodselsnummer().getNummer()))
+            (person) -> singletonList(new Pair<>(AuditIdentifier.FNR, ofNullable(person)
+                    .map(Person::getFodselsnummer)
+                    .map(Fodselsnummer::getNummer)
+                    .orElse("--")
+            ))
     );
     private static final String FNR_REGEX = "\\d{11}";
 
@@ -141,13 +147,13 @@ public class HentPersonService {
     }
 
     private String getDiskresjonskode(HentGeografiskTilknytningResponse response) {
-        return Optional.ofNullable(response.getDiskresjonskode())
+        return ofNullable(response.getDiskresjonskode())
                 .map(Kodeverdi::getValue)
                 .orElse(null);
     }
 
     private String getGeografiskTilknytning(HentGeografiskTilknytningResponse response) {
-        return Optional.ofNullable(response.getGeografiskTilknytning())
+        return ofNullable(response.getGeografiskTilknytning())
                 .map(no.nav.tjeneste.virksomhet.person.v3.informasjon.GeografiskTilknytning::getGeografiskTilknytning)
                 .orElse(null);
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
@@ -31,7 +31,7 @@ class PersonsokController @Autowired constructor(
     val tilgangskontroll: Tilgangskontroll
 ) {
     private val auditDescriptor = Audit.describe<List<PersonSokResponsDTO>>(Audit.Action.READ, AuditResources.Personsok.Resultat) { resultat ->
-        val fnr = resultat.map { it.ident }.joinToString(", ")
+        val fnr = resultat?.map { it.ident }?.joinToString(", ") ?: "--"
         listOf(
             AuditIdentifier.FNR to fnr
         )


### PR DESCRIPTION
ved "denied"/"failed" situasjoner ville ikke standard identifikatorer bli logget. Dette er nå rettet opp slik at identifikatorerene alltid logges.
