### PR TITLE
[OPP-1383] Endrer område til å være en kodebeskrivelse

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -184,7 +184,7 @@ object Persondata {
         val motpartsPersonident: String,
         val motpartsPersonNavn: Navn,
         val motpartsRolle: FullmaktsRolle,
-        val omrade: List<String>,
+        val omrade: List<KodeBeskrivelse<String>>,
         val gyldigFraOgMed: LocalDate,
         val gyldigTilOgMed: LocalDate
     )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -539,11 +539,15 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     HentPersondata.FullmaktsRolle.FULLMEKTIG -> Persondata.FullmaktsRolle.FULLMEKTIG
                     else -> Persondata.FullmaktsRolle.UKJENT
                 },
-                omrade = it.omraader,
+                omrade = hentOmrade(it.omraader),
                 gyldigFraOgMed = it.gyldigFraOgMed.value,
                 gyldigTilOgMed = it.gyldigTilOgMed.value
             )
         }
+    }
+
+    private fun hentOmrade(omraader: List<String>): List<Persondata.KodeBeskrivelse<String>> {
+        return omraader.map { omrade -> kodeverk.hentKodeBeskrivelse(Kodeverk.TEMA, omrade) }
     }
 
     private fun hentVergemal(data: Data): List<Persondata.Verge> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/KodeverkConfig.kt
@@ -10,6 +10,7 @@ enum class KodeverkConfig(private val kilde: EnhetligKodeverk.Kilde) {
     SIVILSTAND(FellesKodeverkKilde("Sivilstander")),
     DISKRESJONSKODER(FellesKodeverkKilde("Diskresjonskoder")),
     VALUTA(FellesKodeverkKilde("Valutaer")),
+    TEMA(FellesKodeverkKilde("Tema")),
     SF_TEMAGRUPPER(SfHenvendelseKodeverkKilde());
 
     fun hentKodeverk(providers: KodeverkProviders) = kilde.hentKodeverk(providers)


### PR DESCRIPTION
Gjør dette fordi vi da får hentet beskrivelsen fra felles kodeverk og vist denne i frontend, i stedet for kun å vise koden.