### PR TITLE
[PROD][KAIZEN-0] legge til jackson-mapping for java.time.*

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
@@ -157,6 +157,9 @@ class PdlOppslagServiceImpl constructor(
                     HentAktorid.Variables(ident)
                 } //
                 is SokPersonUtenlandskID.Variables -> variables
+                is HentPersondata.Variables -> variables
+                is HentPersondataLite.Variables -> variables
+                is HentGeografiskTilknyttning.Variables -> variables
                 else -> throw IllegalStateException("Unrecognized graphql variables type: ${variables.javaClass.simpleName}")
             }
         }


### PR DESCRIPTION
tidligere gjort manuelt ved å konvertere til ulike string-format, eller i visse tilfeller magiske json-objekt.
ved å legge til `JavaTimeModule` så vil jackson få en forståelse av hvordan java.time.* skal serialiseres,
og disse kan da returneres fra kontrollere uten videre seremoni.

**Før:**
```
java.time.LocalDate.now() <-> {"year":2021,"month":"SEPTEMBER","monthValue":9,"dayOfMonth":16,"chronology":{"id":"ISO","calendarType":"iso8601"},"dayOfWeek":"THURSDAY","leapYear":false,"dayOfYear":259,"era":"CE"}
```

**Etter:**
```
java.time.LocalDate.now() <-> 2021-09-16
```
