### PR TITLE
[FAGSYSTEM-194911] Legger til coAdressenavn på tredjepartsperson

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentTredjepartspersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentTredjepartspersondata.graphql
@@ -30,6 +30,7 @@ query($identer: [ID!]!){
                     ajourholdstidspunkt
                     kilde
                 }
+                coAdressenavn
                 vegadresse {
                     husnummer
                     husbokstav

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapper.kt
@@ -60,8 +60,30 @@ class TredjepartspersonMapper(val kodeverk: EnhetligKodeverk.Service) {
             }
     }
 
+    private fun kombinerCoAdressenavnOgVegadresse(
+        coAdressenavn: String,
+        vegadresse: Persondata.Adresse
+    ) = Persondata.Adresse(
+        linje1 = coAdressenavn,
+        linje2 = vegadresse.linje1,
+        linje3 = vegadresse.linje2,
+        sistEndret = null
+    )
+
+    private fun String?.isNotNullOrBlank() = !this.isNullOrBlank()
+
     private fun hentBostedAdresse(adresse: HentTredjepartspersondata.Bostedsadresse): Persondata.Adresse? {
         return when {
+            adresse.coAdressenavn.isNotNullOrBlank() && adresse.vegadresse != null -> {
+                kombinerCoAdressenavnOgVegadresse(
+                    coAdressenavn = adresse.coAdressenavn!!,
+                    vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!)
+                )
+            }
+            adresse.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
+                linje1 = adresse.coAdressenavn!!,
+                sistEndret = null
+            )
             adresse.vegadresse != null -> lagAdresseFraVegadresse(adresse.vegadresse!!)
             adresse.matrikkeladresse != null -> lagAdresseFraMatrikkeladresse(adresse.matrikkeladresse!!)
             adresse.utenlandskAdresse != null -> lagAdresseFraUtenlandskAdresse(adresse.utenlandskAdresse!!)

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -33,6 +33,7 @@ internal class AdresseMappingTest {
         val tredjepartsPerson = gittTredjepartsperson().copy(
             bostedsadresse = HentTredjepartspersondata.Bostedsadresse(
                 folkeregistermetadata = null,
+                coAdressenavn = null,
                 vegadresse = HentTredjepartspersondata.Vegadresse(
                     husnummer = "12",
                     husbokstav = "A",

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -17,6 +17,7 @@ internal class AdresseMappingTest {
         every { kodeverk.hentKodeverk(any()) } returns EnhetligKodeverk.Kodeverk("", emptyMap())
         val hovedperson = gittPerson().copy(
             bostedsadresse = adresse.copy(
+                coAdressenavn = "C/O Her Herrmansen",
                 vegadresse = HentPersondata.Vegadresse(
                     matrikkelId = HentPersondata.Long(1234L),
                     husnummer = "12",
@@ -33,7 +34,7 @@ internal class AdresseMappingTest {
         val tredjepartsPerson = gittTredjepartsperson().copy(
             bostedsadresse = HentTredjepartspersondata.Bostedsadresse(
                 folkeregistermetadata = null,
-                coAdressenavn = null,
+                coAdressenavn = "C/O Her Herrmansen",
                 vegadresse = HentTredjepartspersondata.Vegadresse(
                     husnummer = "12",
                     husbokstav = "A",

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapperTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/TredjepartspersonMapperTest.kt
@@ -121,6 +121,7 @@ internal class TredjepartspersonMapperTest {
     }
 
     private val adresse = Bostedsadresse(
+        coAdressenavn = null,
         folkeregistermetadata = null,
         vegadresse = null,
         matrikkeladresse = null,


### PR DESCRIPTION
For å sjekke om barn/ektefelle bor på samme adresse som bruker så trenger vi å vite evt. C/O adresse også, hvis ikke vil testen alltid feile.