### PR TITLE
[PROD][KAIZEN-0] filtrere ut tråder uten meldinger

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -14,6 +14,7 @@ import no.nav.modiapersonoversikt.legacy.api.domain.sfhenvendelse.generated.mode
 import no.nav.modiapersonoversikt.legacy.api.service.norg.AnsattService
 import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService
 import no.nav.modiapersonoversikt.service.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.modiapersonoversikt.utils.isNotNullOrEmpty
 import okhttp3.OkHttpClient
 import org.slf4j.LoggerFactory
 import java.time.OffsetDateTime
@@ -253,7 +254,7 @@ class SfHenvendelseServiceImpl(
     }
 
     enum class ApiFeilType {
-        IDENT, TEMAGRUPPE, JOURNALFORENDE_IDENT, MARKERT_DATO, MARKERT_AV, FRITEKST
+        IDENT, TEMAGRUPPE, JOURNALFORENDE_IDENT, MARKERT_DATO, MARKERT_AV, FRITEKST, TOM_TRAD
     }
     data class ApiFeil(val type: ApiFeilType, val kjedeId: String)
     private fun loggFeilSomErSpesialHandtert(bruker: EksternBruker, henvendelser: List<HenvendelseDTO>): List<HenvendelseDTO> {
@@ -266,6 +267,9 @@ class SfHenvendelseServiceImpl(
             }
             if (henvendelse.gjeldendeTemagruppe == null) {
                 feil.add(ApiFeil(ApiFeilType.TEMAGRUPPE, henvendelse.kjedeId))
+            }
+            if (henvendelse.meldinger.isNullOrEmpty()) {
+                feil.add(ApiFeil(ApiFeilType.TOM_TRAD, henvendelse.kjedeId))
             }
             val journalposter = henvendelse.journalposter ?: emptyList()
             if (journalposter.any { it.journalforerNavIdent == null }) {
@@ -284,7 +288,10 @@ class SfHenvendelseServiceImpl(
                 feil.add(ApiFeil(ApiFeilType.FRITEKST, henvendelse.kjedeId))
             }
         }
-        val kanJobbesMedIModia = henvendelser.filter { it.gjeldendeTemagruppe != null }
+        val kanJobbesMedIModia = henvendelser
+            .filter { it.gjeldendeTemagruppe != null }
+            .filter { it.meldinger.isNotNullOrEmpty() }
+
         if (feil.isNotEmpty()) {
             val grupperteFeil = feil
                 .groupBy { it.type }

--- a/web/src/main/java/no/nav/modiapersonoversikt/utils/KotlinUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/utils/KotlinUtils.kt
@@ -1,3 +1,14 @@
 package no.nav.modiapersonoversikt.utils
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
 fun String.isNumeric(): Boolean = toIntOrNull()?.let { true } ?: false
+
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> Collection<T>?.isNotNullOrEmpty(): Boolean {
+    contract {
+        returns(true) implies (this@isNotNullOrEmpty != null)
+    }
+    return !this.isNullOrEmpty()
+}

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
@@ -114,6 +114,28 @@ internal class SfHenvendelseServiceImplTest {
         assertThat(henvendelser[0].meldinger?.get(0)?.fritekst).isEqualTo("Innholdet i denne henvendelsen er slettet av NAV.")
     }
 
+    @Test
+    internal fun `skal fjerne henvendelse om den ikke har noen meldinger`() {
+        every { ansattService.hentAnsattFagomrader(any(), any()) } returns setOf("DAG", "OPP")
+        every { arbeidsfordeling.hentGeografiskTilknyttning(any()) } returns listOf(
+            EnhetGeografiskTilknyttning(
+                enhetId = "5678",
+                geografiskOmraade = "005678"
+            )
+        )
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns listOf(
+            dummyHenvendelse.medJournalpost("DAG"),
+            dummyHenvendelse.copy(meldinger = emptyList()),
+            dummyHenvendelse.medJournalpost("SYK")
+        )
+
+        val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")
+
+        assertThat(henvendelser).hasSize(2)
+        assertThat(henvendelser[0].meldinger?.get(0)?.fritekst).isEqualTo("Melding innhold")
+        assertThat(henvendelser[1].meldinger?.get(0)?.fritekst).isEqualTo("Du kan ikke se innholdet i denne henvendelsen fordi tråden er journalført på et tema du ikke har tilgang til.")
+    }
+
     private val dummyHenvendelse = HenvendelseDTO(
         henvendelseType = HenvendelseDTO.HenvendelseType.MELDINGSKJEDE,
         fnr = "12345678910",


### PR DESCRIPTION
feil i Salesforce gjør at vi kan få tråder uten noen meldinger. For å hindre at disse får modia til å eksplodere så filtreres disse ut og vi logger feilen.
