### PR TITLE
[OPP-1383] utvide adresse til å inkludere data om når den ble registrert

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -190,6 +190,12 @@ query($ident: ID!){
             }
         }
         bostedsadresse {
+            metadata {
+                endringer {
+                    registrert
+                    registrertAv
+                }
+            }
             folkeregistermetadata {
                 ajourholdstidspunkt
                 kilde

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -83,16 +83,22 @@ object Persondata {
     data class Adresse constructor(
         val linje1: String,
         val linje2: String? = null,
-        val linje3: String? = null
+        val linje3: String? = null,
+        val registrert: LocalDateTime? = null,
+        val registrertAv: String? = null
     ) {
         constructor(
             linje1: List<String?>,
             linje2: List<String?>? = null,
-            linje3: List<String?>? = null
+            linje3: List<String?>? = null,
+            registrert: LocalDateTime? = null,
+            registrertAv: String? = null
         ) : this(
             linje1.filterNotNull().joinToString(" "),
             linje2?.filterNotNull()?.joinToString(" "),
-            linje3?.filterNotNull()?.joinToString(" ")
+            linje3?.filterNotNull()?.joinToString(" "),
+            registrert,
+            registrertAv
         )
     }
 


### PR DESCRIPTION
Vi utvider `Adresse` slik at vi også har info om når det ble endret og av hvem, som vi har i Modia i dag.

Pdl-docs: https://pdldocs-navno.msappproxy.net/ekstern/index.html#opplysningstyper-felles-metadata