### PR TITLE
[KAIZEN-0] endre lukke-logikk

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
@@ -17,7 +17,6 @@ import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.KodeverkConfig
 import no.nav.modiapersonoversikt.service.sfhenvendelse.EksternBruker
 import no.nav.modiapersonoversikt.service.sfhenvendelse.SfHenvendelseService
-import no.nav.modiapersonoversikt.utils.ConcurrencyUtils.inParallel
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -96,17 +95,13 @@ class SfLegacyDialogController(
             fritekst = infomeldingRequest.fritekst
         )
 
-        inParallel(
-            {
-                sfHenvendelseService.journalforHenvendelse(
-                    enhet = enhet,
-                    kjedeId = henvendelse.kjedeId,
-                    saksId = infomeldingRequest.sak.fagsystemSaksId,
-                    saksTema = infomeldingRequest.sak.temaKode,
-                    fagsakSystem = infomeldingRequest.sak.fagsystemKode
-                )
-            },
-            { sfHenvendelseService.lukkTraad(henvendelse.kjedeId) }
+        sfHenvendelseService.lukkTraad(henvendelse.kjedeId)
+        sfHenvendelseService.journalforHenvendelse(
+            enhet = enhet,
+            kjedeId = henvendelse.kjedeId,
+            saksId = infomeldingRequest.sak.fagsystemSaksId,
+            saksTema = infomeldingRequest.sak.temaKode,
+            fagsakSystem = infomeldingRequest.sak.fagsystemKode
         )
 
         return ResponseEntity(HttpStatus.OK)
@@ -190,10 +185,6 @@ class SfLegacyDialogController(
                     saksTema = fortsettDialogRequest.sak.temaKode,
                     fagsakSystem = fortsettDialogRequest.sak.fagsystemKode
                 )
-            }
-
-            if (fortsettDialogRequest.meldingstype !== Meldingstype.SPORSMAL_MODIA_UTGAAENDE) {
-                sfHenvendelseService.lukkTraad(henvendelse.kjedeId)
             }
         }
         if (oppgaveId != null) {


### PR DESCRIPTION
sf endrer til å journalføre meldingskjeder fortløpende så lukking ved svar ikke lengre nødvendig.

Samtidig er det viktig at lukking skjer før journalføring ved utsending av infomelding for å sikre at dokumentet blir opprettet så fort som mulig, og at det ikke blir opprettet notat-dokument før lukking blir gjennomført.
