### PR TITLE
[PROD][OPP-1383] utvide bostedsadresse

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -167,7 +167,7 @@ object Persondata {
     data class Bankkonto(
         val kontonummer: String,
         val banknavn: String?,
-        val sistEndret: SistEndret,
+        val sistEndret: SistEndret?,
         val bankkode: String? = null,
         val swift: String? = null,
         val landkode: KodeBeskrivelse<String>? = null,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -166,7 +166,7 @@ object Persondata {
 
     data class Bankkonto(
         val kontonummer: String,
-        val banknavn: String,
+        val banknavn: String?,
         val sistEndret: SistEndret,
         val bankkode: String? = null,
         val swift: String? = null,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -11,6 +11,7 @@ import no.nav.modiapersonoversikt.rest.enhet.model.Klokkeslett
 import no.nav.modiapersonoversikt.rest.enhet.model.Publikumsmottak
 import no.nav.modiapersonoversikt.service.dkif.Dkif
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
+import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bankkonto
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.BankkontoNorge
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.BankkontoUtland
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bruker
@@ -695,26 +696,12 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                         is BankkontoNorge -> Persondata.Bankkonto(
                             kontonummer = bankkonto.bankkonto.bankkontonummer,
                             banknavn = bankkonto.bankkonto.banknavn,
-                            sistEndret = Persondata.SistEndret(
-                                ident = bankkonto.endretAv,
-                                tidspunkt = bankkonto.endringstidspunkt
-                                    .toGregorianCalendar()
-                                    .toZonedDateTime()
-                                    .toLocalDateTime(),
-                                system = ""
-                            )
+                            sistEndret = hentSistEndretBankkonto(bankkonto)
                         )
                         is BankkontoUtland -> Persondata.Bankkonto(
                             kontonummer = bankkonto.bankkontoUtland.bankkontonummer,
                             banknavn = bankkonto.bankkontoUtland.banknavn,
-                            sistEndret = Persondata.SistEndret(
-                                ident = bankkonto.endretAv,
-                                tidspunkt = bankkonto.endringstidspunkt
-                                    .toGregorianCalendar()
-                                    .toZonedDateTime()
-                                    .toLocalDateTime(),
-                                system = ""
-                            ),
+                            sistEndret = hentSistEndretBankkonto(bankkonto),
                             bankkode = bankkonto.bankkontoUtland.bankkode,
                             swift = bankkonto.bankkontoUtland.swift,
                             landkode = kodeverk.hentKodeBeskrivelse(
@@ -738,6 +725,21 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     null
                 }
             }
+    }
+
+    private fun hentSistEndretBankkonto(bankkonto: Bankkonto): Persondata.SistEndret? {
+        return if (bankkonto.endretAv != null && bankkonto.endringstidspunkt != null) {
+            Persondata.SistEndret(
+                ident = bankkonto.endretAv,
+                tidspunkt = bankkonto.endringstidspunkt
+                    .toGregorianCalendar()
+                    .toZonedDateTime()
+                    .toLocalDateTime(),
+                system = ""
+            )
+        } else {
+            null
+        }
     }
 
     private fun hentForelderBarnRelasjon(data: Data): List<Persondata.ForelderBarnRelasjon> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -76,7 +76,10 @@ class PersondataServiceImpl(
         return personV3.hentPerson(
             HentPersonRequest()
                 .withAktoer(PersonIdent().withIdent(NorskIdent().withIdent(fnr)))
-                .withInformasjonsbehov(Informasjonsbehov.BANKKONTO)
+                .withInformasjonsbehov(
+                    Informasjonsbehov.BANKKONTO,
+                    Informasjonsbehov.SPORINGSINFORMASJON
+                )
         )
     }
 


### PR DESCRIPTION
Vi ønsker ikke å vise bydelsnummer eller kommunenummer på bostedsadresse, da dette er duplikat informasjon i visittkortet og tallene gir lite mening alene.

Samtidig ønsker vi å bruke `coAdressenavn` da dette kan forekomme noen steder, og vi støttet det tidligere i TPS-visittkortet.