### PR TITLE
[OPP-1383] bruke fnr fra tredjepartsperson på sivilstand

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -77,7 +77,7 @@ object Persondata {
     )
 
     data class SivilstandRelasjon(
-        val fnr: String?,
+        val fnr: String,
         val navn: List<Navn>,
         val alder: Int?,
         val adressebeskyttelse: List<KodeBeskrivelse<AdresseBeskyttelse>>,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -368,7 +368,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         val person = data.tredjepartsPerson.map { it[relatertVedSivilstand] }.getOrNull() ?: return null
 
         return Persondata.SivilstandRelasjon(
-            fnr = relatertVedSivilstand,
+            fnr = person.fnr,
             navn = person.navn,
             alder = person.alder,
             adressebeskyttelse = person.adressebeskyttelse,
@@ -605,7 +605,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         return data.persondata.forelderBarnRelasjon.map { relasjon ->
             val tredjepartsPerson = data.tredjepartsPerson.map { it[relasjon.relatertPersonsIdent] }.getOrNull()
             Persondata.ForelderBarnRelasjon(
-                ident = relasjon.relatertPersonsIdent,
+                ident = tredjepartsPerson?.fnr ?: "",
                 rolle = when (relasjon.relatertPersonsRolle) {
                     HentPersondata.ForelderBarnRelasjonRolle.MOR -> Persondata.ForelderBarnRelasjonRolle.MOR
                     HentPersondata.ForelderBarnRelasjonRolle.FAR -> Persondata.ForelderBarnRelasjonRolle.FAR

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -112,7 +112,8 @@ class PersondataServiceImpl(
             }.toTypedArray(),
             *this.foreldreansvar.mapNotNull { it.ansvarlig }.toTypedArray(),
             *this.foreldreansvar.mapNotNull { it.ansvarssubjekt }.toTypedArray(),
-            *this.sivilstand.mapNotNull { it.relatertVedSivilstand }.toTypedArray()
+            *this.sivilstand.mapNotNull { it.relatertVedSivilstand }.toTypedArray(),
+            *this.forelderBarnRelasjon.mapNotNull { it.relatertPersonsIdent }.toTypedArray()
         ).toList()
     }
 


### PR DESCRIPTION
Vi sendte likevel med fnr for personer med diskresjonskode, siden vi ikke brukte tredjepartspersonmapper-fnr-feltet (som var vasket) når vi oppdaterte feltene.