### PR TITLE
[PROD][OPP-1383] Feilhåndtering persondata result

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -25,6 +25,17 @@ fragment utenlandskadresse on UtenlandskAdresse {
     regionDistriktOmraade
     landkode
 }
+fragment postadresseIFrittFormat on PostadresseIFrittFormat {
+    adresselinje1
+    adresselinje2
+    adresselinje3
+    postnummer
+}
+fragment postboksadresse on Postboksadresse {
+    postbokseier
+    postboks
+    postnummer
+}
 
 fragment sistEndret on Metadata {
     endringer {
@@ -224,6 +235,12 @@ query($ident: ID!){
                ...sistEndret
             }
             coAdressenavn
+            postadresseIFrittFormat {
+                ...postadresseIFrittFormat
+            }
+            postboksadresse {
+                ...postboksadresse
+            }
             vegadresse {
                 ...vegadresse
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -167,7 +167,7 @@ object Persondata {
     data class Bankkonto(
         val kontonummer: String,
         val banknavn: String?,
-        val sistEndret: SistEndret,
+        val sistEndret: SistEndret?,
         val bankkode: String? = null,
         val swift: String? = null,
         val landkode: KodeBeskrivelse<String>? = null,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -166,7 +166,7 @@ object Persondata {
 
     data class Bankkonto(
         val kontonummer: String,
-        val banknavn: String,
+        val banknavn: String?,
         val sistEndret: SistEndret,
         val bankkode: String? = null,
         val swift: String? = null,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -215,7 +215,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             }
         }
     }
-    
+
     private fun lagAdresseFraPostadresseIFrittFormat(
         adresse: HentPersondata.PostadresseIFrittFormat,
         sistEndret: Persondata.SistEndret?
@@ -229,7 +229,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         ),
         sistEndret = sistEndret
     )
-    
+
     private fun lagAdresseFraPostboksadresse(
         adresse: HentPersondata.Postboksadresse,
         sistEndring: Persondata.SistEndret?
@@ -242,7 +242,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         linje3 = listOf(adresse.postbokseier),
         sistEndret = sistEndring
     )
-    
+
     private fun hentSisteEndringFraMetadata(metadata: HentPersondata.Metadata): Persondata.SistEndret? {
         return metadata.endringer.maxBy { it.registrert.value }
             ?.let {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -11,6 +11,7 @@ import no.nav.modiapersonoversikt.rest.enhet.model.Klokkeslett
 import no.nav.modiapersonoversikt.rest.enhet.model.Publikumsmottak
 import no.nav.modiapersonoversikt.service.dkif.Dkif
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
+import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bankkonto
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.BankkontoNorge
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.BankkontoUtland
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bruker
@@ -695,26 +696,12 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                         is BankkontoNorge -> Persondata.Bankkonto(
                             kontonummer = bankkonto.bankkonto.bankkontonummer,
                             banknavn = bankkonto.bankkonto.banknavn,
-                            sistEndret = Persondata.SistEndret(
-                                ident = bankkonto.endretAv,
-                                tidspunkt = bankkonto.endringstidspunkt
-                                    .toGregorianCalendar()
-                                    .toZonedDateTime()
-                                    .toLocalDateTime(),
-                                system = ""
-                            )
+                            sistEndret = hentSistEndretBankkonto(bankkonto)
                         )
                         is BankkontoUtland -> Persondata.Bankkonto(
                             kontonummer = bankkonto.bankkontoUtland.bankkontonummer,
                             banknavn = bankkonto.bankkontoUtland.banknavn,
-                            sistEndret = Persondata.SistEndret(
-                                ident = bankkonto.endretAv,
-                                tidspunkt = bankkonto.endringstidspunkt
-                                    .toGregorianCalendar()
-                                    .toZonedDateTime()
-                                    .toLocalDateTime(),
-                                system = ""
-                            ),
+                            sistEndret = hentSistEndretBankkonto(bankkonto),
                             bankkode = bankkonto.bankkontoUtland.bankkode,
                             swift = bankkonto.bankkontoUtland.swift,
                             landkode = kodeverk.hentKodeBeskrivelse(
@@ -738,6 +725,21 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     null
                 }
             }
+    }
+
+    private fun hentSistEndretBankkonto(bankkonto: Bankkonto): Persondata.SistEndret? {
+        return if (bankkonto.endretAv != null && bankkonto.endringstidspunkt != null) {
+            Persondata.SistEndret(
+                ident = bankkonto.endretAv,
+                tidspunkt = bankkonto.endringstidspunkt
+                    .toGregorianCalendar()
+                    .toZonedDateTime()
+                    .toLocalDateTime(),
+                system = ""
+            )
+        } else {
+            null
+        }
     }
 
     private fun hentForelderBarnRelasjon(data: Data): List<Persondata.ForelderBarnRelasjon> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -76,7 +76,10 @@ class PersondataServiceImpl(
         return personV3.hentPerson(
             HentPersonRequest()
                 .withAktoer(PersonIdent().withIdent(NorskIdent().withIdent(fnr)))
-                .withInformasjonsbehov(Informasjonsbehov.BANKKONTO)
+                .withInformasjonsbehov(
+                    Informasjonsbehov.BANKKONTO,
+                    Informasjonsbehov.SPORINGSINFORMASJON
+                )
         )
     }
 


### PR DESCRIPTION
Vi opplevde problemer med å sette bankkonto, selv om kallene til TPS fungerte slik de skulle.

For å kunne fange opp mapping-feil på vår side, lager vi `fold()` og oppdaterer `feilendeSystemer`.

En del av feltene vi fikk fra TPS for bankkonto var også tomme, så datamodellen måtte håndtere dette.