### PR TITLE
[KAIZEN-0] refaktorere uthenting av callId til en felles funksjon.

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
@@ -10,13 +10,10 @@ import io.ktor.client.engine.cio.CIOEngineConfig
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.util.KtorExperimentalAPI
-import no.nav.common.log.MDCConstants
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
 import no.nav.modiapersonoversikt.legacy.api.utils.TjenestekallLogger
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.net.URL
-import java.util.*
 
 typealias HeadersBuilder = HttpRequestBuilder.() -> Unit
 typealias VariablesTransform = (Any?) -> Any?
@@ -88,6 +85,4 @@ class LoggingGraphqlClient(
             GraphQLResponse(errors = listOf(error))
         }
     }
-
-    private fun getCallId(): String = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -114,8 +114,10 @@ open class HeadersInterceptor(val headersProvider: () -> Map<String, String>) : 
     }
 }
 class XCorrelationIdInterceptor() : HeadersInterceptor({
-    mapOf("X-Correlation-ID" to (MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()))
+    mapOf("X-Correlation-ID" to getCallId())
 })
 class AuthorizationInterceptor(val tokenProvider: () -> String) : HeadersInterceptor({
     mapOf("Authorization" to "Bearer ${tokenProvider()}")
 })
+
+fun getCallId(): String = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/kjerneinfo/consumer/organisasjon/OrganisasjonV1Client.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/kjerneinfo/consumer/organisasjon/OrganisasjonV1Client.kt
@@ -3,16 +3,15 @@ package no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.organisasjon
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.common.log.MDCConstants
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants.MODIABRUKERDIALOG_SYSTEM_USER
 import no.nav.modiapersonoversikt.legacy.api.utils.TjenestekallLogger
 import okhttp3.Request
 import okhttp3.Response
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.util.*
 
 interface OrganisasjonV1Client {
@@ -33,14 +32,14 @@ class OrganisasjonV1ClientImpl(val baseUrl: String = EnvironmentUtils.getRequire
                 "Oppgaver-request: $uuid",
                 mapOf(
                     "orgnummer" to orgnummer,
-                    "callId" to MDC.get(MDCConstants.MDC_CALL_ID)
+                    "callId" to getCallId()
                 )
             )
             val response: Response = client
                 .newCall(
                     Request.Builder()
                         .url("$url$orgnummer/noekkelinfo")
-                        .header(RestConstants.NAV_CALL_ID_HEADER, MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString())
+                        .header(RestConstants.NAV_CALL_ID_HEADER, getCallId())
                         .header(RestConstants.NAV_CONSUMER_ID_HEADER, MODIABRUKERDIALOG_SYSTEM_USER)
                         .header("accept", "application/json")
                         .build()

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/SafGraphqlServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/SafGraphqlServiceImpl.kt
@@ -5,7 +5,6 @@ import io.ktor.util.*
 import kotlinx.coroutines.runBlocking
 import no.nav.common.auth.subject.SsoToken
 import no.nav.common.auth.subject.SubjectHandler
-import no.nav.common.log.MDCConstants
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.infrastructure.http.*
@@ -18,10 +17,8 @@ import no.nav.modiapersonoversikt.legacy.sak.providerdomain.resultatwrappere.Tje
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.net.URL
 import java.time.LocalDateTime
-import java.util.*
 
 private val SAF_GRAPHQL_BASEURL: String = EnvironmentUtils.getRequiredProperty("SAF_GRAPHQL_URL")
 private val SAF_HENTDOKUMENT_BASEURL: String = EnvironmentUtils.getRequiredProperty("SAF_HENTDOKUMENT_URL")
@@ -88,7 +85,7 @@ class SafGraphqlServiceImpl : SafService {
     private fun httpHeaders(): Map<String, String> {
         val token = SubjectHandler.getSsoToken(SsoToken.Type.OIDC)
             .orElseThrow { IllegalStateException("Fant ikke OIDC-token") }
-        val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+        val callId = getCallId()
         return mapOf(
             "Authorization" to "Bearer $token",
             "Content-Type" to "application/json",

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/aaputsending/AAPUtsendingService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/aaputsending/AAPUtsendingService.kt
@@ -4,6 +4,7 @@ import no.nav.common.auth.subject.Subject
 import no.nav.common.auth.subject.SubjectHandler
 import no.nav.common.leaderelection.LeaderElectionClient
 import no.nav.common.log.MDCConstants
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.legacy.api.domain.henvendelse.Fritekst
 import no.nav.modiapersonoversikt.legacy.api.domain.henvendelse.Melding
 import no.nav.modiapersonoversikt.legacy.api.domain.henvendelse.Meldingstype
@@ -39,7 +40,7 @@ class Prosessor<S>(
     private val block: (s: S) -> Unit
 ) {
     private val executor = Executors.newSingleThreadExecutor()
-    private val callId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+    private val callId = getCallId()
     private var job: Future<*>? = null
     private val errors: MutableList<Pair<S, Throwable>> = mutableListOf()
     private val success: MutableList<S> = mutableListOf()

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/arbeidsfordeling/ArbeidsfordelingClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/arbeidsfordeling/ArbeidsfordelingClient.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.common.auth.subject.SsoToken
 import no.nav.common.auth.subject.SubjectHandler
 import no.nav.common.json.JsonMapper
-import no.nav.common.log.MDCConstants
 import no.nav.common.rest.client.RestClient
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.AnsattEnhet
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.EnhetsGeografiskeTilknytning
 import no.nav.modiapersonoversikt.legacy.api.service.arbeidsfordeling.ArbeidsfordelingEnhet
@@ -20,7 +20,6 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.*
 
@@ -75,7 +74,7 @@ open class ArbeidsfordelingClient {
             .newCall(
                 Request.Builder()
                     .url("$NORG2_URL/api/v1/arbeidsfordeling/enheter/bestmatch")
-                    .header(NAV_CALL_ID_HEADER, MDC.get(MDCConstants.MDC_CALL_ID))
+                    .header(NAV_CALL_ID_HEADER, getCallId())
                     .header(AUTHORIZATION, AUTH_METHOD_BEARER + AUTH_SEPERATOR + veilederOidcToken)
                     .header(NAV_CONSUMER_TOKEN_HEADER, AUTH_METHOD_BEARER + AUTH_SEPERATOR + consumerOidcToken)
                     .post(

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/dkif/DkifServiceRestImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/dkif/DkifServiceRestImpl.kt
@@ -5,19 +5,17 @@ import no.nav.common.auth.subject.SubjectHandler
 import no.nav.common.health.HealthCheck
 import no.nav.common.health.HealthCheckResult
 import no.nav.common.health.selftest.SelfTestCheck
-import no.nav.common.log.MDCConstants
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.infrastructure.types.Pingable
 import no.nav.modiapersonoversikt.legacy.api.domain.dkif.generated.apis.DigitalKontaktinformasjonApi
 import no.nav.modiapersonoversikt.legacy.api.domain.dkif.generated.apis.PingApi
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
 import no.nav.modiapersonoversikt.legacy.api.utils.TjenestekallLogger
 import okhttp3.OkHttpClient
-import org.slf4j.MDC
-import java.util.*
 
 class DkifServiceRestImpl(
     baseUrl: String = EnvironmentUtils.getRequiredProperty("DKIF_REST_URL")
@@ -42,7 +40,7 @@ class DkifServiceRestImpl(
             authorization = SubjectHandler.getSsoToken(SsoToken.Type.OIDC)
                 .map { "Bearer $it" }
                 .orElseThrow { IllegalStateException("Fant ikke OIDC-token") },
-            navCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString(),
+            navCallId = getCallId(),
             navConsumerId = RestConstants.MODIABRUKERDIALOG_SYSTEM_USER,
             navPersonidenter = listOf(fnr),
             inkluderSikkerDigitalPost = true

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkProviders.kt
@@ -1,18 +1,16 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk
 
-import no.nav.common.log.MDCConstants
 import no.nav.common.rest.client.RestClient
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.legacy.api.domain.kodeverk.generated.apis.KodeverkApi
 import no.nav.modiapersonoversikt.legacy.api.domain.kodeverk.generated.models.GetKodeverkKoderBetydningerResponseDTO
 import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.models.TemagruppeDTO
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
-import org.slf4j.MDC
-import java.util.*
 import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.apis.KodeverkApi as KodeverkApiSf
 
 class KodeverkProviders(
@@ -21,7 +19,7 @@ class KodeverkProviders(
 ) {
     fun fraFellesKodeverk(kodeverkNavn: String): EnhetligKodeverk.Kodeverk {
         val respons = fellesKodeverk.betydningUsingGET(
-            navCallId = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString(),
+            navCallId = getCallId(),
             navConsumerId = RestConstants.MODIABRUKERDIALOG_SYSTEM_USER,
             kodeverksnavn = kodeverkNavn,
             spraak = listOf("nb")
@@ -31,7 +29,7 @@ class KodeverkProviders(
 
     fun fraSfHenvendelseKodeverk(): EnhetligKodeverk.Kodeverk {
         val respons = sfHenvendelseKodeverk.henvendelseKodeverkTemagrupperGet(
-            MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+            getCallId()
         )
         return EnhetligKodeverk.Kodeverk("SF_TEMAGRUPPE", parseTilKodeverk(respons))
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -2,8 +2,8 @@ package no.nav.modiapersonoversikt.service.oppgavebehandling
 
 import no.nav.common.auth.subject.SsoToken
 import no.nav.common.auth.subject.SubjectHandler
-import no.nav.common.log.MDCConstants
 import no.nav.common.sts.SystemUserTokenProvider
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.infrastructure.rsbac.DecisionEnums
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
@@ -33,7 +33,6 @@ import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.leggTilBeskriv
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.paginering
 import no.nav.modiapersonoversikt.utils.SafeListAggregate
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import java.time.Clock
@@ -503,7 +502,7 @@ class RestOppgaveBehandlingServiceImpl(
         }
     }
 
-    private fun correlationId() = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()
+    private fun correlationId() = getCallId()
     private fun stripTemakode(prioritet: String) = prioritet.substringBefore("_")
     private fun String?.coerceBlankToNull() = if (this == null || this.isBlank()) null else this
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/saker/SakerServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/saker/SakerServiceImpl.kt
@@ -2,6 +2,7 @@ package no.nav.modiapersonoversikt.service.saker
 
 import no.nav.common.auth.subject.SubjectHandler
 import no.nav.common.log.MDCConstants
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.legacy.api.domain.bidragsak.generated.apis.BidragSakControllerApi
 import no.nav.modiapersonoversikt.legacy.api.domain.saker.Sak
 import no.nav.modiapersonoversikt.legacy.api.exceptions.JournalforingFeilet
@@ -201,7 +202,7 @@ class SakerServiceImpl : SakerService {
 
 private infix fun <T> ((T) -> Boolean).or(other: (T) -> Boolean): (T) -> Boolean = { this(it) || other(it) }
 internal fun <T> copyAuthAndMDC(fn: () -> T): () -> T {
-    val callId = MDC.get(MDCConstants.MDC_CALL_ID)
+    val callId = getCallId()
     val subject = SubjectHandler.getSubject()
     val requestAttributes: RequestAttributes? = RequestContextHolder.getRequestAttributes()
     return {
@@ -214,7 +215,7 @@ internal fun <T> copyAuthAndMDC(fn: () -> T): () -> T {
 }
 
 fun <T> withCallId(callId: String, fn: () -> T): T {
-    val originalCallId = MDC.get(MDCConstants.MDC_CALL_ID)
+    val originalCallId = getCallId()
     MDC.put(MDCConstants.MDC_CALL_ID, callId)
     val result = fn()
     MDC.put(MDCConstants.MDC_CALL_ID, originalCallId)


### PR DESCRIPTION
Hver gang vi skal hente callId så kjører vi samme kodesnutt. For å unngå duplikatkode så setter vi det ut i en felles global funksjon getCallId()