### PR TITLE
[KAIZEN-0] legge til muligheten for å styre science vha unleash

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/scientist/Scientist.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/scientist/Scientist.kt
@@ -5,6 +5,8 @@ import no.nav.modiapersonoversikt.config.JacksonConfig
 import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist.UtilityClasses.Try
 import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist.UtilityClasses.measureTimeInMillies
 import no.nav.modiapersonoversikt.legacy.api.utils.TjenestekallLogger
+import no.nav.modiapersonoversikt.service.unleash.Feature
+import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.ConcurrencyUtils
 import kotlin.random.Random
 
@@ -54,9 +56,22 @@ object Scientist {
         }
     }
 
+    interface ExperimentRate {
+        fun shouldRunExperiment(): Boolean
+    }
+    class FixedValueRate(private val rate: Double) : ExperimentRate {
+        override fun shouldRunExperiment(): Boolean {
+            return Random.nextDouble() < rate
+        }
+    }
+    class UnleashRate(private val unleash: UnleashService, val feature: Feature) : ExperimentRate {
+        override fun shouldRunExperiment(): Boolean {
+            return unleash.isEnabled(feature)
+        }
+    }
     data class Config(
         val name: String,
-        val experimentRate: Double,
+        val experimentRate: ExperimentRate,
         val reporter: Reporter = defaultReporter,
         val logAndCompareValues: Boolean = true
     )
@@ -75,7 +90,7 @@ object Scientist {
             control: () -> WithFields<T>,
             experiment: () -> WithFields<Any?>
         ): Result<T> {
-            if (forceExperiment.get() == true || Random.nextDouble() < config.experimentRate) {
+            if (forceExperiment.get() == true || config.experimentRate.shouldRunExperiment()) {
                 val fields = mutableMapOf<String, Any?>()
                 val (controlResult, experimentResult) = ConcurrencyUtils.inParallel(
                     { measureTimeInMillies(control) },

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/ExperimentSafService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/ExperimentSafService.kt
@@ -1,6 +1,7 @@
 package no.nav.modiapersonoversikt.legacy.sak.service.saf
 
 import com.expediagroup.graphql.types.GraphQLResponse
+import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist
 import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist.Config
 import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist.createExperiment
 import no.nav.modiapersonoversikt.legacy.api.domain.saf.generated.Hentbrukerssaker
@@ -13,7 +14,7 @@ class ExperimentSafService(
     private val control: SafService,
     private val experiment: SafService
 ) : SafService {
-    private val experimentRate = 0.05
+    private val experimentRate = Scientist.FixedValueRate(0.05)
     private val journalportExperiment =
         createExperiment<ResultatWrapper<List<DokumentMetadata>>>(Config("SAF-Journalpost", experimentRate))
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/henvendelse/HenvendelseDialog.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/henvendelse/HenvendelseDialog.kt
@@ -32,7 +32,7 @@ class HenvendelseDialog(
     val sfExperiment = Scientist.createExperiment<List<TraadDTO>>(
         Scientist.Config(
             name = "SF-Meldinger",
-            experimentRate = 1.0,
+            experimentRate = Scientist.FixedValueRate(1.0),
             logAndCompareValues = false
         )
     )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/kontaktinformasjon/KontaktinformasjonController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/kontaktinformasjon/KontaktinformasjonController.kt
@@ -26,7 +26,7 @@ class KontaktinformasjonController @Autowired constructor(
     val dkifExperiment = Scientist.createExperiment<Dkif.DigitalKontaktinformasjon>(
         Scientist.Config(
             name = "dkif",
-            experimentRate = 0.0
+            experimentRate = Scientist.FixedValueRate(0.0)
         )
     )
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonController.kt
@@ -53,7 +53,7 @@ class PersonController @Autowired constructor(
     private val standardKodeverk: StandardKodeverk
 ) {
     private val logger = LoggerFactory.getLogger(PersonController::class.java)
-    private val kjoennExperiment = Scientist.createExperiment<String?>(Scientist.Config("PDL-Kjønn", 0.2))
+    private val kjoennExperiment = Scientist.createExperiment<String?>(Scientist.Config("PDL-Kjønn", Scientist.FixedValueRate(0.2)))
 
     @GetMapping
     fun hent(@PathVariable("fnr") fodselsnummer: String): Map<String, Any?> {

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
@@ -12,7 +12,7 @@ internal class ScientistTest {
         Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(header).contains("[SCIENCE] DummyExperiment")
                 }
@@ -25,7 +25,7 @@ internal class ScientistTest {
         Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(fields).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
@@ -40,7 +40,7 @@ internal class ScientistTest {
         Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(fields).containsEntry("ok", false)
                     assertThat(fields).containsKey("control")
@@ -60,7 +60,7 @@ internal class ScientistTest {
         val experiment = Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 0.7,
+                experimentRate = Scientist.FixedValueRate(0.7),
                 reporter = { _, _ -> experimentsRun++ }
             )
         )
@@ -85,7 +85,7 @@ internal class ScientistTest {
         Scientist.createExperiment<List<Sak>>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(fields).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
@@ -120,7 +120,7 @@ internal class ScientistTest {
         Scientist.createExperiment<List<Map<String, Any?>>>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(fields).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
@@ -137,7 +137,7 @@ internal class ScientistTest {
         Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { header, fields ->
                     assertThat(fields).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
@@ -158,7 +158,7 @@ internal class ScientistTest {
         Scientist.createExperiment<String>(
             Scientist.Config(
                 name = "DummyExperiment",
-                experimentRate = 1.0,
+                experimentRate = Scientist.FixedValueRate(1.0),
                 reporter = { _, _ ->
                     val endTime = System.currentTimeMillis()
                     assertThat(endTime - startTime).isCloseTo(2000, Percentage.withPercentage(15.0))


### PR DESCRIPTION
ved å bruke `UnleashRate` kan man styre raten til ett eksperiment basert på en featuretoggle i unleash, og på denne måten få en raskere måte å endre raten på
