### PR TITLE
[OPP-1417] erstatte kodeverksmapper for arbeidsfordeling

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/enhet/EnhetController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/enhet/EnhetController.kt
@@ -66,4 +66,23 @@ constructor(
                 )
             }
     }
+
+    @GetMapping("/oppgavebehandlere/v2/foreslatte")
+    fun hentBehandlendeEnhetV2(
+        @RequestParam("fnr") fnr: String,
+        @RequestParam("temakode") temakode: String,
+        @RequestParam("typekode") typekode: String,
+        @RequestParam("underkategori") underkategorikode: String?
+    ): List<NorgDomain.Enhet> {
+        return tilgangskontroll
+            .check(Policies.tilgangTilBruker.with(fnr))
+            .get(Audit.describe(READ, Enhet.Foreslatte)) {
+                arbeidsfordeling.hentBehandlendeEnheterV2(
+                    brukerIdent = Fnr.of(fnr),
+                    fagomrade = temakode,
+                    oppgavetype = typekode,
+                    underkategori = underkategorikode
+                )
+            }
+    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -9,10 +9,18 @@ import no.nav.modiapersonoversikt.consumer.norg.NorgDomain.EnhetGeografiskTilkny
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.egenansatt.EgenAnsattService
 import no.nav.modiapersonoversikt.rest.persondata.PersondataService
 import no.nav.modiapersonoversikt.service.kodeverksmapper.domain.Behandling
+import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.mapUnderkategori
 import org.slf4j.LoggerFactory
 
 interface ArbeidsfordelingService {
     fun hentBehandlendeEnheter(
+        fagomrade: String?,
+        oppgavetype: String?,
+        brukerIdent: Fnr?,
+        underkategori: String?
+    ): List<NorgDomain.Enhet>
+
+    fun hentBehandlendeEnheterV2(
         fagomrade: String?,
         oppgavetype: String?,
         brukerIdent: Fnr?,
@@ -41,6 +49,31 @@ class ArbeidsfordelingServiceImpl(
         return runCatching {
             val mappedOppgaveType = kodeverksmapper.hentOppgavetype()[oppgavetype]
             val behandling: Behandling? = kodeverksmapper.hentUnderkategori()[underkategori]
+            val parsedUnderkategori = parseUnderkategori(behandling)
+            hentBehandlendeEnheterV2(
+                fagomrade = fagomrade,
+                oppgavetype = mappedOppgaveType,
+                brukerIdent = brukerIdent,
+                underkategori = parsedUnderkategori
+            )
+        }
+            .getOrElse {
+                log.error("Kunne ikke hente behandlende enheter", it)
+                throw ArbeidsfordelingService.ArbeidsfordelingException(
+                    "Kunne ikke hente behandlende enheter",
+                    it
+                )
+            }
+    }
+
+    override fun hentBehandlendeEnheterV2(
+        fagomrade: String?,
+        oppgavetype: String?,
+        brukerIdent: Fnr?,
+        underkategori: String?
+    ): List<NorgDomain.Enhet> {
+        return runCatching {
+            val behandling: Behandling? = mapUnderkategori(underkategori).orElse(null)
             val geografiskTilknyttning = brukerIdent?.get()?.let(persondataService::hentGeografiskTilknytning)
             val diskresjonskode = brukerIdent?.get()
                 ?.let(persondataService::hentAdressebeskyttelse)
@@ -55,7 +88,7 @@ class ArbeidsfordelingServiceImpl(
             norgApi.hentBehandlendeEnheter(
                 behandling = behandling,
                 geografiskTilknyttning = geografiskTilknyttning,
-                oppgavetype = mappedOppgaveType,
+                oppgavetype = oppgavetype,
                 fagomrade = fagomrade,
                 erEgenAnsatt = erEgenAnsatt,
                 diskresjonskode = diskresjonskode
@@ -77,5 +110,14 @@ class ArbeidsfordelingServiceImpl(
             }
             .onFailure { log.error("Kunne ikke hente geografisk tilknyttning", it) }
             .getOrDefault(emptyList())
+    }
+
+    private fun parseUnderkategori(behandling: Behandling?): String? {
+        return if (behandling != null) {
+            listOf(
+                behandling.behandlingstema,
+                behandling.behandlingstype
+            ).joinToString(":") { it ?: "" }
+        } else null
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -31,6 +31,7 @@ import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.SPORSMAL_OG_SV
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.beskrivelseInnslag
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.defaultEnhetGittTemagruppe
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.leggTilBeskrivelse
+import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.mapUnderkategori
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.paginering
 import no.nav.modiapersonoversikt.utils.SafeListAggregate
 import org.slf4j.LoggerFactory
@@ -485,21 +486,6 @@ class RestOppgaveBehandlingServiceImpl(
         return henvendelseOppgave
     }
 
-    fun mapUnderkategori(underkategoriKode: String?): Optional<Behandling> {
-        return ofNullable(underkategoriKode).map { kode ->
-            val behandlingstemaOgType = kode.split(":").map {
-                it.ifEmpty { null }
-            }
-            require(behandlingstemaOgType.size == 2) {
-                "Underkategorikode inneholdt ikke forventet informasjon: $underkategoriKode"
-            }
-            Behandling(
-                behandlingstemaOgType.first(),
-                behandlingstemaOgType.last()
-            )
-        }
-    }
-
     private fun hentOppgaveJsonDTO(oppgaveId: String): OppgaveJsonDTO {
         return apiClient.hentOppgave(
             xCorrelationID = correlationId(),
@@ -539,7 +525,7 @@ class RestOppgaveBehandlingServiceImpl(
 
     private fun finnAnsvarligEnhet(oppgave: OppgaveJsonDTO, temagruppe: Temagruppe): String {
         val aktorId = requireNotNull(oppgave.aktoerId)
-        val enheter: List<NorgDomain.Enhet> = arbeidsfordelingService.hentBehandlendeEnheter(
+        val enheter: List<NorgDomain.Enhet> = arbeidsfordelingService.hentBehandlendeEnheterV2(
             brukerIdent = Fnr.of(pdlOppslagService.hentFnr(aktorId)),
             fagomrade = oppgave.tema,
             oppgavetype = oppgave.oppgavetype,

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/Utils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/Utils.kt
@@ -2,9 +2,11 @@ package no.nav.modiapersonoversikt.service.oppgavebehandling
 
 import no.nav.modiapersonoversikt.legacy.api.domain.Temagruppe
 import no.nav.modiapersonoversikt.legacy.api.domain.Temagruppe.*
+import no.nav.modiapersonoversikt.service.kodeverksmapper.domain.Behandling
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.*
 import kotlin.math.ceil
 
 object Utils {
@@ -73,5 +75,21 @@ object Utils {
         } while (page < maxPage)
 
         return buffer
+    }
+
+    @JvmStatic
+    fun mapUnderkategori(underkategoriKode: String?): Optional<Behandling> {
+        return Optional.ofNullable(underkategoriKode).map { kode ->
+            val behandlingstemaOgType = kode.split(":").map {
+                it.ifEmpty { null }
+            }
+            require(behandlingstemaOgType.size == 2) {
+                "Underkategorikode inneholdt ikke forventet informasjon: $underkategoriKode"
+            }
+            Behandling(
+                behandlingstemaOgType.first(),
+                behandlingstemaOgType.last()
+            )
+        }
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -895,7 +895,7 @@ class RestOppgaveBehandlingServiceImplTest {
             every { apiClient.hentOppgave(any(), any()) } returns testoppgave.toGetOppgaveResponseJsonDTO()
             every { apiClient.endreOppgave(any(), any(), any()) } returns testoppgave.toPutOppgaveResponseJsonDTO()
             every { ansattService.hentAnsattNavn(eq("Z999999")) } returns "Fornavn Etternavn"
-            every { arbeidsfordelingService.hentBehandlendeEnheter(any(), any(), any(), any()) } returns listOf(
+            every { arbeidsfordelingService.hentBehandlendeEnheterV2(any(), any(), any(), any()) } returns listOf(
                 NorgDomain.Enhet("4567", "NAV Mockenhet", NorgDomain.EnhetStatus.AKTIV, false)
             )
 
@@ -944,7 +944,7 @@ class RestOppgaveBehandlingServiceImplTest {
             every { apiClient.hentOppgave(any(), any()) } returns testoppgave.toGetOppgaveResponseJsonDTO()
             every { apiClient.endreOppgave(any(), any(), any()) } returns testoppgave.toPutOppgaveResponseJsonDTO()
             every { ansattService.hentAnsattNavn(eq("Z999999")) } returns "Fornavn Etternavn"
-            every { arbeidsfordelingService.hentBehandlendeEnheter(any(), any(), any(), any()) } returns listOf(
+            every { arbeidsfordelingService.hentBehandlendeEnheterV2(any(), any(), any(), any()) } returns listOf(
                 NorgDomain.Enhet("4567", "NAV Mockenhet", NorgDomain.EnhetStatus.AKTIV, false)
             )
             every { kodeverksmapperService.mapUnderkategori(any()) } returns Optional.of(


### PR DESCRIPTION
Det er to måter å kalle på hentBehandledeEnheter - enten via leggTilbakeOppgaveIGsakV2 eller via endepunktet med samme navn. Førstnevnte håndterer allerede bruk av ny oppgave-struktur. For endepunktet løses dette med en ny V2.