### PR TITLE
[KAIZEN-0] godta blank underkategori

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/kodeverksmapper/domain/BehandlingExt.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/kodeverksmapper/domain/BehandlingExt.kt
@@ -5,6 +5,9 @@ fun Behandling.asV2BehandlingString(): String {
 }
 
 fun String.parseV2BehandlingString(): Behandling {
+    if (this.isBlank()) {
+        return Behandling(null, null)
+    }
     val temaOgType = this.split(":").map {
         it.ifEmpty { null }
     }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/kodeverksmapper/domain/BehandlingExtTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/kodeverksmapper/domain/BehandlingExtTest.kt
@@ -33,11 +33,6 @@ internal class BehandlingExtTest {
     inner class Parsing {
         @Test
         internal fun `should throw exception if invalid format`() {
-            assertThatThrownBy { "".parseV2BehandlingString() }
-                .hasMessageContaining("<tema>:<type>")
-                .hasMessageContaining("''")
-                .isInstanceOf(IllegalArgumentException::class.java)
-
             assertThatThrownBy { "tema".parseV2BehandlingString() }
                 .hasMessageContaining("<tema>:<type>")
                 .hasMessageContaining("'tema'")
@@ -65,6 +60,10 @@ internal class BehandlingExtTest {
             val none = ":".parseV2BehandlingString()
             assertThat(none.behandlingstema).isNull()
             assertThat(none.behandlingstype).isNull()
+
+            val empty = "".parseV2BehandlingString()
+            assertThat(empty.behandlingstema).isNull()
+            assertThat(empty.behandlingstype).isNull()
 
             val both = "tema:type".parseV2BehandlingString()
             assertThat(both.behandlingstema).isEqualTo("tema")


### PR DESCRIPTION
i tilfeller hvor underkategori ikke er valgt vil vi få en tom streng, og vi vil da ha null-verdier for behandlignstema og behandlintstype
