### PR TITLE
[OPP-1405] flytte hentIdenter og hentAktorId til person-v2

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataController.kt
@@ -5,6 +5,8 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
+import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentIdenter
+import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/rest/v2/person/{fnr}")
 class PersondataController(
     private val persondataService: PersondataService,
-    private val tilgangskontroll: Tilgangskontroll
+    private val tilgangskontroll: Tilgangskontroll,
+    private val pdlOppslagService: PdlOppslagService
 ) {
 
     @GetMapping
@@ -24,5 +27,15 @@ class PersondataController(
             .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Personalia, AuditIdentifier.FNR to fnr)) {
                 persondataService.hentPerson(fnr)
             }
+    }
+
+    @GetMapping("/identer")
+    fun hentIdenter(@PathVariable("fnr") fodselsnummer: String): HentIdenter.Identliste? {
+        return pdlOppslagService.hentIdenter(fodselsnummer)
+    }
+
+    @GetMapping("/aktorid")
+    fun hentAktorId(@PathVariable("fnr") fodselsnummer: String): String? {
+        return pdlOppslagService.hentAktorId(fodselsnummer)
     }
 }


### PR DESCRIPTION
Vi ønsker å fjerne den gamle personControlleren, og flytter derfor hentIdenter og HentAktorId over til persondataController. Siden de gamle endepunktene brukes i frontend, må de dupliseres over til den nye urlen, fikses i frontend, og deretter slettes fra gamle personcontroller.