### PR TITLE
[PROD][OPP-1383] unngå null-return på gt for kode6 brukere

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -76,7 +76,10 @@ class PersondataServiceImpl(
         return personV3.hentPerson(
             HentPersonRequest()
                 .withAktoer(PersonIdent().withIdent(NorskIdent().withIdent(fnr)))
-                .withInformasjonsbehov(Informasjonsbehov.BANKKONTO)
+                .withInformasjonsbehov(
+                    Informasjonsbehov.BANKKONTO,
+                    Informasjonsbehov.SPORINGSINFORMASJON
+                )
         )
     }
 


### PR DESCRIPTION
Brukere med kode6 vil kun ha feltet gtType satt i PDL. Dette ville føre til at hentNavKontor returnerte null etter sjekk mot geografisk tilknytning før kallet til NORG. 

Nå ønsker vi å unngå at dette skjer ved å sette GT til `""` dersom vi ikke får noe fra PDL, og så håndterer NORG diskresjonskode deretter. Dette ligner mer på logikken vi brukte for TPS også.