### PR TITLE
[FAGSYSTEM-199029] sortere adresser basert på gyldigFOM

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -198,7 +198,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     null
                 }
             }
-        }
+        }.sortedByDescending { it.gyldighetsPeriode?.gyldigFraOgMed }
     }
 
     private fun hentKontaktAdresse(data: Data): List<Persondata.Adresse> {
@@ -256,7 +256,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                     null
                 }
             }
-        }
+        }.sortedByDescending { it.gyldighetsPeriode?.gyldigFraOgMed }
     }
 
     private fun hentOppholdsAdresse(data: Data): List<Persondata.Adresse> {

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
@@ -48,7 +48,7 @@ fun gittPerson(
     foreldreansvar: HentPersondata.Foreldreansvar = foreldreansvarData,
     forelderBarnRelasjon: List<HentPersondata.ForelderBarnRelasjon> = forelderBarnRelasjonData,
     deltBosted: HentPersondata.DeltBosted = deltBostedData,
-    bosted: List<HentPersondata.Bostedsadresse> = ukjentBosted("Ukjent adresse"),
+    bosted: HentPersondata.Bostedsadresse = bostedadresseData,
     kontaktadresse: HentPersondata.Kontaktadresse = kontaktadresseData,
     oppholdsadresse: HentPersondata.Oppholdsadresse = oppholdsadresseData
 ) = HentPersondata.Person(
@@ -72,8 +72,21 @@ fun gittPerson(
     foreldreansvar = listOf(foreldreansvar),
     forelderBarnRelasjon = forelderBarnRelasjon,
     deltBosted = listOf(deltBosted),
-    bostedsadresse = bosted,
-    kontaktadresse = listOf(kontaktadresse),
+    bostedsadresse = listOf(
+        bosted,
+        bosted.copy(
+            gyldigFraOgMed = gittDateTime("2021-10-01T00:00:00"),
+            gyldigTilOgMed = null
+        )
+    ),
+    kontaktadresse = listOf(
+        kontaktadresse,
+        kontaktadresse.copy(
+            gyldigFraOgMed = null,
+            gyldigTilOgMed = null,
+            vegadresse = gittVegadresse(husnummer = "10")
+        )
+    ),
     oppholdsadresse = listOf(oppholdsadresse)
 )
 
@@ -352,23 +365,34 @@ internal val forelderBarnRelasjonData = listOf(
     )
 )
 
-internal val vegadresse = HentPersondata.Vegadresse(
-    matrikkelId = null,
-    husbokstav = null,
-    husnummer = "3",
-    bruksenhetsnummer = null,
-    adressenavn = "Vegadressestien",
-    kommunenummer = "0987",
-    bydelsnummer = null,
-    tilleggsnavn = null,
-    postnummer = "1444"
+internal fun gittVegadresse(
+    matrikkelId: HentPersondata.Long? = null,
+    husbokstav: String? = null,
+    husnummer: String? = "3",
+    bruksenhetsnummer: String? = null,
+    adressenavn: String? = "Vegadressestien",
+    kommunenummer: String? = "0987",
+    bydelsnummer: String? = null,
+    tilleggsnavn: String? = null,
+    postnumme: String? = "1444"
+
+) = HentPersondata.Vegadresse(
+    matrikkelId = matrikkelId,
+    husbokstav = husbokstav,
+    husnummer = husnummer,
+    bruksenhetsnummer = bruksenhetsnummer,
+    adressenavn = adressenavn,
+    kommunenummer = kommunenummer,
+    bydelsnummer = bydelsnummer,
+    tilleggsnavn = tilleggsnavn,
+    postnummer = postnumme
 )
 
 internal val deltBostedData = HentPersondata.DeltBosted(
     startdatoForKontrakt = gittDato("2019-09-09"),
     sluttdatoForKontrakt = null,
     coAdressenavn = null,
-    vegadresse = vegadresse,
+    vegadresse = gittVegadresse(),
     matrikkeladresse = null,
     utenlandskAdresse = null,
     ukjentBosted = null
@@ -381,7 +405,7 @@ internal val kontaktadresseData = HentPersondata.Kontaktadresse(
     coAdressenavn = "C/O Adressenavn",
     postadresseIFrittFormat = null,
     postboksadresse = null,
-    vegadresse = vegadresse,
+    vegadresse = gittVegadresse(),
     utenlandskAdresse = null,
     utenlandskAdresseIFrittFormat = null
 )
@@ -391,10 +415,21 @@ internal val oppholdsadresseData = HentPersondata.Oppholdsadresse(
     gyldigTilOgMed = gittDateTime("2021-02-02T00:00:00"),
     oppholdAnnetSted = "UTENRIKS",
     coAdressenavn = "Kari Hansen",
-    vegadresse = vegadresse,
+    vegadresse = gittVegadresse(),
     matrikkeladresse = null,
     utenlandskAdresse = null,
     metadata = metadata
+)
+
+internal val bostedadresseData = HentPersondata.Bostedsadresse(
+    gyldigFraOgMed = gittDateTime("2021-02-02T00:00:00"),
+    gyldigTilOgMed = gittDateTime("2021-02-02T00:00:00"),
+    metadata = metadata,
+    vegadresse = gittVegadresse(),
+    utenlandskAdresse = null,
+    ukjentBosted = null,
+    folkeregistermetadata = null,
+    matrikkeladresse = null
 )
 
 internal fun gittDato(dato: String) = HentPersondata.Date(LocalDate.parse(dato))

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
@@ -30,7 +30,7 @@
     },
     "bostedAdresse" : [ "java.util.Arrays$ArrayList", [ {
       "gyldighetsPeriode" : {
-        "gyldigFraOgMed" : "2021-10-02",
+        "gyldigFraOgMed" : "2021-10-01",
         "gyldigTilOgMed" : null
       },
       "linje1" : "Vegadressestien 3",
@@ -176,8 +176,8 @@
     } ] ],
     "kontaktAdresse" : [ "java.util.Arrays$ArrayList", [ {
       "gyldighetsPeriode" : {
-        "gyldigFraOgMed" : "2021-10-02",
-        "gyldigTilOgMed" : null
+        "gyldigFraOgMed" : "2021-02-02",
+        "gyldigTilOgMed" : "2021-02-02"
       },
       "linje1" : "C/O Adressenavn",
       "linje2" : "Vegadressestien 3",
@@ -188,12 +188,9 @@
         "tidspunkt" : "2020-07-01T10:00:00"
       }
     }, {
-      "gyldighetsPeriode" : {
-        "gyldigFraOgMed" : "2021-02-02",
-        "gyldigTilOgMed" : "2021-02-02"
-      },
+      "gyldighetsPeriode" : null,
       "linje1" : "C/O Adressenavn",
-      "linje2" : "Vegadressestien 3",
+      "linje2" : "Vegadressestien 10",
       "linje3" : "1444 TestPoststed",
       "sistEndret" : {
         "ident" : "Folkeregisteret",

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
@@ -28,15 +28,32 @@
         "kode" : "NOK"
       }
     },
-    "bostedAdresse" : [ "java.util.ArrayList", [ {
+    "bostedAdresse" : [ "java.util.Arrays$ArrayList", [ {
+      "gyldighetsPeriode" : {
+        "gyldigFraOgMed" : "2021-10-02",
+        "gyldigTilOgMed" : null
+      },
+      "linje1" : "Vegadressestien 3",
+      "linje2" : "1444 TestPoststed",
+      "linje3" : null,
+      "sistEndret" : {
+        "ident" : "Folkeregisteret",
+        "system" : "FREG",
+        "tidspunkt" : "2020-07-01T10:00:00"
+      }
+    }, {
       "gyldighetsPeriode" : {
         "gyldigFraOgMed" : "2021-02-02",
         "gyldigTilOgMed" : "2021-02-02"
       },
-      "linje1" : "Ukjent adresse",
-      "linje2" : null,
+      "linje1" : "Vegadressestien 3",
+      "linje2" : "1444 TestPoststed",
       "linje3" : null,
-      "sistEndret" : null
+      "sistEndret" : {
+        "ident" : "Folkeregisteret",
+        "system" : "FREG",
+        "tidspunkt" : "2020-07-01T10:00:00"
+      }
     } ] ],
     "deltBosted" : [ "java.util.ArrayList", [ {
       "adresse" : {
@@ -157,7 +174,20 @@
       "beskrivelse" : "Mann",
       "kode" : "M"
     } ] ],
-    "kontaktAdresse" : [ "java.util.ArrayList", [ {
+    "kontaktAdresse" : [ "java.util.Arrays$ArrayList", [ {
+      "gyldighetsPeriode" : {
+        "gyldigFraOgMed" : "2021-10-02",
+        "gyldigTilOgMed" : null
+      },
+      "linje1" : "C/O Adressenavn",
+      "linje2" : "Vegadressestien 3",
+      "linje3" : "1444 TestPoststed",
+      "sistEndret" : {
+        "ident" : "Folkeregisteret",
+        "system" : "FREG",
+        "tidspunkt" : "2020-07-01T10:00:00"
+      }
+    }, {
       "gyldighetsPeriode" : {
         "gyldigFraOgMed" : "2021-02-02",
         "gyldigTilOgMed" : "2021-02-02"


### PR DESCRIPTION
Det er en vurdering om vi heller skulle sortert på `sistEndret.tidspunkt`. Den har også klokkeslett.
Ved tilfeller der det er `gyldighetsperiode = null`, vil denne havne nederst.