### PR TITLE
[KAIZEN-0] legge til enslig forsørger som godkjent fagsaksystem

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/domain/saker/Sak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/domain/saker/Sak.java
@@ -30,12 +30,13 @@ public class Sak implements Serializable, Comparable<Sak> {
     public static final String FAGSYSTEMKODE_BIDRAG = "BISYS";
     public static final String FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK = "FS22";
     public static final String BIDRAG_MARKOR = "BID-HACK";
+    public static final String ENSLIG_FORSORGER = "EF";
 
     public static final List<String> GYLDIGE_FAGSYSTEM_FOR_GENERELLE_SAKER = List.of(FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK, "");
     public static final List<String> GODKJENTE_TEMA_FOR_GENERELL_SAK = List.of("AAP", "AGR", "BAR", "BIL", "DAG", "ENF", "ERS", "FEI", "FOR", "FOS", "FUL", "GEN", "GRA", "GRU", "HEL", "HJE", "IND", "KON", "KTR", "MED", "MOB", "OMS", "REH", "RVE", "RPO", "SAK", "SAP", "SER", "STO", "SUP", "SYK", "SYM", "TRK", "TRY", "TSR", "TSO", "UFM", "VEN", "YRA", "YRK", "FRI", TEMAKODE_OPPFOLGING, BIDRAG_MARKOR);
 
     // TODO Fjern BID_MARKØR etter når Featuretoggle fjernes
-    public static final List<String> GODKJENTE_FAGSYSTEMER_FOR_FAGSAKER = List.of(FAGSYSTEMKODE_BIDRAG, BIDRAG_MARKOR, FAGSYSTEMKODE_ARENA, FAGSYSTEMKODE_PSAK, "IT01", "OEBS", "V2", "AO11", "FS36", "FS38", "K9", "SUPSTONAD");
+    public static final List<String> GODKJENTE_FAGSYSTEMER_FOR_FAGSAKER = List.of(FAGSYSTEMKODE_BIDRAG, BIDRAG_MARKOR, FAGSYSTEMKODE_ARENA, FAGSYSTEMKODE_PSAK, "IT01", "OEBS", "V2", "AO11", "FS36", "FS38", "K9", "SUPSTONAD", ENSLIG_FORSORGER);
 
     public boolean isSakstypeForVisningGenerell() {
         return SAKSTYPE_GENERELL.equals(sakstype);


### PR DESCRIPTION
nytt fagsak system for enslig forsørger, sakene hentes fra `navikt/sak` så trenger bare oppdatering av whitelist
