### PR TITLE
[OPP-1383] Legger til metadata på statsborgerskap

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -55,11 +55,6 @@ query($ident: ID!){
         adressebeskyttelse {
             gradering
         }
-        statsborgerskap {
-            land,
-            gyldigFraOgMed,
-            gyldigTilOgMed
-        }
         doedsfall {
             doedsdato
         }
@@ -116,6 +111,14 @@ query($ident: ID!){
             }
             metadata {
                 ...sistEndret
+            }
+        }
+        statsborgerskap {
+            land,
+            gyldigFraOgMed,
+            gyldigTilOgMed,
+            metadata {
+                historisk
             }
         }
         tilrettelagtKommunikasjon {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -67,7 +67,8 @@ object Persondata {
     data class Statsborgerskap(
         val land: KodeBeskrivelse<String>,
         val gyldigFraOgMed: LocalDate?,
-        val gyldigTilOgMed: LocalDate?
+        val gyldigTilOgMed: LocalDate?,
+        val erHistorisk: Boolean
     )
 
     data class Sivilstand(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -271,7 +271,8 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             Persondata.Statsborgerskap(
                 land = land,
                 gyldigFraOgMed = it.gyldigFraOgMed?.value,
-                gyldigTilOgMed = it.gyldigTilOgMed?.value
+                gyldigTilOgMed = it.gyldigTilOgMed?.value,
+                erHistorisk = it.metadata.historisk
             )
         }
     }


### PR DESCRIPTION
Bakgrunnen er at man kan ha flere gyldige statsborgerskap i PDL. Siden datoene ikke alltid finnes, så ønsker vi å sjekke om dataene er historisk eller fremdeles er gyldig, og filtrere bort historiske data i frontend. 