### PR TITLE
[OPP-1378] sikre at riktig id blir brukt ved oppgave opprettelse

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogOppgaveController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogOppgaveController.kt
@@ -14,6 +14,7 @@ import no.nav.modiapersonoversikt.legacy.api.service.OpprettOppgaveResponse
 import no.nav.modiapersonoversikt.legacy.api.service.OpprettSkjermetOppgaveRequest
 import no.nav.modiapersonoversikt.legacy.api.service.saker.GsakKodeverk
 import no.nav.modiapersonoversikt.legacy.sporsmalogsvar.common.utils.DateUtils.arbeidsdagerFraDatoJava
+import no.nav.modiapersonoversikt.service.sfhenvendelse.fixKjedeId
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -115,7 +116,7 @@ class DialogOppgaveController @Autowired constructor(
         opprettetavenhetsnummer = opprettetavenhetsnummer,
         oppgaveFrist = kalkulerFrist(temaKode, oppgaveTypeKode),
         valgtEnhetsId = valgtEnhetId.toString(),
-        behandlingskjedeId = behandlingskjedeId,
+        behandlingskjedeId = behandlingskjedeId.fixKjedeId(),
         dagerFrist = dagerFrist,
         ansvarligEnhetId = ansvarligEnhetId,
         ansvarligIdent = ansvarligIdent


### PR DESCRIPTION
frontend bruker `eldsteMelding(valgtTraad).id` som vil gi meldingsId istedetfor tradId.
Ved henting av data fra henvendelse vil disse være like per definisjon. Men denne samantikken endrer seg ved overgang til Salesforce
