### PR TITLE
[KAIZEN-0] ikke hente navkontor for utenlandsk gt

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgApi.kt
@@ -17,6 +17,7 @@ import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.models.*
 import no.nav.modiapersonoversikt.legacy.api.utils.RestConstants
 import no.nav.modiapersonoversikt.service.kodeverksmapper.domain.Behandling
 import no.nav.modiapersonoversikt.utils.Retry
+import no.nav.modiapersonoversikt.utils.isNumeric
 import okhttp3.OkHttpClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -119,10 +120,17 @@ class NorgApiImpl(
     override fun finnNavKontor(geografiskTilknytning: String, diskresjonskode: NorgDomain.DiskresjonsKode?): Enhet? {
         val key = "finnNavKontor[$geografiskTilknytning,$diskresjonskode]"
         return navkontorCache.get(key) {
-            enhetApi.getEnhetByGeografiskOmraadeUsingGET(
-                geografiskOmraade = geografiskTilknytning,
-                disk = diskresjonskode?.name
-            ).let(::toInternalDomain)
+            if (geografiskTilknytning.isNumeric()) {
+                enhetApi.getEnhetByGeografiskOmraadeUsingGET(
+                    geografiskOmraade = geografiskTilknytning,
+                    disk = diskresjonskode?.name
+                ).let(::toInternalDomain)
+            } else {
+                /**
+                 * Ikke numerisk GT tilsier at det er landkode pga utenlandsk GT og da har vi ingen enhet
+                 */
+                null
+            }
         }
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/utils/KotlinUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/utils/KotlinUtils.kt
@@ -1,0 +1,3 @@
+package no.nav.modiapersonoversikt.utils
+
+fun String.isNumeric(): Boolean = toIntOrNull()?.let { true } ?: false


### PR DESCRIPTION
Ikke numerisk GT tilsier at det er landkode pga utenlandsk GT og da har vi ingen enhet
