### PR TITLE
[OPP-1378] legge til støtte for oppfølgingsreferat

### DIFF
--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi.json
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi.json
@@ -456,6 +456,29 @@
             "description": "Referanse til fagsak i overenstemmelse med påkrevd input til [Dokarkiv API](https://dokarkiv-q2.nais.preprod.local/swagger-ui.html#/arkiver-og-journalfoer-rest-controller/opprettJournalpostUsingPOST). Ved blank/null som saksId vil journalposten opprettes som generell sak på tema.",
             "example": "005602185"
           },
+          "fagsaksystem": {
+            "type": "string",
+            "enum": [
+              "FS38",
+              "FS36",
+              "UFM",
+              "AO01",
+              "AO11",
+              "IT01",
+              "OEBS",
+              "PP01",
+              "K9",
+              "BISYS",
+              "BA",
+              "EF",
+              "KONT",
+              "SUPSTONAD",
+              "OMSORGSPENGER",
+              "HJELPEMIDLER"
+            ],
+            "description": "Fagsystemet som saken behandles i, required hvis saksId er definert",
+            "example": "AO01"
+          },
           "temakode": {
             "type": "string",
             "description": "Temakode for journalpost som skal opprettes",
@@ -493,18 +516,41 @@
             "description": "Tema for opprettet journalpost",
             "example": "DAG"
           },
+          "saksId": {
+            "type": "string",
+            "description": "Referanse til fagsak",
+            "example": "005602185"
+          },
+          "fagsaksystem": {
+            "type": "string",
+            "enum": [
+              "FS38",
+              "FS36",
+              "UFM",
+              "AO01",
+              "AO11",
+              "IT01",
+              "OEBS",
+              "PP01",
+              "K9",
+              "BISYS",
+              "BA",
+              "EF",
+              "KONT",
+              "SUPSTONAD",
+              "OMSORGSPENGER",
+              "HJELPEMIDLER"
+            ],
+            "description": "Fagsystemet som saken behandles i.",
+            "example": "AO01"
+          },
           "journalpostId": {
             "type": "string",
             "description": "Unik referanse til journalpost i JOARK",
             "example": "509934220"
           }
         },
-        "required": [
-          "journalforerNavIdent",
-          "journalforendeEnhet",
-          "journalfortDato",
-          "journalfortTema"
-        ]
+        "required": ["journalforerNavIdent", "journalforendeEnhet", "journalfortDato", "journalfortTema"]
       },
       "MeldingFra": {
         "type": "object",

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfDialogController.kt
@@ -19,6 +19,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 
+/**
+ * En forenklet api-modell som kan brukes av frontend-koden etterhver.
+ * Per i dag vil frontend bruke de gamle api-ene implementert av `SfLegacyXXXXXX` filene
+ */
 @RestController
 @RequestMapping("/rest/sf-dialog")
 class SfDialogController @Autowired constructor(
@@ -134,7 +138,11 @@ class SfDialogController @Autowired constructor(
             }
     }
 
-    data class JournalforHenvendelseRequest(val saksId: String?, val saksTema: String)
+    data class JournalforHenvendelseRequest(
+        val saksId: String,
+        val fagsaksystem: String,
+        val saksTema: String
+    )
 
     @PostMapping("/{fnr}/{kjedeId}/journalfor")
     fun journalforHenvendelse(
@@ -152,10 +160,12 @@ class SfDialogController @Autowired constructor(
             .check(Policies.tilgangTilBruker.with(fnr))
             .check(Policies.sfDialogTilhorerBruker.with(KjedeIdTilgangData(fnr, kjedeId)))
             .get(Audit.describe(Audit.Action.UPDATE, AuditResources.Person.Henvendelse.Journalfor, *auditIdentifier)) {
+                // NB Denne controlleren er ikke ibruk per idag. Men dette må tittes nærmere på før en evt overgang.
                 sfHenvendelseService.journalforHenvendelse(
                     enhet = enhet,
                     kjedeId = kjedeId,
                     saksId = request.saksId,
+                    fagsakSystem = request.fagsaksystem,
                     saksTema = request.saksTema
                 )
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
@@ -74,8 +74,9 @@ class SfLegacyDialogController(
         sfHenvendelseService.journalforHenvendelse(
             enhet = enhet,
             kjedeId = henvendelse.kjedeId,
-            saksId = sporsmalsRequest.sak.saksId,
-            saksTema = sporsmalsRequest.sak.temaKode
+            saksId = sporsmalsRequest.sak.fagsystemSaksId,
+            saksTema = sporsmalsRequest.sak.temaKode,
+            fagsakSystem = sporsmalsRequest.sak.fagsystemKode
         )
         return ResponseEntity(HttpStatus.OK)
     }
@@ -91,8 +92,9 @@ class SfLegacyDialogController(
         sfHenvendelseService.journalforHenvendelse(
             enhet = enhet,
             kjedeId = henvendelse.kjedeId,
-            saksId = infomeldingRequest.sak.saksId,
-            saksTema = infomeldingRequest.sak.temaKode
+            saksId = infomeldingRequest.sak.fagsystemSaksId,
+            saksTema = infomeldingRequest.sak.temaKode,
+            fagsakSystem = infomeldingRequest.sak.fagsystemKode
         )
         sfHenvendelseService.lukkTraad(henvendelse.kjedeId)
 
@@ -147,13 +149,14 @@ class SfLegacyDialogController(
                 fritekst = fortsettDialogRequest.fritekst
             )
             val journalposter = (henvendelse.journalposter ?: emptyList())
-                .distinctBy { it.journalpostId /* Må byttes ut med saksId */ }
+                .distinctBy { it.saksId }
             journalposter.forEach {
                 sfHenvendelseService.journalforHenvendelse(
                     enhet = enhet,
                     kjedeId = henvendelse.kjedeId,
-                    saksId = "-", // TODO ikke eksponert enda it.saksId
-                    saksTema = it.journalfortTema
+                    saksId = it.saksId,
+                    saksTema = it.journalfortTema,
+                    fagsakSystem = it.fagsaksystem?.name
                 )
             }
         } else {
@@ -168,8 +171,9 @@ class SfLegacyDialogController(
                 sfHenvendelseService.journalforHenvendelse(
                     enhet = enhet,
                     kjedeId = henvendelse.kjedeId,
-                    saksId = fortsettDialogRequest.sak.saksId,
-                    saksTema = fortsettDialogRequest.sak.temaKode
+                    saksId = fortsettDialogRequest.sak.fagsystemSaksId,
+                    saksTema = fortsettDialogRequest.sak.temaKode,
+                    fagsakSystem = fortsettDialogRequest.sak.fagsystemKode
                 )
             }
         }
@@ -223,7 +227,7 @@ class SfLegacyDialogController(
     ): TraadDTO {
         val journalpost: JournalpostDTO? = henvendelse.journalposter?.firstOrNull()
 
-        val journalfortSaksid = "-" // TODO Ikke levert fra SF, mulig journalpostId kan brukes?
+        val journalfortSaksid = journalpost?.saksId
         val journalfortDato = journalpost?.journalfortDato?.format(DateTimeFormatter.ofPattern(DATO_TID_FORMAT))
         val journalfortTema = journalpost?.journalfortTema
         val journalfortTemanavn = temakodeMap[journalpost?.journalfortTema ?: ""]

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogMerkController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogMerkController.kt
@@ -37,7 +37,7 @@ class SfLegacyDialogMerkController(
     }
 
     override fun avsluttUtenSvar(request: AvsluttUtenSvarRequest): ResponseEntity<Void> {
-        // TODO vil det være innafor å merke meldinger på denne måten.
+        // TODO SF vil det være innafor å merke meldinger på denne måten.
         // Hva skjer evt om vi forsøker å gjøre det med samtalereferat etc?
         sfHenvendelseService.lukkTraad(request.eldsteMeldingTraadId)
         return ResponseEntity(HttpStatus.OK)

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/SFJournalforing.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/SFJournalforing.kt
@@ -17,8 +17,9 @@ class SFJournalforing @Autowired constructor(
         sfHenvendelseService.journalforHenvendelse(
             enhet = enhet,
             kjedeId = traadId,
-            saksId = sak.fagsystemSaksId,
-            saksTema = sak.temaKode
+            saksTema = sak.temaKode,
+            fagsakSystem = sak.fagsystemKode,
+            saksId = sak.fagsystemSaksId
         )
     }
 }


### PR DESCRIPTION
Ved opprettelse av samtalereferat med kjedeId == null blir det opprettet ett nytt referat, men om kjedeId != null blir dette regnet som ett oppfølgingsreferat og disse blir knyttet sammen.

Siden samtalereferat ikke er modellert i salesforce til å støtte dette, så må vi håndtere flyten med automatisk journalføring selv. Og derfor bruker vi eksisterende journalposter for "tråden" og passer på at journalføringen blir oppdatert for det nye samtalereferatet
