### PR TITLE
[PROD][OPP-1383] utvide kontaktadresse-mapping

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -25,6 +25,17 @@ fragment utenlandskadresse on UtenlandskAdresse {
     regionDistriktOmraade
     landkode
 }
+fragment postadresseIFrittFormat on PostadresseIFrittFormat {
+    adresselinje1
+    adresselinje2
+    adresselinje3
+    postnummer
+}
+fragment postboksadresse on Postboksadresse {
+    postbokseier
+    postboks
+    postnummer
+}
 
 fragment sistEndret on Metadata {
     endringer {
@@ -224,6 +235,12 @@ query($ident: ID!){
                ...sistEndret
             }
             coAdressenavn
+            postadresseIFrittFormat {
+                ...postadresseIFrittFormat
+            }
+            postboksadresse {
+                ...postboksadresse
+            }
             vegadresse {
                 ...vegadresse
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -215,7 +215,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             }
         }
     }
-    
+
     private fun lagAdresseFraPostadresseIFrittFormat(
         adresse: HentPersondata.PostadresseIFrittFormat,
         sistEndret: Persondata.SistEndret?
@@ -229,7 +229,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         ),
         sistEndret = sistEndret
     )
-    
+
     private fun lagAdresseFraPostboksadresse(
         adresse: HentPersondata.Postboksadresse,
         sistEndring: Persondata.SistEndret?
@@ -242,7 +242,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         linje3 = listOf(adresse.postbokseier),
         sistEndret = sistEndring
     )
-    
+
     private fun hentSisteEndringFraMetadata(metadata: HentPersondata.Metadata): Persondata.SistEndret? {
         return metadata.endringer.maxBy { it.registrert.value }
             ?.let {


### PR DESCRIPTION
Ved noen tilfeller vil man både ha coAdressenavn og vegadresse. Logikken utelukket dette tilfellet, men vil nå lage et Adresse-objekt ved å slå sammen informasjon fra begge.