### PR TITLE
[OPP-1197] bytte tilbake til fritekst.navn og fuzzy-matching

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
@@ -39,7 +39,7 @@ interface PdlOppslagService {
         val boost: Float? = null
     ) {
         fun asCriterion() =
-            if (value == null) {
+            if (value.isNullOrEmpty()) {
                 null
             } else {
                 SokPerson.Criterion(

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/api/service/pdl/PdlOppslagService.kt
@@ -23,7 +23,7 @@ interface PdlOppslagService {
     }
 
     enum class PdlFelt(val feltnavn: String, val rule: SokKriterieRule) {
-        NAVN("fritekst.navn", CONTAINS),
+        NAVN("fritekst.navn", FUZZY_MATCH),
         FORNAVN("person.navn.fornavn", FUZZY_MATCH),
         ETTERNAVN("person.navn.etternavn", FUZZY_MATCH),
         MELLOMNAVN("person.navn.mellomnavn", FUZZY_MATCH),

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
@@ -466,6 +466,7 @@ data class PersonsokRequest(
 )
 
 fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): List<PdlKriterie> {
+    val navn = listOf(this.fornavn, this.etternavn).joinNotNullToString(" ")
     val adresse = listOf(this.gatenavn, this.husnummer, this.husbokstav, this.postnummer, this.kommunenummer).joinNotNullToString(" ")
     val fodselsdatoFra = this.fodselsdatoFra ?: this.alderTil?.let { finnSenesteDatoGittAlder(it, clock) }
     val fodselsdatoTil = this.fodselsdatoTil ?: this.alderFra?.let { finnTidligsteDatoGittAlder(it, clock) }
@@ -476,9 +477,7 @@ fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): 
     }
 
     return listOf(
-        PdlKriterie(PdlFelt.FORNAVN, this.fornavn, 1.5f),
-        PdlKriterie(PdlFelt.ETTERNAVN, this.etternavn, 1.5f),
-        PdlKriterie(PdlFelt.MELLOMNAVN, this.etternavn, 1.0f),
+        PdlKriterie(PdlFelt.NAVN, navn),
         PdlKriterie(PdlFelt.ADRESSE, adresse),
         PdlKriterie(PdlFelt.UTENLANDSK_ID, this.utenlandskID),
         PdlKriterie(PdlFelt.FODSELSDATO_FRA, fodselsdatoFra),

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/person/PersonsokController.kt
@@ -466,8 +466,8 @@ data class PersonsokRequest(
 )
 
 fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): List<PdlKriterie> {
-    val navn = listOf(this.fornavn, this.etternavn).joinNotNullToString(" ")
-    val adresse = listOf(this.gatenavn, this.husnummer, this.husbokstav, this.postnummer, this.kommunenummer).joinNotNullToString(" ")
+    val navn = listOfNotNull(this.fornavn, this.etternavn).joinToString(" ")
+    val adresse = listOfNotNull(this.gatenavn, this.husnummer, this.husbokstav, this.postnummer, this.kommunenummer).joinToString(" ")
     val fodselsdatoFra = this.fodselsdatoFra ?: this.alderTil?.let { finnSenesteDatoGittAlder(it, clock) }
     val fodselsdatoTil = this.fodselsdatoTil ?: this.alderFra?.let { finnTidligsteDatoGittAlder(it, clock) }
     val kjonn = when (this.kjonn) {
@@ -486,19 +486,10 @@ fun PersonsokRequest.tilPdlKriterier(clock: Clock = Clock.systemDefaultZone()): 
     )
 }
 
-fun finnSenesteDatoGittAlder(alderTil: Int, clock: Clock): String {
+private fun finnSenesteDatoGittAlder(alderTil: Int, clock: Clock): String {
     return LocalDate.now(clock).minusYears(alderTil.toLong() + 1).plusDays(1).toString()
 }
 
-fun finnTidligsteDatoGittAlder(alderFra: Int, clock: Clock): String {
+private fun finnTidligsteDatoGittAlder(alderFra: Int, clock: Clock): String {
     return LocalDate.now(clock).minusYears(alderFra.toLong()).toString()
-}
-
-private fun <T : Any> Iterable<T?>.joinNotNullToString(delimiter: String): String? {
-    val nonNullElement = this.filterNotNull()
-    return if (nonNullElement.isEmpty()) {
-        null
-    } else {
-        nonNullElement.joinToString(delimiter)
-    }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/person/PersonsokControllerTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/person/PersonsokControllerTest.kt
@@ -200,14 +200,25 @@ class PersonsokControllerTest {
         )
 
         @Test
-        internal fun `boosting for prioritering av etternavn`() {
+        internal fun `samler navne-felt til ett felt`() {
             val kriterier = request
                 .copy(fornavn = "Fornavn", etternavn = "Etternavn")
                 .tilPdlKriterier(clock)
 
-            assertThat(kriterier).contains(PdlKriterie(PdlFelt.FORNAVN, "Fornavn", 1.5f))
-            assertThat(kriterier).contains(PdlKriterie(PdlFelt.ETTERNAVN, "Etternavn", 1.5f))
-            assertThat(kriterier).contains(PdlKriterie(PdlFelt.MELLOMNAVN, "Etternavn", 1.0f))
+            assertThat(kriterier).contains(PdlKriterie(PdlFelt.NAVN, "Fornavn Etternavn"))
+        }
+
+        @Test
+        internal fun `filtrerer bort navne-felt som er null`() {
+            val bareFornavn = request
+                .copy(fornavn = "Fornavn")
+                .tilPdlKriterier(clock)
+            val bareEtternavn = request
+                .copy(etternavn = "Etternavn")
+                .tilPdlKriterier(clock)
+
+            assertThat(bareFornavn).contains(PdlKriterie(PdlFelt.NAVN, "Fornavn"))
+            assertThat(bareEtternavn).contains(PdlKriterie(PdlFelt.NAVN, "Etternavn"))
         }
 
         @Test


### PR DESCRIPTION
ved bruk av fuzzy (vs tidligere contains) får man for "aremark tesfamilien" bare en respons (som ved TPS-søk).
