### PR TITLE
[KAIZEN-0] logge bare ident

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
@@ -40,7 +40,7 @@ class PersonsokController @Autowired constructor(
 ) {
     private val auditDescriptor =
         Audit.describe<List<PersonSokResponsDTO>>(Audit.Action.READ, AuditResources.Personsok.Resultat) { resultat ->
-            val fnr = resultat?.map { it.ident }?.joinToString(", ") ?: "--"
+            val fnr = resultat?.joinToString(", ") { it.ident.ident } ?: "--"
             listOf(
                 AuditIdentifier.FNR to fnr
             )


### PR DESCRIPTION
logget tidligere objektet `NorskIdent` som skapte støy i tjenestekall-loggene
