### PR TITLE
[OPP-1383] fjerne bostedadresse fra forelderBarnRelasjon

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -214,7 +214,6 @@ object Persondata {
         val kjonn: List<KodeBeskrivelse<Kjonn>>,
         val alder: Int?,
         val adressebeskyttelse: List<KodeBeskrivelse<AdresseBeskyttelse>>,
-        val bostedAdresse: List<Adresse>,
         val harSammeAdresse: Boolean,
         val personstatus: List<KodeBeskrivelse<PersonStatus>>
     )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -618,7 +618,6 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                 alder = tredjepartsPerson?.alder,
                 kjonn = tredjepartsPerson?.kjonn ?: emptyList(),
                 adressebeskyttelse = tredjepartsPerson?.adressebeskyttelse ?: emptyList(),
-                bostedAdresse = tredjepartsPerson?.bostedAdresse ?: emptyList(),
                 harSammeAdresse = harSammeAdresse(
                     personAdresse = hentBostedAdresse(data).firstOrNull(),
                     tredjepartsPersonAdresse = tredjepartsPerson?.bostedAdresse?.firstOrNull()


### PR DESCRIPTION
Dette feltet trengs kun for å avgjøre om tredjepartspersonen harSammeAdresse, og skal ikke sendes videre til frontend.