### PR TITLE
[KAIZEN-0] legge til redis-caffeine-cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <mockito.version>2.25.0</mockito.version>
         <mockito-kotlin.version>2.2.0</mockito-kotlin.version>
         <mockk-version>1.9.3</mockk-version>
+        <jedis.version>4.0.1</jedis.version>
         <spotify.logging.version>2.2.2</spotify.logging.version>
 
         <!-- Tjenestespecs -->
@@ -101,6 +102,12 @@
                 <artifactId>tilgangskontroll</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>redis.clients</groupId>
+                <artifactId>jedis</artifactId>
+                <version>${jedis.version}</version>
+            </dependency>
+
 
             <!--Kontrakter-->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,13 @@
                 <groupId>com.natpryce</groupId>
                 <artifactId>hamkrest</artifactId>
                 <version>${hamkrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>1.16.2</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- kjerneinfo/personsok -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -382,6 +382,12 @@
             <version>1.3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -250,6 +250,11 @@
             <artifactId>unleash-client-java</artifactId>
             <version>3.2.2</version>
         </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+
 
         <!-- tjenester -->
         <dependency>

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.java
@@ -47,8 +47,7 @@ public class CacheConfig {
                 cache("varslingCache", 180, 10_000),
                 cache("kodeverksmapperCache", 86400),
                 cache("innsynJournalCache", 1800, 10_000),
-                cache("pesysCache", 600),
-                redisCache("test", new TypeReference<String>() {}, 3600, 1000, true)
+                cache("pesysCache", 600)
         ));
 
         return cacheManager;

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.java
@@ -47,7 +47,8 @@ public class CacheConfig {
                 cache("varslingCache", 180, 10_000),
                 cache("kodeverksmapperCache", 86400),
                 cache("innsynJournalCache", 1800, 10_000),
-                cache("pesysCache", 600)
+                cache("pesysCache", 600),
+                redisCache("test", new TypeReference<String>() {}, 3600, 1000, true)
         ));
 
         return cacheManager;
@@ -81,7 +82,7 @@ public class CacheConfig {
         CaffeineCache localCache = cache(name, time, maximumSize, allowNullValues);
         return new RedisCaffeineCache<>(new RedisCaffeineCache.Config<>(
                 name,
-                HostAndPort.from(""),
+                HostAndPort.from("localhost:6379"),
                 Duration.ofSeconds(time),
                 localCache,
                 valueType,

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/RedisCaffeineCache.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/RedisCaffeineCache.kt
@@ -1,0 +1,111 @@
+package no.nav.modiapersonoversikt.infrastructure.cache.redis
+
+import com.fasterxml.jackson.core.type.TypeReference
+import no.nav.modiapersonoversikt.config.JacksonConfig
+import org.springframework.cache.Cache
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.AbstractValueAdaptingCache
+import redis.clients.jedis.HostAndPort
+import redis.clients.jedis.Jedis
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.locks.ReentrantLock
+
+@Suppress("UNCHECKED_CAST")
+class RedisCaffeineCache<T>(
+    val config: Config<T>
+) : AbstractValueAdaptingCache(config.allowNullValues) {
+    data class Config<T>(
+        val name: String,
+        val hostAndPort: HostAndPort,
+        val expiry: Duration?,
+        val localCache: CaffeineCache,
+        val type: TypeReference<T>,
+        val allowNullValues: Boolean
+    )
+    data class CacheMessage(val cacheName: String, val value: Any?)
+    private val lock = ReentrantLock()
+    private val jedis = Jedis(config.hostAndPort)
+    private val mapper = JacksonConfig.mapper
+
+    override fun getName(): String = config.name
+
+    override fun getNativeCache(): RedisCaffeineCache<T> = this
+
+    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
+        var value: Any? = lookup(key)
+        if (value != null) {
+            return value as T
+        }
+        try {
+            lock.lock()
+            value = lookup(key)
+            if (value != null) {
+                return value as T
+            }
+            value = valueLoader.call()
+            put(key, toStoreValue(value))
+            return value
+        } catch (e: Exception) {
+            throw Cache.ValueRetrievalException(key, valueLoader, e)
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    override fun put(key: Any, value: Any?) {
+        if (!config.allowNullValues && value == null) {
+            evict(key)
+        } else {
+            val expire = config.expiry?.seconds ?: -1
+            if (expire > 0) {
+                jedis.setex(serialize(key), expire, serialize(value))
+            } else {
+                jedis.set(serialize(key), serialize(value))
+            }
+
+            push(CacheMessage(config.name, key))
+            config.localCache.put(key, value)
+        }
+    }
+
+    override fun putIfAbsent(key: Any, value: Any?): Cache.ValueWrapper? {
+        return super.putIfAbsent(key, value)
+    }
+
+    override fun evict(key: Any) {
+        jedis.del(serialize(key))
+        config.localCache.evict(key)
+    }
+
+    override fun clear() {
+        val keys: Set<String> = jedis.keys("*")
+        jedis.del(*keys.toTypedArray())
+        push(CacheMessage(config.name, null))
+        config.localCache.clear()
+    }
+
+    override fun lookup(key: Any): Any? {
+        var value: Any? = config.localCache.get(key)
+        if (value != null) {
+            return value
+        }
+        value = deserialize(jedis.get(serialize(key)))
+        if (value != null) {
+            config.localCache.put(key, value)
+        }
+        return value
+    }
+
+    private fun push(message: CacheMessage) {
+        jedis.publish("cache-change", serialize(message))
+    }
+
+    private fun serialize(value: Any?): String {
+        return mapper.writeValueAsString(value)
+    }
+
+    private fun deserialize(value: String): T {
+        return mapper.readValue(value, config.type)
+    }
+}

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/RedisCaffeineCacheTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/RedisCaffeineCacheTest.kt
@@ -1,0 +1,77 @@
+package no.nav.modiapersonoversikt.infrastructure.cache.redis
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.caffeine.CaffeineCache
+import java.time.Duration
+
+data class CacheData(val id: Long, val name: String)
+data class CacheKey(val id: Long)
+
+internal class RedisCaffeineCacheTest : TestUtils.WithRedis {
+    val testCache = createRedisCache("test-cache", Duration.ofSeconds(2))
+    val otherCache = createRedisCache("other-cache", Duration.ofSeconds(2))
+
+    @Test
+    internal fun `skal lagre cache verdi i begge cachene`() = runBlocking {
+        val (cache, caffeine) = testCache
+        val (otherCache, otherCaffeine) = otherCache
+        val key = CacheKey(1)
+
+        cache.get(key) { CacheData(1, "data") }
+        cache.get(key) { CacheData(1, "data") }
+        otherCache.get(key) { CacheData(1, "data") }
+        otherCache.get(key) { CacheData(1, "data") }
+
+        assertThat(caffeine.estimatedSize()).isEqualTo(1)
+        assertThat(otherCaffeine.estimatedSize()).isEqualTo(1)
+        assertThat(getRedisKeys("*")).hasSize(2)
+        assertThat(getRedisKeys("test-cache:*")).hasSize(1)
+        assertThat(getRedisKeys("other-cache:*")).hasSize(1)
+
+        cache.clear()
+
+        assertThat(caffeine.estimatedSize()).isEqualTo(0)
+        assertThat(otherCaffeine.estimatedSize()).isEqualTo(1)
+        assertThat(getRedisKeys("*")).hasSize(1)
+        assertThat(getRedisKeys("test-cache:*")).hasSize(0)
+        assertThat(getRedisKeys("other-cache:*")).hasSize(1)
+
+        delay(2500)
+        caffeine.cleanUp()
+        otherCaffeine.cleanUp()
+
+        assertThat(caffeine.estimatedSize()).isEqualTo(0)
+        assertThat(otherCaffeine.estimatedSize()).isEqualTo(0)
+        assertThat(getRedisKeys("*")).hasSize(0)
+        assertThat(getRedisKeys("test-cache:*")).hasSize(0)
+        assertThat(getRedisKeys("other-cache:*")).hasSize(0)
+
+        Unit
+    }
+
+    fun createRedisCache(cacheName: String, expiry: Duration): Pair<RedisCaffeineCache<CacheData>, Cache<Any?, Any?>> {
+        val caffeine: Cache<Any?, Any?> = Caffeine
+            .newBuilder()
+            .expireAfterAccess(expiry)
+            .expireAfterWrite(expiry)
+            .build()
+        val cache = RedisCaffeineCache(
+            RedisCaffeineCache.Config(
+                name = cacheName,
+                hostAndPort = redisHostAndPort(),
+                expiry = expiry,
+                localCache = CaffeineCache(cacheName, caffeine, true),
+                type = object : TypeReference<CacheData>() {},
+                allowNullValues = true
+            )
+        )
+
+        return cache to caffeine
+    }
+}

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/TestUtils.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/cache/redis/TestUtils.kt
@@ -1,0 +1,119 @@
+package no.nav.modiapersonoversikt.infrastructure.cache.redis
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.testcontainers.containers.GenericContainer
+import redis.clients.jedis.HostAndPort
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPubSub
+import java.time.Duration
+import java.util.*
+
+object TestUtils {
+
+    class RedisContainer : GenericContainer<RedisContainer>("redis:6-alpine") {
+        init {
+            withExposedPorts(6379)
+        }
+    }
+
+    class RedisSubscriber(private val subscribeCallback: () -> Unit = {}) : JedisPubSub() {
+        private val messages: MutableList<Pair<String, String>> = mutableListOf()
+        private val lock = WaitLock(false)
+
+        override fun onPMessage(pattern: String, channel: String, message: String) {
+            val messagePair = Pair(channel, message)
+            messages.add(messagePair)
+            if (messagePair == lock.keyOwner) {
+                lock.unlock(messagePair)
+            }
+        }
+
+        override fun onPSubscribe(pattern: String?, subscribedChannels: Int) {
+            subscribeCallback()
+        }
+
+        suspend fun assertReceivedMessage(channel: String, message: String) {
+            val messagePair = Pair(channel, message)
+            if (!messages.contains(messagePair)) {
+                lock.lock(messagePair)
+                lock.waitForUnlock()
+            }
+        }
+    }
+
+    interface WithRedis {
+        companion object {
+            private var job: Job? = null
+            private var subscriber: RedisSubscriber? = null
+            private val container = RedisContainer()
+
+            @BeforeAll
+            @JvmStatic
+            fun startContainer() {
+                container.start()
+            }
+
+            @AfterAll
+            @JvmStatic
+            fun stopContainer() {
+                container.stop()
+            }
+        }
+
+        @BeforeEach
+        fun setupSubscriber() = runBlocking {
+            val lock = WaitLock(true)
+            subscriber = RedisSubscriber { lock.unlock() }
+            val jedis = Jedis(redisHostAndPort())
+            job = GlobalScope.launch {
+                jedis.psubscribe(subscriber, "*")
+            }
+            lock.waitForUnlock()
+        }
+
+        @AfterEach
+        fun closeSubscriber() {
+            subscriber?.unsubscribe()
+            job?.cancel()
+            subscriber = null
+            job = null
+        }
+
+        fun redisHostAndPort() = HostAndPort(container.host, container.getMappedPort(6379))
+
+        fun getRedisValue(key: String): String = Jedis(redisHostAndPort()).get(key)
+        fun getRedisKeys(pattern: String): List<String> = Jedis(redisHostAndPort()).keys(pattern).toList()
+
+        suspend fun assertReceivedMessage(channel: String, message: String, timeout: Duration = Duration.ofSeconds(1)) {
+            withTimeout(timeout.toMillis()) {
+                subscriber?.assertReceivedMessage(channel, message)
+            }
+        }
+    }
+
+    class WaitLock(initiallyLocked: Boolean = false) {
+        private val mutex = Mutex(initiallyLocked)
+        var keyOwner: Any? = null
+
+        suspend fun lock(key: Any? = null) {
+            mutex.lock(key)
+            keyOwner = key
+        }
+
+        fun unlock(key: Any? = null) {
+            mutex.unlock(key)
+            keyOwner = null
+        }
+
+        suspend fun waitForUnlock() {
+            val key = UUID.randomUUID()
+            lock(key)
+            unlock(key)
+        }
+    }
+}


### PR DESCRIPTION
RedisCaffeinceCache er en to-tiered cache som bruker redis som distribuert cache.

På sikt kan vi se at dette kan brukes for semi-statiske data slik at prodsetting på dagtid ikke fører til at alle cacher blir tomme som beskrevet i https://jira.adeo.no/browse/OPP-1342
