### PR TITLE
[OPP-1383] unngå null-return på gt for kode6 brukere

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -25,7 +25,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         val persondata: HentPersondata.Person,
         val geografiskeTilknytning: PersondataResult<String?>,
         val erEgenAnsatt: PersondataResult<Boolean>,
-        val navEnhet: PersondataResult<EnhetKontaktinformasjon>?,
+        val navEnhet: PersondataResult<EnhetKontaktinformasjon>,
         val dkifData: PersondataResult<Dkif.DigitalKontaktinformasjon>,
         val bankkonto: PersondataResult<HentPersonResponse>,
         val tredjepartsPerson: PersondataResult<Map<String, Persondata.TredjepartsPerson>>
@@ -347,8 +347,8 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
 
     private fun hentNavEnhet(data: Data): Persondata.Enhet? {
         return data.navEnhet
-            ?.map { Persondata.Enhet(it.enhetId, it.enhetNavn, hentPublikumsmottak(it.publikumsmottak)) }
-            ?.getOrNull()
+            .map { Persondata.Enhet(it.enhetId, it.enhetNavn, hentPublikumsmottak(it.publikumsmottak)) }
+            .getOrNull()
     }
 
     private fun hentPublikumsmottak(publikumsmottak: List<Publikumsmottak>): List<Persondata.Publikumsmottak> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -86,10 +86,8 @@ class PersondataServiceImpl(
     private fun hentNavEnhet(
         persondata: HentPersondata.Person,
         geografiskeTilknytning: PersondataResult<String?>
-    ): PersondataResult<EnhetKontaktinformasjon>? {
-        if (geografiskeTilknytning.getOrNull() == null) {
-            return null
-        }
+    ): PersondataResult<EnhetKontaktinformasjon> {
+        val gt = geografiskeTilknytning.getOrElse("")
 
         var diskresjonskode = ""
         val adressebeskyttelse = persondata.adressebeskyttelse
@@ -105,13 +103,12 @@ class PersondataServiceImpl(
                 break
             }
         }
-        return geografiskeTilknytning
-            .map("NORG") {
-                organisasjonEnhetV2Service
-                    .finnNAVKontor(it, diskresjonskode)
-                    .orElseThrow()
-                    .enhetId
-            }
+        return PersondataResult.runCatching("NORG") {
+            organisasjonEnhetV2Service
+                .finnNAVKontor(gt, diskresjonskode)
+                .orElseThrow()
+                .enhetId
+        }
             .map("NORG Kontaktinformasjon") {
                 EnhetKontaktinformasjon(organisasjonEnhetKontaktinformasjonService.hentKontaktinformasjon(it))
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
@@ -79,7 +79,7 @@ class PdlOppslagServiceImpl constructor(
             .data
             ?.hentGeografiskTilknytning
             ?.run {
-                gtBydel ?: gtKommune ?: gtLand ?: gtType.toString()
+                gtBydel ?: gtKommune ?: gtLand
             }
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
@@ -79,7 +79,7 @@ class PdlOppslagServiceImpl constructor(
             .data
             ?.hentGeografiskTilknytning
             ?.run {
-                gtBydel ?: gtKommune ?: gtLand
+                gtBydel ?: gtKommune ?: gtLand ?: gtType.toString()
             }
     }
 


### PR DESCRIPTION
Brukere med kode6 vil kun ha feltet gtType satt i PDL. Dette ville føre til at hentNavKontor returnerte null etter sjekk mot geografisk tilknytning før kallet til NORG. Nå garanterer vi at dersom man får en respons, så sender vi noe tilbake (gtType.toString()) og forhåpentligvis fungerer kallet til NORG.