### PR TITLE
[KAIZEN-0] legge til rette for chat i modia

### DIFF
--- a/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
+++ b/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
@@ -8,6 +8,7 @@ import Manuelle_fikser_for_api_main.ChangeUtils.addResponse
 import Manuelle_fikser_for_api_main.ChangeUtils.changeFile
 import Manuelle_fikser_for_api_main.ChangeUtils.forDefinition
 import Manuelle_fikser_for_api_main.ChangeUtils.forEndpoint
+import Manuelle_fikser_for_api_main.ChangeUtils.forProperty
 import Manuelle_fikser_for_api_main.ChangeUtils.getTyped
 import Manuelle_fikser_for_api_main.ChangeUtils.objectOf
 import Manuelle_fikser_for_api_main.ChangeUtils.removeProperty
@@ -53,6 +54,9 @@ changeFile(
      */
     forDefinition("Henvendelse") {
         setRequired("gjeldendeTemagruppe", false)
+        forProperty("henvendelseType") {
+            getTyped<MutableList<String>>("enum").add("CHAT")
+        }
     }
     forDefinition("Markering") {
         setRequired("markertDato", false)
@@ -125,6 +129,9 @@ object ChangeUtils {
     }
     fun Json.forEndpoint(method: String, path: String, block: Json.() -> Unit) {
         block(this.getTyped<Json>("paths").getTyped<Json>(path).getTyped(method))
+    }
+    fun Json.forProperty(name: String, block: Json.() -> Unit) {
+        block(this.getTyped<Json>("properties").getTyped(name))
     }
     fun Json.removeProperty(vararg names: String) {
         if (this.has("properties")) {

--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
@@ -488,6 +488,7 @@ components:
           enum:
           - "SAMTALEREFERAT"
           - "MELDINGSKJEDE"
+          - "CHAT"
         fnr:
           type: "string"
           example: "12345678910"

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfDialogController.kt
@@ -83,6 +83,9 @@ class SfDialogController @Autowired constructor(
                             fritekst = request.fritekst
                         )
                     }
+                    HenvendelseDTO.HenvendelseType.CHAT -> {
+                        throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Kan ikke opprette chat-melding fra modia")
+                    }
                 }
                 Unit
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
@@ -369,6 +369,13 @@ class SfLegacyDialogController(
                     MeldingFraDTO.IdentType.SYSTEM -> Meldingstype.SVAR_SKRIFTLIG
                 }
             }
+            HenvendelseDTO.HenvendelseType.CHAT -> {
+                when (melding.fra.identType) {
+                    MeldingFraDTO.IdentType.AKTORID -> if (erForsteMelding) Meldingstype.SPORSMAL_SKRIFTLIG else Meldingstype.SVAR_SBL_INNGAAENDE
+                    MeldingFraDTO.IdentType.NAVIDENT -> if (erForsteMelding) Meldingstype.SPORSMAL_MODIA_UTGAAENDE else Meldingstype.SVAR_SKRIFTLIG
+                    MeldingFraDTO.IdentType.SYSTEM -> Meldingstype.SVAR_SKRIFTLIG
+                }
+            }
         }
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -254,7 +254,7 @@ class SfHenvendelseServiceImpl(
     }
 
     enum class ApiFeilType {
-        IDENT, TEMAGRUPPE, JOURNALFORENDE_IDENT, MARKERT_DATO, MARKERT_AV, FRITEKST, TOM_TRAD
+        IDENT, TEMAGRUPPE, JOURNALFORENDE_IDENT, MARKERT_DATO, MARKERT_AV, FRITEKST, TOM_TRAD, CHAT
     }
     data class ApiFeil(val type: ApiFeilType, val kjedeId: String)
     private fun loggFeilSomErSpesialHandtert(bruker: EksternBruker, henvendelser: List<HenvendelseDTO>): List<HenvendelseDTO> {
@@ -287,10 +287,14 @@ class SfHenvendelseServiceImpl(
             if (henvendelse.kasseringsDato?.isAfter(now) == true && meldinger.any { it.fritekst == null }) {
                 feil.add(ApiFeil(ApiFeilType.FRITEKST, henvendelse.kjedeId))
             }
+            if (henvendelse.henvendelseType == HenvendelseDTO.HenvendelseType.CHAT) {
+                feil.add(ApiFeil(ApiFeilType.CHAT, henvendelse.kjedeId))
+            }
         }
         val kanJobbesMedIModia = henvendelser
             .filter { it.gjeldendeTemagruppe != null }
             .filter { it.meldinger.isNotNullOrEmpty() }
+            .filter { it.henvendelseType != HenvendelseDTO.HenvendelseType.CHAT }
 
         if (feil.isNotEmpty()) {
             val grupperteFeil = feil


### PR DESCRIPTION
legger til enum-verdi for chat fra SF slik at de kan starte med å sende det i responsen.

For nå blir alle chat-trådene filtrert ut slik at det ikke kan skal feil før vi ser at alt fungerer.
