### PR TITLE
[KAIZEN-0] tillate visning av bidragsdokumenter

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/TilgangskontrollServiceImpl.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/TilgangskontrollServiceImpl.java
@@ -30,11 +30,7 @@ public class TilgangskontrollServiceImpl implements TilgangskontrollService {
     private static final Logger logger = getLogger(TilgangskontrollService.class);
 
     public TjenesteResultatWrapper harSaksbehandlerTilgangTilDokument(HttpServletRequest request, DokumentMetadata journalpostMetadata, String fnr, String urlTemakode) {
-        String temakode = journalpostMetadata.getTemakode();
-
-        if (temakodeErBidrag(temakode)) {
-            return new TjenesteResultatWrapper(TEMAKODE_ER_BIDRAG);
-        } else if (erJournalfortPaAnnetTema(urlTemakode, journalpostMetadata)) {
+        if (erJournalfortPaAnnetTema(urlTemakode, journalpostMetadata)) {
             return new TjenesteResultatWrapper(JOURNALFORT_ANNET_TEMA, journalfortAnnetTemaEktraFeilInfo(journalpostMetadata.getTemakodeVisning(), fnr));
         } else if (!journalpostMetadata.isErJournalfort()) {
             return new TjenesteResultatWrapper(IKKE_JOURNALFORT, ikkeJournalfortEkstraFeilInfo(fnr));

--- a/web/src/test/java/no/nav/modiapersonoversikt/legacy/sak/service/TilgangskontrollServiceTest.java
+++ b/web/src/test/java/no/nav/modiapersonoversikt/legacy/sak/service/TilgangskontrollServiceTest.java
@@ -1,10 +1,6 @@
 package no.nav.modiapersonoversikt.legacy.sak.service;
 
 
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
-import no.nav.common.auth.context.AuthContext;
-import no.nav.common.auth.context.UserRole;
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.AnsattEnhet;
 import no.nav.modiapersonoversikt.legacy.api.service.norg.AnsattService;
 import no.nav.modiapersonoversikt.legacy.sak.providerdomain.DokumentMetadata;
@@ -78,16 +74,6 @@ public class TilgangskontrollServiceTest {
 
         assertThat(result.result.isPresent(), is(TRUE));
         assertThat(result.result.get(), is(TRUE));
-    }
-
-    @Test
-    public void temaBidragGirFeilmelding() {
-        DokumentMetadata journalpostMetadata = new DokumentMetadata().withTemakode("BID");
-        TjenesteResultatWrapper result = tilgangskontrollService.harSaksbehandlerTilgangTilDokument(mockRequest, journalpostMetadata, BRUKERS_IDENT, TEMAKODE);
-
-
-        assertThat(result.result.isPresent(), is(FALSE));
-        assertThat(result.feilmelding, is(TEMAKODE_ER_BIDRAG));
     }
 
     @Test


### PR DESCRIPTION
Det begynner å komme bidrags dokumenter inn i joark, og vi ønsker nå åpne opp for å vise disse. Fjerner derfor den eksplisitte sperren, og lar SAF's tilgangskontroll håndtere tilgang til disse dokumentene.
