### PR TITLE
[PROD][KAIZEN-0] fix: fjerne tilgangskontroll på ident-feltet i tredjepartsperson 

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -327,7 +327,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     Kodeverk.DISKRESJONSKODER,
                     "SPSF"
                 )
-                FORTROLIG -> kodeverk.hentKodeBeskrivelse(Kodeverk.DISKRESJONSKODER, "SPSO")
+                FORTROLIG -> kodeverk.hentKodeBeskrivelse(Kodeverk.DISKRESJONSKODER, "SPFO")
                 UGRADERT -> Persondata.KodeBeskrivelse("", "Ugradert")
                 else -> Persondata.KodeBeskrivelse("", "Ukjent")
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
@@ -16,7 +16,7 @@ class TredjepartspersonMapper(val kodeverk: EnhetligKodeverk.Service) {
         val fodselsdato = person.foedsel.mapNotNull { it.foedselsdato?.value }
         val harTilgang = person.harTilgang(tilganger)
         return Persondata.TredjepartsPerson(
-            fnr = if (harTilgang) ident else "",
+            fnr = ident,
             navn = person.navn.mapNotNull {
                 if (harTilgang) {
                     Persondata.Navn(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
@@ -152,7 +152,7 @@ class TredjepartspersonMapper(val kodeverk: EnhetligKodeverk.Service) {
                     Kodeverk.DISKRESJONSKODER,
                     "SPSF"
                 )
-                HentTredjepartspersondata.AdressebeskyttelseGradering.FORTROLIG -> kodeverk.hentKodeBeskrivelse(Kodeverk.DISKRESJONSKODER, "SPSO")
+                HentTredjepartspersondata.AdressebeskyttelseGradering.FORTROLIG -> kodeverk.hentKodeBeskrivelse(Kodeverk.DISKRESJONSKODER, "SPFO")
                 HentTredjepartspersondata.AdressebeskyttelseGradering.UGRADERT -> Persondata.KodeBeskrivelse("", "Ugradert")
                 else -> Persondata.KodeBeskrivelse("", "Ukjent")
             }

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-0.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-0.json
@@ -5,7 +5,7 @@
   } ] ],
   "alder" : null,
   "bostedAdresse" : [ "java.util.ArrayList", [ ] ],
-  "fnr" : "",
+  "fnr" : "00000000000",
   "fodselsdato" : [ "kotlin.collections.EmptyList", [ ] ],
   "kjonn" : [ "kotlin.collections.EmptyList", [ ] ],
   "navn" : [ "java.util.ArrayList", [ ] ],

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-0.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-0.json
@@ -1,6 +1,6 @@
 {
   "adressebeskyttelse" : [ "java.util.ArrayList", [ {
-    "beskrivelse" : "SPSO",
+    "beskrivelse" : "SPFO",
     "kode" : "KODE7"
   } ] ],
   "alder" : null,

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-1.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-1.json
@@ -5,7 +5,7 @@
   } ] ],
   "alder" : null,
   "bostedAdresse" : [ "java.util.ArrayList", [ ] ],
-  "fnr" : "",
+  "fnr" : "00000000000",
   "fodselsdato" : [ "kotlin.collections.EmptyList", [ ] ],
   "kjonn" : [ "kotlin.collections.EmptyList", [ ] ],
   "navn" : [ "java.util.ArrayList", [ ] ],

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-2.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.TredjepartspersonMapperTest_skal fjerne informasjon relatert til kode 6-7 ved manglende tilgang-2.json
@@ -5,7 +5,7 @@
   } ] ],
   "alder" : null,
   "bostedAdresse" : [ "java.util.ArrayList", [ ] ],
-  "fnr" : "",
+  "fnr" : "00000000000",
   "fodselsdato" : [ "kotlin.collections.EmptyList", [ ] ],
   "kjonn" : [ "kotlin.collections.EmptyList", [ ] ],
   "navn" : [ "java.util.ArrayList", [ ] ],


### PR DESCRIPTION
Dersom man ikke har tilgang til personen, vil fnr bli satt til tom string. Det gjør at uthenting på fnr for tredjepartsperson senere vil matche på tom string. Det vil ikke gi noen informasjon, og dersom det finnes flere relasjoner man ikke har tilgang til vil alle disse overskrives.