### PR TITLE
[PROD][OPP-1383] håndtere utenlandsk GT for nav-enhet

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/abac/Response.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/abac/Response.kt
@@ -47,8 +47,11 @@ data class AbacResponse(private val response: List<Response>) {
 }
 
 enum class DenyCause(vararg val policy: String) {
-    FP1_KODE6("fp1_behandle_kode6", "adressebeskyttelse_strengt_fortrolig_adresse"),
-    FP1_KODE6_UTLAND("adressebeskyttelse_strengt_fortrolig_adresse_utland"),
+    FP1_KODE6(
+        "fp1_behandle_kode6",
+        "adressebeskyttelse_strengt_fortrolig_adresse",
+        "adressebeskyttelse_strengt_fortrolig_adresse_utland"
+    ),
     FP2_KODE7("fp2_behandle_kode7", "adressebeskyttelse_fortrolig_adresse"),
     FP3_EGEN_ANSATT("fp3_behandle_egen_ansatt"),
     FP4_GEOGRAFISK("fp4_geografi"),

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/TilgangskontrollTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/TilgangskontrollTest.kt
@@ -55,7 +55,7 @@ class TilgangskontrollTest {
             .getDecision()
 
         assertEquals(DecisionEnums.DENY, decision)
-        assertEquals("Saksbehandler (Optional[Z999999]) har ikke tilgang til modia. Årsak: FP1_KODE6_UTLAND", message)
+        assertEquals("Saksbehandler (Optional[Z999999]) har ikke tilgang til modia. Årsak: FP1_KODE6", message)
     }
 
     @Test


### PR DESCRIPTION
Dersom bruker bor i utlandet, vil vi få empty() på kallet til finnNavKontor(), og dette må håndteres i stedet for å kaste feil.