### PR TITLE
[KAIZEN-0] fjerne tps personsok

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
@@ -5,7 +5,6 @@ enum class Feature(val propertyKey: String) {
     USE_SALESFORCE_DIALOG("modiabrukerdialog.bruker-salesforce-dialoger"),
     USE_GRAPHQL_SAF("modiabrukerdialog.bruker-graphql-saf"),
     HENT_BISYS_SAKER("modiabrukerdialog.hent-bisys-saker"),
-    PDL_PERSONSOK_RATE("modiabrukerdialog.science.pdl-personsok-rate"),
     SF_HENVENDELSE_RATE("modiabrukerdialog.science.sf-henvendelse-rate"),
     SAF_RATE("modiabrukerdialog.science.saf-rate")
 }


### PR DESCRIPTION
for kontonummer brukes fortsatt TPS frem til ny løsning er på plass, men endepunkt og resterende kode for TPS-søket er nå fjernet
