### PR TITLE
[PROD][OPP-1383] bruke sikkerhetstiltak type og beskrivelse direkte fra PDL

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -85,7 +85,8 @@ object Persondata {
     )
 
     data class Sikkerhetstiltak(
-        val type: SikkerhetstiltakType,
+        val type: String,
+        val beskrivelse: String,
         val gyldigFraOgMed: LocalDate,
         val gyldigTilOgMed: LocalDate
     )
@@ -265,14 +266,6 @@ object Persondata {
         SEPARERT_PARTNER("SEPA"),
         SKILT_PARTNER("SKPA"),
         GJENLEVENDE_PARTNER("GJPA")
-    }
-
-    enum class SikkerhetstiltakType(val beskrivelse: String) {
-        FYUS("Fysisk utestengelse"),
-        TFUS("Telefonisk utestengelse"),
-        FTUS("Fysisk/telefonisk utestengelse"),
-        DIUS("Digital utestengelse"),
-        TOAN("To ansatte i samtale")
     }
 
     enum class Skifteform {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -345,7 +345,8 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
     private fun hentSikkerhetstiltak(data: Data): List<Persondata.Sikkerhetstiltak> {
         return data.persondata.sikkerhetstiltak.map {
             Persondata.Sikkerhetstiltak(
-                type = Persondata.SikkerhetstiltakType.valueOf(it.tiltakstype),
+                type = it.tiltakstype,
+                beskrivelse = it.beskrivelse,
                 gyldigFraOgMed = it.gyldigFraOgMed.value,
                 gyldigTilOgMed = it.gyldigTilOgMed.value
             )


### PR DESCRIPTION
Beskrivelse kommer direkte fra PDL så vi trenger ikke å mappe om til vår enum.