### PR TITLE
[PROD][OPP-1383] fikse feil på uthenting av bankkonto

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/abac/Response.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/abac/Response.kt
@@ -47,8 +47,11 @@ data class AbacResponse(private val response: List<Response>) {
 }
 
 enum class DenyCause(vararg val policy: String) {
-    FP1_KODE6("fp1_behandle_kode6", "adressebeskyttelse_strengt_fortrolig_adresse"),
-    FP1_KODE6_UTLAND("adressebeskyttelse_strengt_fortrolig_adresse_utland"),
+    FP1_KODE6(
+        "fp1_behandle_kode6",
+        "adressebeskyttelse_strengt_fortrolig_adresse",
+        "adressebeskyttelse_strengt_fortrolig_adresse_utland"
+    ),
     FP2_KODE7("fp2_behandle_kode7", "adressebeskyttelse_fortrolig_adresse"),
     FP3_EGEN_ANSATT("fp3_behandle_egen_ansatt"),
     FP4_GEOGRAFISK("fp4_geografi"),

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -162,7 +162,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             val gyldighetsPeriode = hentGyldighetsperiode(adresse.gyldigFraOgMed, adresse.gyldigTilOgMed)
             when {
-                adresse.coAdressenavn != null && adresse.vegadresse != null -> {
+                adresse.coAdressenavn.isNotNullOrBlank() && adresse.vegadresse != null -> {
                     kombinerCoAdressenavnOgVegadresse(
                         coAdressenavn = adresse.coAdressenavn!!,
                         vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!),
@@ -170,7 +170,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                         gyldighetsPeriode = gyldighetsPeriode
                     )
                 }
-                adresse.coAdressenavn != null -> Persondata.Adresse(
+                adresse.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
                     linje1 = adresse.coAdressenavn!!,
                     sistEndret = sisteEndring,
                     gyldighetsPeriode = gyldighetsPeriode
@@ -215,7 +215,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             val gyldighetsPeriode = hentGyldighetsperiode(adresse.gyldigFraOgMed, adresse.gyldigTilOgMed)
             when {
-                adresse.coAdressenavn != null && adresse.vegadresse != null -> {
+                adresse.coAdressenavn.isNotNullOrBlank() && adresse.vegadresse != null -> {
                     kombinerCoAdressenavnOgVegadresse(
                         coAdressenavn = adresse.coAdressenavn!!,
                         vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!),
@@ -223,7 +223,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                         gyldighetsPeriode = gyldighetsPeriode
                     )
                 }
-                adresse.coAdressenavn != null -> Persondata.Adresse(
+                adresse.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
                     linje1 = adresse.coAdressenavn!!,
                     sistEndret = sisteEndring,
                     gyldighetsPeriode = gyldighetsPeriode
@@ -268,7 +268,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             val gyldighetsPeriode = hentGyldighetsperiode(adresse.gyldigFraOgMed, adresse.gyldigTilOgMed)
             when {
-                adresse.coAdressenavn != null && adresse.vegadresse != null -> {
+                adresse.coAdressenavn.isNotNullOrBlank() && adresse.vegadresse != null -> {
                     kombinerCoAdressenavnOgVegadresse(
                         coAdressenavn = adresse.coAdressenavn!!,
                         vegadresse = lagAdresseFraVegadresse(
@@ -278,7 +278,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                         gyldighetsPeriode = gyldighetsPeriode
                     )
                 }
-                adresse.coAdressenavn != null -> Persondata.Adresse(
+                adresse.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
                     linje1 = adresse.coAdressenavn!!,
                     sistEndret = sisteEndring,
                     gyldighetsPeriode = gyldighetsPeriode
@@ -625,7 +625,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     it.vegadresse != null -> lagAdresseFraVegadresse(it.vegadresse!!)
                     it.matrikkeladresse != null -> lagAdresseFraMatrikkeladresse(it.matrikkeladresse!!)
                     it.utenlandskAdresse != null -> lagAdresseFraUtenlandskAdresse(it.utenlandskAdresse!!)
-                    it.coAdressenavn != null -> Persondata.Adresse(
+                    it.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
                         linje1 = it.coAdressenavn!!,
                         sistEndret = null
                     )
@@ -936,6 +936,8 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                 Period.between(it.value, LocalDate.now()).years
             }
     }
+
+    private fun String?.isNotNullOrBlank() = !this.isNullOrBlank()
 }
 
 fun <T> EnhetligKodeverk.Service.hentKodeBeskrivelse(

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/TilgangskontrollTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/TilgangskontrollTest.kt
@@ -55,7 +55,7 @@ class TilgangskontrollTest {
             .getDecision()
 
         assertEquals(DecisionEnums.DENY, decision)
-        assertEquals("Saksbehandler (Optional[Z999999]) har ikke tilgang til modia. Årsak: FP1_KODE6_UTLAND", message)
+        assertEquals("Saksbehandler (Optional[Z999999]) har ikke tilgang til modia. Årsak: FP1_KODE6", message)
     }
 
     @Test


### PR DESCRIPTION
Valuta og Landkode har ikke feltene kodeRef, men value.

Knyttet til feil i loggene:
Vi får følgende respons fra Soap: `<landkode>ESP</landkode>`
Og feilmelding: `bankkonto.bankkontoUtland.landkode.kodeRef must not be null`

Legger også til mock for BankKontoUtland, slik at vi ser at mappingen fungerer.