### PR TITLE
[OPP-1383] utvide bostedsadresse

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -217,6 +217,7 @@ query($ident: ID!){
                 ajourholdstidspunkt
                 kilde
             }
+            coAdressenavn
             vegadresse {
                 ...vegadresse
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -327,10 +327,6 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             adresse.postnummer,
             adresse.postnummer?.let { kodeverk.hentKodeverk(Kodeverk.POSTNUMMER).hentBeskrivelse(it) }
         ),
-        linje3 = listOf(
-            adresse.bydelsnummer,
-            adresse.kommunenummer
-        ),
         sistEndret = sisteEndring
     )
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -139,18 +139,30 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
 
     private fun hentBostedAdresse(data: Data): List<Persondata.Adresse> {
         return data.persondata.bostedsadresse.mapNotNull { adresse ->
+            val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             when {
+                adresse.coAdressenavn != null && adresse.vegadresse != null -> {
+                    kombinerCoAdresseNavnOgVegadresse(
+                        coAdressenavn = adresse.coAdressenavn!!,
+                        vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!),
+                        sisteEndring = sisteEndring
+                    )
+                }
+                adresse.coAdressenavn != null -> Persondata.Adresse(
+                    linje1 = adresse.coAdressenavn!!,
+                    sistEndret = sisteEndring
+                )
                 adresse.vegadresse != null -> lagAdresseFraVegadresse(
                     adresse = adresse.vegadresse!!,
-                    sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
+                    sisteEndring = sisteEndring
                 )
                 adresse.matrikkeladresse != null -> lagAdresseFraMatrikkeladresse(
                     adresse = adresse.matrikkeladresse!!,
-                    sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
+                    sisteEndring = sisteEndring
                 )
                 adresse.utenlandskAdresse != null -> lagAdresseFraUtenlandskAdresse(
                     adresse = adresse.utenlandskAdresse!!,
-                    sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
+                    sisteEndring = sisteEndring
                 )
                 adresse.ukjentBosted != null -> Persondata.Adresse(
                     linje1 = adresse.ukjentBosted?.bostedskommune ?: "Ukjent kommune",
@@ -176,22 +188,14 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             when {
                 adresse.coAdressenavn != null && adresse.vegadresse != null -> {
-                    val coAdressenavn = Persondata.Adresse(
-                        linje1 = adresse.coAdressenavn ?: "Ukjent kommune",
-                        sistEndret = sisteEndring
-                    )
-                    val vegadresse = lagAdresseFraVegadresse(
-                        adresse = adresse.vegadresse!!
-                    )
-                    Persondata.Adresse(
-                        linje1 = coAdressenavn.linje1,
-                        linje2 = vegadresse.linje1,
-                        linje3 = vegadresse.linje2,
-                        sistEndret = sisteEndring
+                    kombinerCoAdresseNavnOgVegadresse(
+                        coAdressenavn = adresse.coAdressenavn!!,
+                        vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!),
+                        sisteEndring = sisteEndring
                     )
                 }
                 adresse.coAdressenavn != null -> Persondata.Adresse(
-                    linje1 = adresse.coAdressenavn ?: "Ukjent kommune",
+                    linje1 = adresse.coAdressenavn!!,
                     sistEndret = sisteEndring
                 )
                 adresse.vegadresse != null -> lagAdresseFraVegadresse(
@@ -223,6 +227,23 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                 }
             }
         }
+    }
+
+    private fun kombinerCoAdresseNavnOgVegadresse(
+        coAdressenavn: String,
+        vegadresse: Persondata.Adresse,
+        sisteEndring: Persondata.SistEndret?
+    ): Persondata.Adresse {
+        val coAdresse = Persondata.Adresse(
+            linje1 = coAdressenavn,
+            sistEndret = sisteEndring
+        )
+        return Persondata.Adresse(
+            linje1 = coAdresse.linje1,
+            linje2 = vegadresse.linje1,
+            linje3 = vegadresse.linje2,
+            sistEndret = sisteEndring
+        )
     }
 
     private fun lagAdresseFraPostadresseIFrittFormat(


### PR DESCRIPTION
Vi ønsker ikke å vise bydelsnummer eller kommunenummer på bostedsadresse, da dette er duplikat informasjon i visittkortet og tallene gir lite mening alene.

Samtidig ønsker vi å bruke `coAdressenavn` da dette kan forekomme noen steder, og vi støttet det tidligere i TPS-visittkortet.