### PR TITLE
[KAIZEN-0] slette ubrukte felter fra nais-env-config

### DIFF
--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -74,56 +74,22 @@ spec:
       value: "https://abac-modia-q0.dev.intern.nav.no/application/authorize"
     - name: BRUKERVARSELV1_ENDPOINTURL
       value: "https://app-q0.adeo.no/varsel/ws/Brukervarsel/v1"
-    - name: BRUKERVARSELV1_SECURITYTOKEN
-      value: "SAML"
-    - name: BRUKERVARSELV1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-brukervarsel-v1-tjenestespesifikasjon/1.0.4/nav-brukervarsel-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/henvendelse/services/domene.Brukerdialog/BehandleHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenestespesifikasjoner/behandle-henvendelse/1.2019.04.04-09.14-c6cea90b8e95/behandle-henvendelse-1.2019.04.04-09.14-c6cea90b8e95.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/henvendelse/services/domene.Brukerdialog/Henvendelse_v2"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-informasjon-v2/0.6/henvendelse-informasjon-v2-0.6.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/henvendelse/services/domene.Brukerdialog/HenvendelseSoknaderService_v1"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-soknader-tjenestespesifikasjon/0.0.26/henvendelse-soknader-tjenestespesifikasjon-0.0.26.zip"
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/henvendelse/services/domene.Brukerdialog/SendUtHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
       value: "https://dokarkiv-q0.nais.preprod.local/services/innsynjournal/v2"
-    - name: INNSYNJOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: INNSYNJOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-innsynJournal-v2-tjenestespesifikasjon/2.0.2/nav-innsynJournal-v2-tjenestespesifikasjon-2.0.2.zip"
     - name: JOURNAL_V2_ENDPOINTURL
       value: "https://wasapp-q0.adeo.no/joark/Journal/v2"
-    - name: JOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: JOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-journal-v2-tjenestespesifikasjon/1.0.3/nav-journal-v2-tjenestespesifikasjon-1.0.3.zip"
-    - name: KODEVERKSMAPPER_OPPGAVETYPE_DESCRIPTION
-      value: "Mapper fra oppgavetyper i fellessystemers kodeverk til oppgavetyper felles kodeverk"
     - name: KODEVERKSMAPPER_OPPGAVETYPE_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/mapOppgavetype"
-    - name: KODEVERKSMAPPER_PING_DESCRIPTION
-      value: "Ping-tjeneste som kan kalles fra konsumenters selftest"
     - name: KODEVERKSMAPPER_PING_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/ping"
-    - name: KODEVERKSMAPPER_UNDERKATEGORI_DESCRIPTION
-      value: "Mapper fra underkategorier i fellessystemers kodeverk til behandlingstema og behandlingstype i felles kodeverk"
     - name: KODEVERKSMAPPER_UNDERKATEGORI_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/mapUnderkategori"
     - name: FELLES_KODEVERK_URL
@@ -138,24 +104,14 @@ spec:
       value: "ldaps://ldapgw.preprod.local"
     - name: LDAP_USER_BASEDN
       value: "ou=NAV,ou=BusinessUnits,dc=preprod,dc=local"
-    - name: MODIABRUKERDIALOG_STANDARDTEKSTER_TILBAKEMELDING_URL
-      value: "https://navet.adeo.no/411275.cms"
     - name: PENSJON_PENSJONSAK_V1_ENDPOINTURL
       value: "https://pensjon-pen-q0.nais.preprod.local/pen/services/PensjonSak_v1"
-    - name: PENSJON_PENSJONSAK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: PENSJON_PENSJONSAK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-pensjonSak-v1-tjenestespesifikasjon/1.0.0/nav-pensjonSak-v1-tjenestespesifikasjon-1.0.0.zip"
     - name: SAF_GRAPHQL_URL
       value: "https://saf-q0.nais.preprod.local/graphql"
     - name: SAF_HENTDOKUMENT_URL
       value: "https://saf-q0.nais.preprod.local/rest/hentdokument"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SAKOGBEHANDLING_SECURITYTOKEN
-      value: "SAML"
-    - name: SAKOGBEHANDLING_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon/1.0.0-alpha011/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon-1.0.0-alpha011.zip"
     - name: SERVER_AKTIVITETSPLAN_URL
       value: "https://app-q0.adeo.no"
     - name: SERVER_ARENA_URL
@@ -178,90 +134,34 @@ spec:
       value: "https://tjenester-q0.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
-    - name: UTBETALING_V1_DESCRIPTION
-      value: "Utbetalingsoversikt"
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp-q0.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
-    - name: UTBETALING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: UTBETALING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-utbetaling-v1-tjenestespesifikasjon/1.1.3/nav-fim-utbetaling-v1-tjenestespesifikasjon-1.1.3.zip"
     - name: VEILARBOPPFOLGINGAPI_URL
       value: "https://veilarboppfolging-q0.nais.preprod.local/veilarboppfolging/api"
-#    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_ENDPOINTURL
-#      value: "https\://tjenestebuss-q0.adeo.no/nav-tjeneste-arbeidOgAktivitet_v1Web/sca/ArbeidOgAktivitetWSEXP"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_ENDPOINTURL
-      value: "https://service-gw-q0.preprod.local/"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_SECURITYTOKEN
-      value: "LTPA"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?r=m2internal&g=no.nav.esb.nav&a=nav-tjeneste-arbeidOgAktivitet&v=1.0.6&e=zip&c=wsdlif"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL
       value: "https://dkif.dev.adeo.no/"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=nav-digitalKontaktinformasjon-v1-tjenestespesifikasjon&e=zip&g=no.nav.tjenester.fim&r=m2internal&v=2.0.0"
     - name: VIRKSOMHET_EGENANSATT_V1_ENDPOINTURL
       value: "https://app-q0.adeo.no/tpsws-aura/ws/EgenAnsatt/v1"
-    - name: VIRKSOMHET_EGENANSATT_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_EGENANSATT_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/pip/nav-pip-egenAnsatt-v1-tjenestespesifikasjon/1.0.1/nav-pip-egenAnsatt-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_FORELDREPENGER_V2_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/infotrygd-ws/ForeldrepengerService/v2"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-foreldrepenger-v2-tjenestespesifikasjon/2.0.2/nav-foreldrepenger-v2-tjenestespesifikasjon-2.0.2.zip"
-    - name: VIRKSOMHET_KODEVERK_V2_ENDPOINTURL
-      value: "https://kodeverk.nais.preprod.local/ws/kodeverk/v2"
-    - name: VIRKSOMHET_KODEVERK_V2_SECURITYTOKEN
-      value: "NONE"
-    - name: VIRKSOMHET_KODEVERK_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-kodeverk-v2-tjenestespesifikasjon/2.0.0/nav-fim-kodeverk-v2-tjenestespesifikasjon-2.0.0.zip"
     - name: VIRKSOMHET_OPPFOLGING_V1_ENDPOINTURL
       value: "https://arena-q0.adeo.no/ail_ws/Oppfoelging_v1"
-    - name: VIRKSOMHET_OPPFOLGING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_OPPFOLGING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/repositories/public/no/nav/tjenester/fim/nav-fim-oppfoelging-v1-tjenestespesifikasjon/1.2.0/nav-fim-oppfoelging-v1-tjenestespesifikasjon-1.2.0.zip"
     - name: EREG_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/ereg/"
     - name: VIRKSOMHET_PERSON_V3_ENDPOINTURL
       value: "https://app-q0.adeo.no/tpsws-aura/ws/Person/v3"
-    - name: VIRKSOMHET_PERSON_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSON_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-person-v3-tjenestespesifikasjon/3.6.1/nav-person-v3-tjenestespesifikasjon-3.6.1.zip"
     - name: VIRKSOMHET_PERSONSOK_V1_ENDPOINTURL
       value: "https://app-q0.adeo.no/tpsws-aura/ws/Personsok/v1"
-    - name: VIRKSOMHET_PERSONSOK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSONSOK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-personsok-v1-tjenestespesifikasjon/1.0.1/nav-fim-personsok-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_PLEIEPENGER_V1_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/infotrygd-ws/Pleiepenger/v1"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-pleiepenger-v1-tjenestespesifikasjon/1.0.4/nav-pleiepenger-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: SAK_ENDPOINTURL
       value: "https://sak.nais.preprod.local"
     - name: VIRKSOMHET_SYKEPENGER_V2_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/infotrygd-ws/SykepengerService/v2"
-    - name: VIRKSOMHET_SYKEPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_SYKEPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-sykepenger-v2-tjenestespesifikasjon/2.0.1/nav-sykepenger-v2-tjenestespesifikasjon-2.0.1.zip"
     - name: VIRKSOMHET_YTELSESKONTRAKT_V3_ENDPOINTURL
       value: "https://arena-q0.adeo.no/ail_ws/Ytelseskontrakt_v3"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon/3.0.1/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon-3.0.1.zip"
     - name: HENVENDELSE_LES_API_URL
       value: "https://modapp-q0.adeo.no/henvendelse-les/api"
     - name: SF_HENVENDELSE_URL
@@ -276,42 +176,12 @@ spec:
       value: "https://bidrag-sak.dev.adeo.no/bidrag-sak"
     - name: NORG2_BASEURL
       value: "https://app-q0.adeo.no/norg2"
-    - name: TILLATMOCK
-      value: "true"
-    - name: VISUTBETALINGER
-      value: "true"
-    - name: DEAKTIVERAAREGLENKE
-      value: "false"
     - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
       value: "0 0 7,19 * * *"
-    - name: UTBETALINGTILGANG
-      value: "[]"
-    - name: TEMASIDER_VIKTIGAVITELENKE
-      value: "DAG,AAP,IND"
-    - name: BEHANDLINGSSTATUS_SYNLIG_ANTALLDAGER
-      value: "28"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
     - name: FJERN_SOKNADER_FOR_DATO
       value: "2014-12-09"
-    - name: TOGGLE_DIGISYFO
-      value: "true"
-    - name: VISNYEKOER
-      value: "true"
-    - name: VISDELVISESVARFUNKSJONALITET
-      value: "true"
-    - name: VISPLEIEPENGER
-      value: "true"
-    - name: ORGENHET_2_1
-      value: "true"
-    - name: VISENDRENAVNFUNKSJONALITET
-      value: "true"
-    - name: VISORGANISASJONENHETKONTAKTINFORMASJON
-      value: "true"
-    - name: FEATURE_AKTIVERPERSONRESTAPI
-      value: "true"
-    - name: FEATURE_NYTTVISITTKORT
-      value: "true"
     - name: HASTEKASSERING_TILGANG
       value: "Z992323,Z990366,Z990083,Z990351"
     - name: INTERNAL_TILGANG

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -70,56 +70,22 @@ spec:
       value: "https://abac-modia-q1.dev.intern.nav.no/application/authorize"
     - name: BRUKERVARSELV1_ENDPOINTURL
       value: "https://app-q1.adeo.no/varsel/ws/Brukervarsel/v1"
-    - name: BRUKERVARSELV1_SECURITYTOKEN
-      value: "SAML"
-    - name: BRUKERVARSELV1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-brukervarsel-v1-tjenestespesifikasjon/1.0.4/nav-brukervarsel-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/BehandleHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenestespesifikasjoner/behandle-henvendelse/1.2019.04.04-09.14-c6cea90b8e95/behandle-henvendelse-1.2019.04.04-09.14-c6cea90b8e95.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/Henvendelse_v2"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-informasjon-v2/0.6/henvendelse-informasjon-v2-0.6.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/HenvendelseSoknaderService_v1"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-soknader-tjenestespesifikasjon/0.0.26/henvendelse-soknader-tjenestespesifikasjon-0.0.26.zip"
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/henvendelse/services/domene.Brukerdialog/SendUtHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
       value: "https://dokarkiv-q1.nais.preprod.local/services/innsynjournal/v2"
-    - name: INNSYNJOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: INNSYNJOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-innsynJournal-v2-tjenestespesifikasjon/2.0.2/nav-innsynJournal-v2-tjenestespesifikasjon-2.0.2.zip"
     - name: JOURNAL_V2_ENDPOINTURL
       value: "https://wasapp-q1.adeo.no/joark/Journal/v2"
-    - name: JOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: JOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-journal-v2-tjenestespesifikasjon/1.0.3/nav-journal-v2-tjenestespesifikasjon-1.0.3.zip"
-    - name: KODEVERKSMAPPER_OPPGAVETYPE_DESCRIPTION
-      value: "Mapper fra oppgavetyper i fellessystemers kodeverk til oppgavetyper felles kodeverk"
     - name: KODEVERKSMAPPER_OPPGAVETYPE_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/mapOppgavetype"
-    - name: KODEVERKSMAPPER_PING_DESCRIPTION
-      value: "Ping-tjeneste som kan kalles fra konsumenters selftest"
     - name: KODEVERKSMAPPER_PING_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/ping"
-    - name: KODEVERKSMAPPER_UNDERKATEGORI_DESCRIPTION
-      value: "Mapper fra underkategorier i fellessystemers kodeverk til behandlingstema og behandlingstype i felles kodeverk"
     - name: KODEVERKSMAPPER_UNDERKATEGORI_URL
       value: "https://kodeverksmapper.nais.preprod.local/kodeverksmapper/mapUnderkategori"
     - name: FELLES_KODEVERK_URL
@@ -134,24 +100,14 @@ spec:
       value: "ldaps://ldapgw.preprod.local"
     - name: LDAP_USER_BASEDN
       value: "ou=NAV,ou=BusinessUnits,dc=preprod,dc=local"
-    - name: MODIABRUKERDIALOG_STANDARDTEKSTER_TILBAKEMELDING_URL
-      value: "https://navet.adeo.no/411275.cms"
     - name: PENSJON_PENSJONSAK_V1_ENDPOINTURL
       value: "https://pensjon-pen-q1.nais.preprod.local/pen/services/PensjonSak_v1"
-    - name: PENSJON_PENSJONSAK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: PENSJON_PENSJONSAK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-pensjonSak-v1-tjenestespesifikasjon/1.0.0/nav-pensjonSak-v1-tjenestespesifikasjon-1.0.0.zip"
     - name: SAF_GRAPHQL_URL
       value: "https://saf-q1.nais.preprod.local/graphql"
     - name: SAF_HENTDOKUMENT_URL
       value: "https://saf-q1.nais.preprod.local/rest/hentdokument"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SAKOGBEHANDLING_SECURITYTOKEN
-      value: "SAML"
-    - name: SAKOGBEHANDLING_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon/1.0.0-alpha011/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon-1.0.0-alpha011.zip"
     - name: SERVER_AKTIVITETSPLAN_URL
       value: "https://app-q1.adeo.no"
     - name: SERVER_ARENA_URL
@@ -174,90 +130,36 @@ spec:
       value: "https://tjenester-q1.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
-    - name: UTBETALING_V1_DESCRIPTION
-      value: "Utbetalingsoversikt"
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp-q1.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
-    - name: UTBETALING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: UTBETALING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-utbetaling-v1-tjenestespesifikasjon/1.1.3/nav-fim-utbetaling-v1-tjenestespesifikasjon-1.1.3.zip"
     - name: VEILARBOPPFOLGINGAPI_URL
       value: "https://veilarboppfolging-q1.nais.preprod.local/veilarboppfolging/api"
-    #    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_ENDPOINTURL
-    #      value: "https\://tjenestebuss-q1.adeo.no/nav-tjeneste-arbeidOgAktivitet_v1Web/sca/ArbeidOgAktivitetWSEXP"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_ENDPOINTURL
-      value: "https://service-gw-q1.preprod.local/"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_SECURITYTOKEN
-      value: "LTPA"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?r=m2internal&g=no.nav.esb.nav&a=nav-tjeneste-arbeidOgAktivitet&v=1.0.6&e=zip&c=wsdlif"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL
       value: "https://dkif.dev.adeo.no/"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=nav-digitalKontaktinformasjon-v1-tjenestespesifikasjon&e=zip&g=no.nav.tjenester.fim&r=m2internal&v=2.0.0"
     - name: VIRKSOMHET_EGENANSATT_V1_ENDPOINTURL
       value: "https://app-q1.adeo.no/tpsws-aura/ws/EgenAnsatt/v1"
-    - name: VIRKSOMHET_EGENANSATT_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_EGENANSATT_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/pip/nav-pip-egenAnsatt-v1-tjenestespesifikasjon/1.0.1/nav-pip-egenAnsatt-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_FORELDREPENGER_V2_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/infotrygd-ws/ForeldrepengerService/v2"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-foreldrepenger-v2-tjenestespesifikasjon/2.0.2/nav-foreldrepenger-v2-tjenestespesifikasjon-2.0.2.zip"
     - name: VIRKSOMHET_KODEVERK_V2_ENDPOINTURL
       value: "https://kodeverk.nais.preprod.local/ws/kodeverk/v2"
-    - name: VIRKSOMHET_KODEVERK_V2_SECURITYTOKEN
-      value: "NONE"
-    - name: VIRKSOMHET_KODEVERK_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-kodeverk-v2-tjenestespesifikasjon/2.0.0/nav-fim-kodeverk-v2-tjenestespesifikasjon-2.0.0.zip"
     - name: VIRKSOMHET_OPPFOLGING_V1_ENDPOINTURL
       value: "https://arena-q1.adeo.no/ail_ws/Oppfoelging_v1"
-    - name: VIRKSOMHET_OPPFOLGING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_OPPFOLGING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/repositories/public/no/nav/tjenester/fim/nav-fim-oppfoelging-v1-tjenestespesifikasjon/1.2.0/nav-fim-oppfoelging-v1-tjenestespesifikasjon-1.2.0.zip"
     - name: EREG_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/ereg/"
     - name: VIRKSOMHET_PERSON_V3_ENDPOINTURL
       value: "https://app-q1.adeo.no/tpsws-aura/ws/Person/v3"
-    - name: VIRKSOMHET_PERSON_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSON_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-person-v3-tjenestespesifikasjon/3.6.1/nav-person-v3-tjenestespesifikasjon-3.6.1.zip"
     - name: VIRKSOMHET_PERSONSOK_V1_ENDPOINTURL
       value: "https://app-q1.adeo.no/tpsws-aura/ws/Personsok/v1"
-    - name: VIRKSOMHET_PERSONSOK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSONSOK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-personsok-v1-tjenestespesifikasjon/1.0.1/nav-fim-personsok-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_PLEIEPENGER_V1_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/infotrygd-ws/Pleiepenger/v1"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-pleiepenger-v1-tjenestespesifikasjon/1.0.4/nav-pleiepenger-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: SAK_ENDPOINTURL
       value: "https://sak.nais.preprod.local"
     - name: VIRKSOMHET_SYKEPENGER_V2_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/infotrygd-ws/SykepengerService/v2"
-    - name: VIRKSOMHET_SYKEPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_SYKEPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-sykepenger-v2-tjenestespesifikasjon/2.0.1/nav-sykepenger-v2-tjenestespesifikasjon-2.0.1.zip"
     - name: VIRKSOMHET_YTELSESKONTRAKT_V3_ENDPOINTURL
       value: "https://arena-q1.adeo.no/ail_ws/Ytelseskontrakt_v3"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon/3.0.1/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon-3.0.1.zip"
     - name: HENVENDELSE_LES_API_URL
       value: "https://modapp-q1.adeo.no/henvendelse-les/api"
     - name: SF_HENVENDELSE_URL
@@ -272,42 +174,12 @@ spec:
       value: "https://bidrag-sak.dev.adeo.no/bidrag-sak"
     - name: NORG2_BASEURL
       value: "https://app-q1.adeo.no/norg2"
-    - name: TILLATMOCK
-      value: "true"
-    - name: VISUTBETALINGER
-      value: "true"
-    - name: DEAKTIVERAAREGLENKE
-      value: "false"
     - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
       value: "0 0 7,19 * * *"
-    - name: UTBETALINGTILGANG
-      value: "[]"
-    - name: TEMASIDER_VIKTIGAVITELENKE
-      value: "DAG,AAP,IND"
-    - name: BEHANDLINGSSTATUS_SYNLIG_ANTALLDAGER
-      value: "28"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
     - name: FJERN_SOKNADER_FOR_DATO
       value: "2014-12-09"
-    - name: TOGGLE_DIGISYFO
-      value: "true"
-    - name: VISNYEKOER
-      value: "true"
-    - name: VISDELVISESVARFUNKSJONALITET
-      value: "true"
-    - name: VISPLEIEPENGER
-      value: "true"
-    - name: ORGENHET_2_1
-      value: "true"
-    - name: VISENDRENAVNFUNKSJONALITET
-      value: "true"
-    - name: VISORGANISASJONENHETKONTAKTINFORMASJON
-      value: "true"
-    - name: FEATURE_AKTIVERPERSONRESTAPI
-      value: "true"
-    - name: FEATURE_NYTTVISITTKORT
-      value: "true"
     - name: HASTEKASSERING_TILGANG
       value: "Z992323,Z990366,Z990083,Z990351"
     - name: INTERNAL_TILGANG

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -70,56 +70,22 @@ spec:
       value: "https://abac-modia.intern.nav.no/application/authorize"
     - name: BRUKERVARSELV1_ENDPOINTURL
       value: "https://app.adeo.no/varsel/ws/Brukervarsel/v1"
-    - name: BRUKERVARSELV1_SECURITYTOKEN
-      value: "SAML"
-    - name: BRUKERVARSELV1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-brukervarsel-v1-tjenestespesifikasjon/1.0.4/nav-brukervarsel-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/BehandleHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_BEHANDLEHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenestespesifikasjoner/behandle-henvendelse/1.2019.04.04-09.14-c6cea90b8e95/behandle-henvendelse-1.2019.04.04-09.14-c6cea90b8e95.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_ENDPOINTURL
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/Henvendelse_v2"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSE_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-informasjon-v2/0.6/henvendelse-informasjon-v2-0.6.zip"
     - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_ENDPOINTURL
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/HenvendelseSoknaderService_v1"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_HENVENDELSESOKNADERSERVICE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/henvendelse-soknader-tjenestespesifikasjon/0.0.26/henvendelse-soknader-tjenestespesifikasjon-0.0.26.zip"
     - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_ENDPOINTURL
       value: "https://modapp.adeo.no/henvendelse/services/domene.Brukerdialog/SendUtHenvendelse_v1"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: DOMENE_BRUKERDIALOG_SENDUTHENVENDELSE_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/sbl/dialogarena/send-ut-henvendelse/0.7/send-ut-henvendelse-0.7.zip"
     - name: INNSYNJOURNAL_V2_ENDPOINTURL
       value: "https://dokarkiv.nais.adeo.no/services/innsynjournal/v2"
-    - name: INNSYNJOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: INNSYNJOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-innsynJournal-v2-tjenestespesifikasjon/2.0.2/nav-innsynJournal-v2-tjenestespesifikasjon-2.0.2.zip"
     - name: JOURNAL_V2_ENDPOINTURL
       value: "https://wasapp.adeo.no/joark/Journal/v2"
-    - name: JOURNAL_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: JOURNAL_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-journal-v2-tjenestespesifikasjon/1.0.3/nav-journal-v2-tjenestespesifikasjon-1.0.3.zip"
-    - name: KODEVERKSMAPPER_OPPGAVETYPE_DESCRIPTION
-      value: "Mapper fra oppgavetyper i fellessystemers kodeverk til oppgavetyper felles kodeverk"
     - name: KODEVERKSMAPPER_OPPGAVETYPE_URL
       value: "https://kodeverksmapper.nais.adeo.no/kodeverksmapper/mapOppgavetype"
-    - name: KODEVERKSMAPPER_PING_DESCRIPTION
-      value: "Ping-tjeneste som kan kalles fra konsumenters selftest"
     - name: KODEVERKSMAPPER_PING_URL
       value: "https://kodeverksmapper.nais.adeo.no/kodeverksmapper/ping"
-    - name: KODEVERKSMAPPER_UNDERKATEGORI_DESCRIPTION
-      value: "Mapper fra underkategorier i fellessystemers kodeverk til behandlingstema og behandlingstype i felles kodeverk"
     - name: KODEVERKSMAPPER_UNDERKATEGORI_URL
       value: "https://kodeverksmapper.nais.adeo.no/kodeverksmapper/mapUnderkategori"
     - name: FELLES_KODEVERK_URL
@@ -134,24 +100,14 @@ spec:
       value: "ldaps://ldapgw.adeo.no"
     - name: LDAP_USER_BASEDN
       value: "ou=NAV,ou=BusinessUnits,dc=adeo,dc=no"
-    - name: MODIABRUKERDIALOG_STANDARDTEKSTER_TILBAKEMELDING_URL
-      value: "https://navet.adeo.no/411275.cms"
     - name: PENSJON_PENSJONSAK_V1_ENDPOINTURL
       value: "https://pensjon-pen.nais.adeo.no/pen/services/PensjonSak_v1"
-    - name: PENSJON_PENSJONSAK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: PENSJON_PENSJONSAK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-pensjonSak-v1-tjenestespesifikasjon/1.0.0/nav-pensjonSak-v1-tjenestespesifikasjon-1.0.0.zip"
     - name: SAF_GRAPHQL_URL
       value: "https://saf.nais.adeo.no/graphql"
     - name: SAF_HENTDOKUMENT_URL
       value: "https://saf.nais.adeo.no/rest/hentdokument"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SAKOGBEHANDLING_SECURITYTOKEN
-      value: "SAML"
-    - name: SAKOGBEHANDLING_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon/1.0.0-alpha011/nav-fim-sakOgBehandling-v1-tjenestespesifikasjon-1.0.0-alpha011.zip"
     - name: SERVER_AKTIVITETSPLAN_URL
       value: "https://app.adeo.no"
     - name: SERVER_ARENA_URL
@@ -174,88 +130,34 @@ spec:
       value: "https://tjenester.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
-    - name: UTBETALING_V1_DESCRIPTION
-      value: "Utbetalingsoversikt"
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
-    - name: UTBETALING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: UTBETALING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-utbetaling-v1-tjenestespesifikasjon/1.1.3/nav-fim-utbetaling-v1-tjenestespesifikasjon-1.1.3.zip"
     - name: VEILARBOPPFOLGINGAPI_URL
       value: "https://veilarboppfolging.nais.adeo.no/veilarboppfolging/api"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_ENDPOINTURL
-      value: "https://service-gw.adeo.no/"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_SECURITYTOKEN
-      value: "LTPA"
-    - name: VIRKSOMHET_ARBEIDOGAKTIVITET_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?r=m2internal&g=no.nav.esb.nav&a=nav-tjeneste-arbeidOgAktivitet&v=1.0.6&e=zip&c=wsdlif"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.adeo.no/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL
       value: "https://dkif.nais.adeo.no/"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=nav-digitalKontaktinformasjon-v1-tjenestespesifikasjon&e=zip&g=no.nav.tjenester.fim&r=m2internal&v=2.0.0"
     - name: VIRKSOMHET_EGENANSATT_V1_ENDPOINTURL
       value: "https://app.adeo.no/tpsws-aura/ws/EgenAnsatt/v1"
-    - name: VIRKSOMHET_EGENANSATT_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_EGENANSATT_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/pip/nav-pip-egenAnsatt-v1-tjenestespesifikasjon/1.0.1/nav-pip-egenAnsatt-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_FORELDREPENGER_V2_ENDPOINTURL
       value: "https://modapp.adeo.no/infotrygd-ws/ForeldrepengerService/v2"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_FORELDREPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-foreldrepenger-v2-tjenestespesifikasjon/2.0.2/nav-foreldrepenger-v2-tjenestespesifikasjon-2.0.2.zip"
-    - name: VIRKSOMHET_KODEVERK_V2_ENDPOINTURL
-      value: "https://kodeverk.nais.adeo.no/ws/kodeverk/v2"
-    - name: VIRKSOMHET_KODEVERK_V2_SECURITYTOKEN
-      value: "NONE"
-    - name: VIRKSOMHET_KODEVERK_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-kodeverk-v2-tjenestespesifikasjon/2.0.0/nav-fim-kodeverk-v2-tjenestespesifikasjon-2.0.0.zip"
     - name: VIRKSOMHET_OPPFOLGING_V1_ENDPOINTURL
       value: "https://arena.adeo.no/ail_ws/Oppfoelging_v1"
-    - name: VIRKSOMHET_OPPFOLGING_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_OPPFOLGING_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/repositories/public/no/nav/tjenester/fim/nav-fim-oppfoelging-v1-tjenestespesifikasjon/1.2.0/nav-fim-oppfoelging-v1-tjenestespesifikasjon-1.2.0.zip"
     - name: EREG_ENDPOINTURL
       value: "https://modapp.adeo.no/ereg/"
     - name: VIRKSOMHET_PERSON_V3_ENDPOINTURL
       value: "https://app.adeo.no/tpsws-aura/ws/Person/v3"
-    - name: VIRKSOMHET_PERSON_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSON_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-person-v3-tjenestespesifikasjon/3.6.1/nav-person-v3-tjenestespesifikasjon-3.6.1.zip"
     - name: VIRKSOMHET_PERSONSOK_V1_ENDPOINTURL
       value: "https://app.adeo.no/tpsws-aura/ws/Personsok/v1"
-    - name: VIRKSOMHET_PERSONSOK_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PERSONSOK_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-personsok-v1-tjenestespesifikasjon/1.0.1/nav-fim-personsok-v1-tjenestespesifikasjon-1.0.1.zip"
     - name: VIRKSOMHET_PLEIEPENGER_V1_ENDPOINTURL
       value: "https://modapp.adeo.no/infotrygd-ws/Pleiepenger/v1"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_PLEIEPENGER_V1_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-pleiepenger-v1-tjenestespesifikasjon/1.0.4/nav-pleiepenger-v1-tjenestespesifikasjon-1.0.4.zip"
     - name: SAK_ENDPOINTURL
       value: "https://sak.nais.adeo.no"
     - name: VIRKSOMHET_SYKEPENGER_V2_ENDPOINTURL
       value: "https://modapp.adeo.no/infotrygd-ws/SykepengerService/v2"
-    - name: VIRKSOMHET_SYKEPENGER_V2_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_SYKEPENGER_V2_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/nav-sykepenger-v2-tjenestespesifikasjon/2.0.1/nav-sykepenger-v2-tjenestespesifikasjon-2.0.1.zip"
     - name: VIRKSOMHET_YTELSESKONTRAKT_V3_ENDPOINTURL
       value: "https://arena.adeo.no/ail_ws/Ytelseskontrakt_v3"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_SECURITYTOKEN
-      value: "SAML"
-    - name: VIRKSOMHET_YTELSESKONTRAKT_V3_WSDLURL
-      value: "http://maven.adeo.no/nexus/content/groups/public/no/nav/tjenester/fim/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon/3.0.1/nav-fim-ytelseskontrakt-v3-tjenestespesifikasjon-3.0.1.zip"
     - name: HENVENDELSE_LES_API_URL
       value: "https://modapp.adeo.no/henvendelse-les/api"
     - name: SF_HENVENDELSE_URL
@@ -270,46 +172,15 @@ spec:
       value: "https://bidrag-sak-nais.adeo.no/bidrag-sak"
     - name: NORG2_BASEURL
       value: "https://app.adeo.no/norg2"
-    - name: TILLATMOCK
-      value: "false"
-    - name: VISUTBETALINGER
-      value: "true"
-    - name: DEAKTIVERAAREGLENKE
-      value: "false"
     - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
       value: "0 0 7,19 * * *"
-    - name: UTBETALINGTILGANG
-      value: "[]"
-    - name: TEMASIDER_VIKTIGAVITELENKE
-      value: "DAG,AAP,IND"
-    - name: BEHANDLINGSSTATUS_SYNLIG_ANTALLDAGER
-      value: "28"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
     - name: FJERN_SOKNADER_FOR_DATO
       value: "2014-12-09"
-    - name: TOGGLE_DIGISYFO
-      value: "true"
-    - name: VISNYEKOER
-      value: "true"
-    - name: VISDELVISESVARFUNKSJONALITET
-      value: "true"
-    - name: VISPLEIEPENGER
-      value: "true"
-    - name: ORGENHET_2_1
-      value: "true"
-    - name: VISENDRENAVNFUNKSJONALITET
-      value: "true"
-    - name: VISORGANISASJONENHETKONTAKTINFORMASJON
-      value: "true"
-    - name: FEATURE_AKTIVERPERSONRESTAPI
-      value: "true"
-    - name: FEATURE_NYTTVISITTKORT
-      value: "true"
     - name: HASTEKASSERING_TILGANG
       value: "G110867,S111498,W152868,N127626,B152650,B152650,B114736,H110866,J121487,O122413,T110884,V114843,E110861,U136854"
     - name: INTERNAL_TILGANG
       value: ""
     - name: CXF_SECURE_LOG
       value: "enabled"
-


### PR DESCRIPTION
fjerner env-variabler som er ubrukt, og samtidig securitytoken/wsdlurl attributtene siden vi aldri har tatt ibruk disse etter migrering til nais
