### PR TITLE
[KAIZEN-0] bruke Clock slik at tester fungerer uavhengig av dato

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -19,6 +19,7 @@ import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bruker
 import no.nav.tjeneste.virksomhet.person.v3.meldinger.HentPersonResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.time.LocalDate
 import java.time.Period
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.KodeverkConfig as Kodeverk
@@ -56,7 +57,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         }
     }
 
-    fun flettSammenData(data: Data): Persondata.Data {
+    fun flettSammenData(data: Data, clock: Clock = Clock.systemDefaultZone()): Persondata.Data {
         val feilendeSystemer = data.feilendeSystemer().toMutableList()
         return Persondata.Data(
             feilendeSystemer = feilendeSystemer,
@@ -66,7 +67,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                 kjonn = hentKjonn(data),
                 fodselsdato = hentFodselsdato(data),
                 geografiskTilknytning = hentGeografiskTilknytning(data),
-                alder = hentAlder(data),
+                alder = hentAlder(data, clock),
                 dodsdato = hentDodsdato(data),
                 bostedAdresse = hentBostedAdresse(data),
                 kontaktAdresse = hentKontaktAdresse(data),
@@ -949,10 +950,10 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             (personAdresse.linje3 == tredjepartsPersonAdresse.linje3)
     }
 
-    private fun hentAlder(data: Data): Int? {
+    private fun hentAlder(data: Data, clock: Clock): Int? {
         return data.persondata.foedsel.firstOrNull()?.foedselsdato
             ?.let {
-                Period.between(it.value, LocalDate.now()).years
+                Period.between(it.value, LocalDate.now(clock)).years
             }
     }
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -7,6 +7,9 @@ import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentTredjepart
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 internal class AdresseMappingTest {
     val kodeverk: EnhetligKodeverk.Service = mockk()
@@ -54,12 +57,13 @@ internal class AdresseMappingTest {
             .lagTredjepartsperson(barnFnr, tredjepartsPerson, PersondataService.Tilganger(true, true))
 
         val persondata = mapper.flettSammenData(
-            gittData(
+            data = gittData(
                 persondata = hovedperson,
                 tredjepartsPerson = PersondataResult.runCatching("tredjepartsperson") {
                     mapOf(barnFnr to requireNotNull(tredjepartsPersonData))
                 }
-            )
+            ),
+            clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault())
         )
 
         val harSammeAdresse = persondata.person.forelderBarnRelasjon.find { it.ident == barnFnr }?.harSammeAdresse

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
@@ -7,6 +7,9 @@ import no.nav.modiapersonoversikt.testutils.SnapshotExtension
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 internal class PersondataFletterTest {
     @JvmField
@@ -26,9 +29,10 @@ internal class PersondataFletterTest {
     internal fun `skal mappe data fra pdl til Persondata`() {
         snapshot.assertMatches(
             mapper.flettSammenData(
-                gittData(
+                data = gittData(
                     persondata = gittPerson(fnr = fnr)
-                )
+                ),
+                clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault())
             )
         )
     }


### PR DESCRIPTION
årsskifte gjorde at alder-beregningen ble feil siden test-figuren hadde blitt eldre. Det er ikke ønskelig at tid skal få testene til å feile, så derfor brukes `Clock` for å "låse tiden"
