### PR TITLE
[FAGSYSTEM-194911] Fjerner coAdressenavn fra bostedsadresse

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -219,7 +219,6 @@ query($ident: ID!){
                 ajourholdstidspunkt
                 kilde
             }
-            coAdressenavn
             vegadresse {
                 ...vegadresse
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -161,19 +161,6 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             val sisteEndring = hentSisteEndringFraMetadata(adresse.metadata)
             val gyldighetsPeriode = hentGyldighetsperiode(adresse.gyldigFraOgMed, adresse.gyldigTilOgMed)
             when {
-                adresse.coAdressenavn.isNotNullOrBlank() && adresse.vegadresse != null -> {
-                    kombinerCoAdressenavnOgVegadresse(
-                        coAdressenavn = adresse.coAdressenavn!!,
-                        vegadresse = lagAdresseFraVegadresse(adresse.vegadresse!!),
-                        sisteEndring = sisteEndring,
-                        gyldighetsPeriode = gyldighetsPeriode
-                    )
-                }
-                adresse.coAdressenavn.isNotNullOrBlank() -> Persondata.Adresse(
-                    linje1 = adresse.coAdressenavn!!,
-                    sistEndret = sisteEndring,
-                    gyldighetsPeriode = gyldighetsPeriode
-                )
                 adresse.vegadresse != null -> lagAdresseFraVegadresse(
                     adresse = adresse.vegadresse!!,
                     sisteEndring = sisteEndring,

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
@@ -208,7 +208,6 @@ internal val adresse = HentPersondata.Bostedsadresse(
     gyldigTilOgMed = gittDateTime("2021-02-02T00:00:00"),
     metadata = metadata,
     folkeregistermetadata = null,
-    coAdressenavn = null,
     vegadresse = null,
     matrikkeladresse = null,
     utenlandskAdresse = null,


### PR DESCRIPTION
Dette er i følge PDL lite brukt, og dette brukes til å finne ut hvor man skal sende post så det skal ikke være relevant i forhold til hvor noen bor.