### PR TITLE
[OPP-1378] flytte bid-hack håndtering for sf

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/SFJournalforing.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/SFJournalforing.kt
@@ -14,22 +14,12 @@ class SFJournalforing @Autowired constructor(
     }
 
     override fun knyttTilSak(fnr: String, traadId: String, sak: Sak, enhet: String) {
-        if (sak.fagsystemKode == Sak.BIDRAG_MARKOR || sak.temaKode == Sak.BIDRAG_MARKOR) {
-            sfHenvendelseService.journalforHenvendelse(
-                enhet = enhet,
-                kjedeId = traadId,
-                saksTema = "BID",
-                fagsakSystem = Sak.FAGSYSTEMKODE_BIDRAG,
-                saksId = null
-            )
-        } else {
-            sfHenvendelseService.journalforHenvendelse(
-                enhet = enhet,
-                kjedeId = traadId,
-                saksTema = sak.temaKode,
-                fagsakSystem = sak.fagsystemKode,
-                saksId = sak.fagsystemSaksId
-            )
-        }
+        sfHenvendelseService.journalforHenvendelse(
+            enhet = enhet,
+            kjedeId = traadId,
+            saksTema = sak.temaKode,
+            fagsakSystem = sak.fagsystemKode,
+            saksId = sak.fagsystemSaksId
+        )
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
+import no.nav.modiapersonoversikt.legacy.api.domain.saker.Sak
 import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.apis.*
 import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.infrastructure.*
 import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.models.*
@@ -108,6 +109,16 @@ class SfHenvendelseServiceImpl(
     }
 
     override fun journalforHenvendelse(enhet: String, kjedeId: String, saksTema: String, saksId: String?, fagsakSystem: String?) {
+        if (fagsakSystem == Sak.BIDRAG_MARKOR || saksTema == Sak.BIDRAG_MARKOR) {
+            // Fikser opp i bidrags-hack verdier, og kaller metoden på nytt
+            return journalforHenvendelse(
+                enhet = enhet,
+                kjedeId = kjedeId,
+                saksTema = "BID",
+                fagsakSystem = Sak.FAGSYSTEMKODE_BIDRAG,
+                saksId = null
+            )
+        }
         val fagsaksystem = if (saksId != null) {
             JournalRequestDTO.Fagsaksystem.valueOf(
                 requireNotNull(fagsakSystem) {


### PR DESCRIPTION
Journalføring kan skje fra dialog-controller og journalforingscontroller, for å slippe å håndtere bid-hack begge steder flyttes det inn til SfHenvendelseService
