### PR TITLE
[KAIZEN-0] legge til concurrency kontroll på gh-workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Build, push, and deploy
 
 on: [push]
 
+concurrency:
+  group: main-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/modiapersonoversikt-api:${{ github.sha }}
   CI: true


### PR DESCRIPTION
Om man lager flere commits (eller merger flere PRer) raskt til en dev/master så startes det flere workflows i parallell.

Endringen her gjør sånn at pågående workflows blir stoppet om man lager en ny commit.

På denne måten kan vi pushe commits i flere faser, og fortsatt ende opp med en enkelt deploy.
