### PR TITLE
[OPP-1197] splitte navn-søk i egne felter

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
@@ -1,9 +1,10 @@
 package no.nav.modiapersonoversikt.legacy.api.service.pdl
 
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.*
+import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.SokKriterieRule.*
 
 interface PdlOppslagService {
-    fun sokPerson(kriterier: List<SokKriterier>): List<SokPerson.PersonSearchHit>
+    fun sokPerson(kriterier: List<PdlKriterie>): List<SokPerson.PersonSearchHit>
     fun hentPerson(fnr: String): HentPerson.Person?
     fun hentPersondata(fnr: String): HentPersondata.Person?
     fun hentTredjepartspersondata(fnrs: List<String>): List<HentTredjepartspersondata.HentPersonBolkResult>
@@ -16,31 +17,39 @@ interface PdlOppslagService {
     enum class SokKriterieRule {
         EQUALS,
         CONTAINS,
+        FUZZY_MATCH,
         AFTER,
         BEFORE
     }
 
-    enum class PdlSokbareFelt(val feltnavn: String, val rule: SokKriterieRule) {
-        NAVN("fritekst.navn", SokKriterieRule.CONTAINS),
-        ADRESSE("fritekst.adresser", SokKriterieRule.CONTAINS),
-        UTENLANDSK_ID("person.utenlandskIdentifikasjonsnummer.identifikasjonsnummer", SokKriterieRule.EQUALS),
-        FODSELSDATO_FRA("person.foedsel.foedselsdato", SokKriterieRule.AFTER),
-        FODSELSDATO_TIL("person.foedsel.foedselsdato", SokKriterieRule.BEFORE),
-        KJONN("person.kjoenn.kjoenn", SokKriterieRule.EQUALS)
+    enum class PdlFelt(val feltnavn: String, val rule: SokKriterieRule) {
+        NAVN("fritekst.navn", CONTAINS),
+        FORNAVN("person.navn.fornavn", FUZZY_MATCH),
+        ETTERNAVN("person.navn.etternavn", FUZZY_MATCH),
+        MELLOMNAVN("person.navn.mellomnavn", FUZZY_MATCH),
+        ADRESSE("fritekst.adresser", CONTAINS),
+        UTENLANDSK_ID("person.utenlandskIdentifikasjonsnummer.identifikasjonsnummer", EQUALS),
+        FODSELSDATO_FRA("person.foedsel.foedselsdato", AFTER),
+        FODSELSDATO_TIL("person.foedsel.foedselsdato", BEFORE),
+        KJONN("person.kjoenn.kjoenn", EQUALS)
     }
-
-    data class SokKriterier(val felt: PdlSokbareFelt, val value: String?) {
+    data class PdlKriterie(
+        val felt: PdlFelt,
+        val value: String?,
+        val boost: Float? = null
+    ) {
         fun asCriterion() =
-            if (this.value == null) {
+            if (value == null) {
                 null
             } else {
                 SokPerson.Criterion(
-                    fieldName = this.felt.feltnavn,
-                    searchRule = when (this.felt.rule) {
-                        SokKriterieRule.EQUALS -> SokPerson.SearchRule(equals = this.value)
-                        SokKriterieRule.CONTAINS -> SokPerson.SearchRule(contains = this.value)
-                        SokKriterieRule.AFTER -> SokPerson.SearchRule(after = this.value)
-                        SokKriterieRule.BEFORE -> SokPerson.SearchRule(before = this.value)
+                    fieldName = felt.feltnavn,
+                    searchRule = when (felt.rule) {
+                        EQUALS -> SokPerson.SearchRule(equals = this.value, boost = boost)
+                        CONTAINS -> SokPerson.SearchRule(contains = this.value, boost = boost)
+                        FUZZY_MATCH -> SokPerson.SearchRule(fuzzy = this.value, boost = boost)
+                        AFTER -> SokPerson.SearchRule(after = this.value, boost = boost)
+                        BEFORE -> SokPerson.SearchRule(before = this.value, boost = boost)
                     }
                 )
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
@@ -9,8 +9,8 @@ import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.SokPerson
 import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService
-import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.PdlSokbareFelt
-import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.SokKriterier
+import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.PdlFelt
+import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.PdlKriterie
 import no.nav.modiapersonoversikt.rest.lagXmlGregorianDato
 import no.nav.modiapersonoversikt.service.unleash.Feature
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
@@ -97,8 +97,8 @@ class PersonsokController @Autowired constructor(
                 pdlOppslagService
                     .sokPerson(
                         listOf(
-                            SokKriterier(
-                                PdlSokbareFelt.UTENLANDSK_ID,
+                            PdlKriterie(
+                                PdlFelt.UTENLANDSK_ID,
                                 personsokRequest.utenlandskID
                             )
                         )
@@ -465,8 +465,7 @@ data class PersonsokRequest(
     val postnummer: String?
 )
 
-fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): List<SokKriterier> {
-    val navn = listOf(this.fornavn, this.etternavn).joinNotNullToString(" ")
+fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): List<PdlKriterie> {
     val adresse = listOf(this.gatenavn, this.husnummer, this.husbokstav, this.postnummer, this.kommunenummer).joinNotNullToString(" ")
     val fodselsdatoFra = this.fodselsdatoFra ?: this.alderTil?.let { finnSenesteDatoGittAlder(it, clock) }
     val fodselsdatoTil = this.fodselsdatoTil ?: this.alderFra?.let { finnTidligsteDatoGittAlder(it, clock) }
@@ -477,12 +476,14 @@ fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): 
     }
 
     return listOf(
-        SokKriterier(PdlSokbareFelt.NAVN, navn),
-        SokKriterier(PdlSokbareFelt.ADRESSE, adresse),
-        SokKriterier(PdlSokbareFelt.UTENLANDSK_ID, this.utenlandskID),
-        SokKriterier(PdlSokbareFelt.FODSELSDATO_FRA, fodselsdatoFra),
-        SokKriterier(PdlSokbareFelt.FODSELSDATO_TIL, fodselsdatoTil),
-        SokKriterier(PdlSokbareFelt.KJONN, kjonn)
+        PdlKriterie(PdlFelt.FORNAVN, this.fornavn, 1.5f),
+        PdlKriterie(PdlFelt.ETTERNAVN, this.etternavn, 1.5f),
+        PdlKriterie(PdlFelt.MELLOMNAVN, this.etternavn, 1.0f),
+        PdlKriterie(PdlFelt.ADRESSE, adresse),
+        PdlKriterie(PdlFelt.UTENLANDSK_ID, this.utenlandskID),
+        PdlKriterie(PdlFelt.FODSELSDATO_FRA, fodselsdatoFra),
+        PdlKriterie(PdlFelt.FODSELSDATO_TIL, fodselsdatoTil),
+        PdlKriterie(PdlFelt.KJONN, kjonn)
     )
 }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceImpl.kt
@@ -87,7 +87,7 @@ open class PdlOppslagServiceImpl constructor(
     override fun hentAktorId(fnr: String): String? = hentAktivIdent(fnr, IdentGruppe.AKTORID)
     override fun hentFnr(aktorid: String): String? = hentAktivIdent(aktorid, IdentGruppe.FOLKEREGISTERIDENT)
 
-    override fun sokPerson(kriterier: List<SokKriterier>): List<SokPerson.PersonSearchHit> = runBlocking {
+    override fun sokPerson(kriterier: List<PdlKriterie>): List<SokPerson.PersonSearchHit> = runBlocking {
         val paging = SokPerson.Paging(
             pageNumber = 1,
             resultsPerPage = 30

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/person/PersonsokControllerTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/person/PersonsokControllerTest.kt
@@ -1,8 +1,7 @@
 package no.nav.modiapersonoversikt.rest.person
 
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.SokPerson
-import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.PdlSokbareFelt
-import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.SokKriterier
+import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService.*
 import no.nav.modiapersonoversikt.testutils.SnapshotExtension
 import no.nav.tjeneste.virksomhet.personsoek.v1.informasjon.*
 import org.assertj.core.api.Assertions.assertThat
@@ -201,25 +200,14 @@ class PersonsokControllerTest {
         )
 
         @Test
-        internal fun `samler navne-felt til ett felt`() {
+        internal fun `boosting for prioritering av etternavn`() {
             val kriterier = request
                 .copy(fornavn = "Fornavn", etternavn = "Etternavn")
                 .tilPdlKriterier(clock)
 
-            assertThat(kriterier).contains(SokKriterier(PdlSokbareFelt.NAVN, "Fornavn Etternavn"))
-        }
-
-        @Test
-        internal fun `filtrerer bort navne-felt som er null`() {
-            val bareFornavn = request
-                .copy(fornavn = "Fornavn")
-                .tilPdlKriterier(clock)
-            val bareEtternavn = request
-                .copy(etternavn = "Etternavn")
-                .tilPdlKriterier(clock)
-
-            assertThat(bareFornavn).contains(SokKriterier(PdlSokbareFelt.NAVN, "Fornavn"))
-            assertThat(bareEtternavn).contains(SokKriterier(PdlSokbareFelt.NAVN, "Etternavn"))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.FORNAVN, "Fornavn", 1.5f))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.ETTERNAVN, "Etternavn", 1.5f))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.MELLOMNAVN, "Etternavn", 1.0f))
         }
 
         @Test
@@ -233,7 +221,7 @@ class PersonsokControllerTest {
                 )
                 .tilPdlKriterier(clock)
 
-            assertThat(kriterier).contains(SokKriterier(PdlSokbareFelt.ADRESSE, "Gatenavn 1 A 0100"))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.ADRESSE, "Gatenavn 1 A 0100"))
         }
 
         @Test
@@ -242,7 +230,7 @@ class PersonsokControllerTest {
                 .copy(alderFra = 30)
                 .tilPdlKriterier(clock)
 
-            assertThat(kriterier).contains(SokKriterier(PdlSokbareFelt.FODSELSDATO_TIL, "1990-12-02"))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.FODSELSDATO_TIL, "1990-12-02"))
         }
 
         @Test
@@ -251,7 +239,7 @@ class PersonsokControllerTest {
                 .copy(alderTil = 32)
                 .tilPdlKriterier(clock)
 
-            assertThat(kriterier).contains(SokKriterier(PdlSokbareFelt.FODSELSDATO_FRA, "1987-12-03"))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.FODSELSDATO_FRA, "1987-12-03"))
         }
 
         @Test
@@ -260,19 +248,19 @@ class PersonsokControllerTest {
                 .copy(kjonn = "M")
                 .tilPdlKriterier(clock)
 
-            assertThat(mann).contains(SokKriterier(PdlSokbareFelt.KJONN, "MANN"))
+            assertThat(mann).contains(PdlKriterie(PdlFelt.KJONN, "MANN"))
 
             val kvinne = request
                 .copy(kjonn = "K")
                 .tilPdlKriterier(clock)
 
-            assertThat(kvinne).contains(SokKriterier(PdlSokbareFelt.KJONN, "KVINNE"))
+            assertThat(kvinne).contains(PdlKriterie(PdlFelt.KJONN, "KVINNE"))
 
             val ukjent = request
                 .copy(kjonn = "U")
                 .tilPdlKriterier(clock)
 
-            assertThat(ukjent).contains(SokKriterier(PdlSokbareFelt.KJONN, null))
+            assertThat(ukjent).contains(PdlKriterie(PdlFelt.KJONN, null))
         }
 
         val request = PersonsokRequest(


### PR DESCRIPTION
Vi har informasjon om fornavn vs etternavn fra frontend-koden, og kan derfor gjøre søket litt bedre med å ikke blande disse sammen før vi sender det til PDL.

Vi kan med dette unngå at søk på Aremark Testfamilien returnerer folk med "***mark" til etternavn osv.
