### PR TITLE
[FAGSYSTEM-210465] eksponere dodsdato i sivilstandrelasjoner

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -83,7 +83,8 @@ object Persondata {
         val navn: List<Navn>,
         val alder: Int?,
         val adressebeskyttelse: List<KodeBeskrivelse<AdresseBeskyttelse>>,
-        val harSammeAdresse: Boolean
+        val harSammeAdresse: Boolean,
+        val dodsdato: List<LocalDate>
     )
 
     data class Sikkerhetstiltak(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -595,7 +595,8 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             navn = person.navn,
             alder = person.alder,
             adressebeskyttelse = person.adressebeskyttelse,
-            harSammeAdresse = harSammeAdresse(hentBostedAdresse(data).firstOrNull(), person.bostedAdresse.firstOrNull())
+            harSammeAdresse = harSammeAdresse(hentBostedAdresse(data).firstOrNull(), person.bostedAdresse.firstOrNull()),
+            dodsdato = person.dodsdato
         )
     }
 

--- a/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
+++ b/web/src/test/resources/snapshots/no.nav.modiapersonoversikt.rest.persondata.PersondataFletterTest_skal mappe data fra pdl til Persondata-0.json
@@ -272,6 +272,7 @@
           "kode" : "UGRADERT"
         } ] ],
         "alder" : 20,
+        "dodsdato" : [ "kotlin.collections.EmptyList", [ ] ],
         "fnr" : "11225678910",
         "harSammeAdresse" : false,
         "navn" : [ "java.util.Collections$SingletonList", [ {


### PR DESCRIPTION
gjøres slik at infomasjon om død partner kan vises
