### PR TITLE
[KAIZEN-0] legge til jackson-mapping for java.time.*

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/config/JacksonConfig.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/JacksonConfig.java
@@ -1,25 +1,19 @@
 package no.nav.modiapersonoversikt.config;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
-
-import java.io.IOException;
-import java.time.LocalDate;
 
 public class JacksonConfig {
     public static final ObjectMapper mapper = new ObjectMapper();
 
     static {
         mapper.registerModule(new JodaModule());
-        mapper.registerModule(new KotlinModule().addDeserializer(LocalDate.class, new JsonDeserializer<LocalDate>() {
-            @Override
-            public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-                return LocalDate.parse(jsonParser.getText());
-            }
-        }));
+        mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new KotlinModule());
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }


### PR DESCRIPTION
tidligere gjort manuelt ved å konvertere til ulike string-format, eller i visse tilfeller magiske json-objekt.
ved å legge til `JavaTimeModule` så vil jackson få en forståelse av hvordan java.time.* skal serialiseres,
og disse kan da returneres fra kontrollere uten videre seremoni.

**Før:**
```
java.time.LocalDate.now() <-> {"year":2021,"month":"SEPTEMBER","monthValue":9,"dayOfMonth":16,"chronology":{"id":"ISO","calendarType":"iso8601"},"dayOfWeek":"THURSDAY","leapYear":false,"dayOfYear":259,"era":"CE"}
```

**Etter:**
```
java.time.LocalDate.now() <-> 2021-09-16
```
