### PR TITLE
[OPP-1378] legge til sf tema-temagruppe mapping

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
@@ -11,7 +11,6 @@ import no.nav.modiapersonoversikt.legacy.api.service.OppgaveBehandlingService
 import no.nav.modiapersonoversikt.legacy.api.service.kodeverk.StandardKodeverk
 import no.nav.modiapersonoversikt.legacy.api.service.ldap.LDAPService
 import no.nav.modiapersonoversikt.legacy.api.utils.RestUtils
-import no.nav.modiapersonoversikt.legacy.api.utils.TemagruppeTemaMapping
 import no.nav.modiapersonoversikt.rest.DATO_TID_FORMAT
 import no.nav.modiapersonoversikt.rest.dialog.apis.*
 import no.nav.modiapersonoversikt.rest.dialog.apis.MeldingDTO
@@ -71,7 +70,7 @@ class SfLegacyDialogController(
         val henvendelse = sfHenvendelseService.opprettNyDialogOgSendMelding(
             bruker = EksternBruker.Fnr(fnr),
             enhet = enhet,
-            temagruppe = TemagruppeTemaMapping.hentTemagruppeForTema(sporsmalsRequest.sak.temaKode),
+            temagruppe = SfTemagruppeTemaMapping.hentTemagruppeForTema(sporsmalsRequest.sak.temaKode),
             fritekst = sporsmalsRequest.fritekst
         )
         sfHenvendelseService.journalforHenvendelse(
@@ -89,7 +88,7 @@ class SfLegacyDialogController(
         val henvendelse = sfHenvendelseService.opprettNyDialogOgSendMelding(
             bruker = EksternBruker.Fnr(fnr),
             enhet = enhet,
-            temagruppe = TemagruppeTemaMapping.hentTemagruppeForTema(infomeldingRequest.sak.temaKode),
+            temagruppe = SfTemagruppeTemaMapping.hentTemagruppeForTema(infomeldingRequest.sak.temaKode),
             fritekst = infomeldingRequest.fritekst
         )
         sfHenvendelseService.journalforHenvendelse(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfTemagruppeTemaMapping.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfTemagruppeTemaMapping.kt
@@ -1,0 +1,35 @@
+package no.nav.modiapersonoversikt.rest.dialog.salesforce
+
+import no.nav.modiapersonoversikt.legacy.api.domain.Temagruppe
+import no.nav.modiapersonoversikt.legacy.api.utils.TemagruppeTemaMapping
+
+object SfTemagruppeTemaMapping {
+    private val legacyMapping = HashMap(TemagruppeTemaMapping.TEMA_TEMAGRUPPE_MAPPING)
+
+    private val enkeltTemaOverstyring = mapOf(
+        "UFO" to Temagruppe.PENS.name
+    )
+
+    private val sfGodkjenteTemagrupper = listOf(
+        Temagruppe.ARBD,
+        Temagruppe.PENS,
+        Temagruppe.FMLI,
+        Temagruppe.HELSE,
+        Temagruppe.HJLPM,
+        Temagruppe.OVRG
+    ).map { it.name }
+
+    private val sfMapping = legacyMapping
+        .apply { putAll(enkeltTemaOverstyring) }
+        .mapValues {
+            if (it.value in sfGodkjenteTemagrupper) {
+                it.value
+            } else {
+                Temagruppe.OVRG.name
+            }
+        }
+
+    fun hentTemagruppeForTema(temaKode: String): String {
+        return sfMapping[temaKode] ?: TemagruppeTemaMapping.TEMA_UTEN_TEMAGRUPPE.name
+    }
+}


### PR DESCRIPTION
mange temagrupper blir fjernet ved overgangen til SF, vi må derfor oppdatere mappingen til å håndtere dette.

I første omgang tar vi utgangspunkt i tidligere mapping, og gjør mindre tilpassninger slik at vi holder oss innenfor sf-begrensningene
