### PR TITLE
[FAGSYSTEM-209818] endre visning av postboks adresse

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -337,12 +337,12 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         sistEndring: Persondata.SistEndret?,
         gyldighetsPeriode: Persondata.GyldighetsPeriode? = null
     ) = Persondata.Adresse(
-        linje1 = listOf(adresse.postboks),
-        linje2 = listOf(
+        linje1 = listOf(adresse.postbokseier),
+        linje2 = listOf("Postboks", adresse.postboks),
+        linje3 = listOf(
             adresse.postnummer,
             adresse.postnummer?.let { kodeverk.hentKodeverk(Kodeverk.POSTNUMMER).hentVerdi(it, it) }
         ),
-        linje3 = listOf(adresse.postbokseier),
         sistEndret = sistEndring,
         gyldighetsPeriode = gyldighetsPeriode
     )

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -6,6 +6,7 @@ import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentTredjepartspersondata
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -15,9 +16,18 @@ internal class AdresseMappingTest {
     val kodeverk: EnhetligKodeverk.Service = mockk()
     val mapper = PersondataFletter(kodeverk)
 
+    @BeforeEach
+    fun setup() {
+        every { kodeverk.hentKodeverk<Any, Any>(any()) } returns EnhetligKodeverk.Kodeverk(
+            "",
+            mapOf(
+                "9750" to "Nordkapp"
+            )
+        )
+    }
+
     @Test
     internal fun `skal mappe vegadresse likt for person og tredjepartsperson`() {
-        every { kodeverk.hentKodeverk<Any, Any>(any()) } returns EnhetligKodeverk.Kodeverk("", emptyMap())
         val hovedperson = gittPerson().copy(
             bostedsadresse = adresse.copy(
                 vegadresse = HentPersondata.Vegadresse(
@@ -69,6 +79,34 @@ internal class AdresseMappingTest {
 
         val harSammeAdresse = persondata.person.forelderBarnRelasjon.find { it.ident == barnFnr }?.harSammeAdresse
         Assertions.assertTrue(harSammeAdresse ?: false)
+    }
+
+    @Test
+    internal fun `skal mappe postboksadresse riktig`() {
+        val person = gittPerson().copy(
+            kontaktadresse = kontaktadresseData.copy(
+                coAdressenavn = null,
+                vegadresse = null,
+                postboksadresse = HentPersondata.Postboksadresse(
+                    postbokseier = "C/O Fornavn Etternavn",
+                    postboks = "123",
+                    postnummer = "9750"
+                )
+            ).asList()
+        )
+
+        val persondata = mapper.flettSammenData(
+            data = gittData(
+                personIdent = "",
+                persondata = person
+            ),
+            clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault())
+        )
+
+        val kontaktAdresse = persondata.person.kontaktAdresse.first()
+        Assertions.assertEquals("C/O Fornavn Etternavn", kontaktAdresse.linje1)
+        Assertions.assertEquals("Postboks 123", kontaktAdresse.linje2)
+        Assertions.assertEquals("9750 Nordkapp", kontaktAdresse.linje3)
     }
 
     private fun gittTredjepartsperson() = HentTredjepartspersondata.Person(


### PR DESCRIPTION
Endret format til å matche visning i visning i pdl, e.g:
- \<postboks-eier>
- Postboks \<postboks-nummer>
- \<postnummer> \<poststed>
