### PR TITLE
[PROD][KAIZEN-0] etablere enum for informasjonselementer i persondata

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 open class SkjermedePersonerConfig {
-    var url = EnvironmentUtils.getRequiredProperty("NOM_URL")
+    var url = EnvironmentUtils.getRequiredProperty("SKJERMEDE_PERSONER_PIP_URL")
 
     @Autowired
     lateinit var tokenProvider: ServiceToServiceTokenProvider

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata.KontaktinformasjonForDoedsboSkifteform.OFFENTLIG
 import no.nav.modiapersonoversikt.legacy.api.utils.TjenestekallLogger
 import no.nav.modiapersonoversikt.rest.persondata.Persondata.asNavnOgIdent
+import no.nav.modiapersonoversikt.rest.persondata.PersondataResult.InformasjonElement
 import no.nav.modiapersonoversikt.service.dkif.Dkif
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.Bankkonto
@@ -47,7 +48,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
             return ekstraDatapunker.mapNotNull {
                 if (it is PersondataResult.Failure<*>) {
                     TjenestekallLogger.logger.error("Persondata feilet system: ${it.system}", it.exception)
-                    it.system
+                    it.system.name
                 } else {
                     null
                 }
@@ -89,7 +90,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
                 bankkonto = hentBankkonto(data).fold(
                     onSuccess = { it },
                     onFailure = { system, cause ->
-                        feilendeSystemer.add(system)
+                        feilendeSystemer.add(system.name)
                         TjenestekallLogger.logger.error("Persondata feilet system: $system", cause)
                         null
                     }
@@ -854,7 +855,7 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
 
     private fun hentBankkonto(data: Data): PersondataResult<Persondata.Bankkonto?> {
         return data.bankkonto
-            .map("Bankkonto") {
+            .map(InformasjonElement.BANKKONTO) {
                 if (it.person is Bruker) {
                     when (val bankkonto = (it.person as Bruker).bankkonto) {
                         is BankkontoNorge -> Persondata.Bankkonto(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataResult.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataResult.kt
@@ -1,7 +1,17 @@
 package no.nav.modiapersonoversikt.rest.persondata
 
-sealed class PersondataResult<T>(val system: String) {
-    fun <S> map(newSystem: String = system, block: (t: T) -> S): PersondataResult<S> {
+sealed class PersondataResult<T>(val system: InformasjonElement) {
+    enum class InformasjonElement {
+        PDL_GT,
+        PDL_TREDJEPARTSPERSONER,
+        EGEN_ANSATT,
+        DKIF,
+        BANKKONTO,
+        VEILEDER_ROLLER,
+        NORG_NAVKONTOR,
+        NORG_KONTAKTINFORMASJON,
+    }
+    fun <S> map(newSystem: InformasjonElement = system, block: (t: T) -> S): PersondataResult<S> {
         return when (this) {
             is Failure<*> -> this as PersondataResult<S>
             is Success<T> -> runCatching(newSystem) {
@@ -24,19 +34,19 @@ sealed class PersondataResult<T>(val system: String) {
         }
     }
 
-    fun <S> fold(onSuccess: (t: T) -> S, onFailure: (system: String, t: Throwable) -> S): S {
+    fun <S> fold(onSuccess: (t: T) -> S, onFailure: (system: InformasjonElement, t: Throwable) -> S): S {
         return when (this) {
             is Failure<*> -> onFailure(this.system, this.exception)
             is Success<T> -> onSuccess(this.value)
         }
     }
 
-    class Success<T>(name: String, val value: T) : PersondataResult<T>(name)
-    class Failure<T>(name: String, val exception: Throwable) : PersondataResult<T>(name)
+    class Success<T>(name: InformasjonElement, val value: T) : PersondataResult<T>(name)
+    class Failure<T>(name: InformasjonElement, val exception: Throwable) : PersondataResult<T>(name)
 
     companion object {
         @JvmStatic
-        fun <T> runCatching(system: String, block: () -> T): PersondataResult<T> {
+        fun <T> runCatching(system: InformasjonElement, block: () -> T): PersondataResult<T> {
             return try {
                 Success(system, block())
             } catch (e: Throwable) {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataService.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontro
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata
 import no.nav.modiapersonoversikt.legacy.api.service.pdl.PdlOppslagService
 import no.nav.modiapersonoversikt.legacy.kjerneinfo.consumer.egenansatt.EgenAnsattService
+import no.nav.modiapersonoversikt.rest.persondata.PersondataResult.InformasjonElement
 import no.nav.modiapersonoversikt.service.dkif.Dkif
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.tjeneste.virksomhet.person.v3.binding.PersonV3
@@ -44,14 +45,15 @@ class PersondataServiceImpl(
         val persondata = requireNotNull(pdl.hentPersondata(personIdent)) {
             "Fant ikke person med personIdent $personIdent"
         }
-        val geografiskeTilknytning = PersondataResult.runCatching("PDL-GT") { pdl.hentGeografiskTilknyttning(personIdent) }
+
+        val geografiskeTilknytning = PersondataResult.runCatching(InformasjonElement.PDL_GT) { pdl.hentGeografiskTilknyttning(personIdent) }
         val adressebeskyttelse = persondataFletter.hentAdressebeskyttelse(persondata.adressebeskyttelse)
         val navEnhet = hentNavEnhetFraNorg(adressebeskyttelse, geografiskeTilknytning)
-        val erEgenAnsatt = PersondataResult.runCatching("TPS-EGEN-ANSATT") { egenAnsattService.erEgenAnsatt(personIdent) }
+        val erEgenAnsatt = PersondataResult.runCatching(InformasjonElement.EGEN_ANSATT) { egenAnsattService.erEgenAnsatt(personIdent) }
         val tilganger = PersondataResult
-            .runCatching("TILGANGSKONTROLL") { hentTilganger() }
+            .runCatching(InformasjonElement.VEILEDER_ROLLER) { hentTilganger() }
             .getOrElse(PersondataService.Tilganger(kode6 = false, kode7 = false))
-        val tredjepartsPerson = PersondataResult.runCatching("PDL") {
+        val tredjepartsPerson = PersondataResult.runCatching(InformasjonElement.PDL_TREDJEPARTSPERSONER) {
             persondata
                 .findTredjepartsPersoner()
                 .let { pdl.hentTredjepartspersondata(it) }
@@ -59,8 +61,8 @@ class PersondataServiceImpl(
                 .associateBy { it.fnr }
         }
 
-        val dkifData = PersondataResult.runCatching("DKIF") { dkif.hentDigitalKontaktinformasjon(personIdent) }
-        val bankkonto = PersondataResult.runCatching("TPS") { hentBankkonto(personIdent) }
+        val dkifData = PersondataResult.runCatching(InformasjonElement.DKIF) { dkif.hentDigitalKontaktinformasjon(personIdent) }
+        val bankkonto = PersondataResult.runCatching(InformasjonElement.BANKKONTO) { hentBankkonto(personIdent) }
 
         return persondataFletter.flettSammenData(
             PersondataFletter.Data(
@@ -77,11 +79,11 @@ class PersondataServiceImpl(
     }
 
     override fun hentGeografiskTilknytning(personIdent: String): String? {
-        return PersondataResult.runCatching("PDL-GT") { pdl.hentGeografiskTilknyttning(personIdent) }.getOrNull()
+        return PersondataResult.runCatching(InformasjonElement.PDL_GT) { pdl.hentGeografiskTilknyttning(personIdent) }.getOrNull()
     }
 
     override fun hentNavEnhet(personIdent: String): Persondata.Enhet? {
-        val geografiskeTilknytning = PersondataResult.runCatching("PDL-GT") { pdl.hentGeografiskTilknyttning(personIdent) }
+        val geografiskeTilknytning = PersondataResult.runCatching(InformasjonElement.PDL_GT) { pdl.hentGeografiskTilknyttning(personIdent) }
         val adressebeskyttelse = hentAdressebeskyttelse(personIdent)
         return hentNavEnhetFraNorg(adressebeskyttelse, geografiskeTilknytning).let { persondataFletter.hentNavEnhet(it) }
     }
@@ -128,12 +130,12 @@ class PersondataServiceImpl(
                 break
             }
         }
-        return PersondataResult.runCatching("NORG") {
+        return PersondataResult.runCatching(InformasjonElement.NORG_NAVKONTOR) {
             norgApi
                 .finnNavKontor(gt, diskresjonskode)
                 ?.enhetId
         }
-            .map("NORG Kontaktinformasjon") {
+            .map(InformasjonElement.NORG_KONTAKTINFORMASJON) {
                 it?.let { enhetId -> norgApi.hentKontaktinfo(EnhetId(enhetId)) }
             }
     }

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentTredjepartspersondata
+import no.nav.modiapersonoversikt.rest.persondata.PersondataResult.InformasjonElement
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -70,7 +71,7 @@ internal class AdresseMappingTest {
             data = gittData(
                 personIdent = "",
                 persondata = hovedperson,
-                tredjepartsPerson = PersondataResult.runCatching("tredjepartsperson") {
+                tredjepartsPerson = PersondataResult.runCatching(InformasjonElement.PDL_TREDJEPARTSPERSONER) {
                     mapOf(barnFnr to requireNotNull(tredjepartsPersonData))
                 }
             ),

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
@@ -3,6 +3,7 @@ package no.nav.modiapersonoversikt.rest.persondata
 import no.nav.modiapersonoversikt.consumer.norg.NorgDomain
 import no.nav.modiapersonoversikt.consumer.norg.NorgDomain.Publikumsmottak
 import no.nav.modiapersonoversikt.legacy.api.domain.pdl.generated.HentPersondata
+import no.nav.modiapersonoversikt.rest.persondata.PersondataResult.InformasjonElement
 import no.nav.modiapersonoversikt.service.dkif.Dkif
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.*
@@ -13,12 +14,12 @@ import java.time.LocalDateTime
 fun gittData(
     personIdent: String,
     persondata: HentPersondata.Person,
-    geografiskeTilknytning: PersondataResult<String?> = PersondataResult.runCatching("gt") { "0123" },
-    erEgenAnsatt: PersondataResult<Boolean> = PersondataResult.runCatching("egenAnsatt") { false },
-    navEnhet: PersondataResult<NorgDomain.EnhetKontaktinformasjon?> = PersondataResult.runCatching("navEnhet") { gittNavKontorEnhet() },
-    dkifData: PersondataResult<Dkif.DigitalKontaktinformasjon> = PersondataResult.runCatching("dkif") { digitalKontaktinformasjon },
-    bankkonto: PersondataResult<HentPersonResponse> = PersondataResult.runCatching("bankkonto") { utenlandskBankkonto },
-    tredjepartsPerson: PersondataResult<Map<String, Persondata.TredjepartsPerson>> = PersondataResult.runCatching("tredjepartsperson") { tredjepartsPersoner }
+    geografiskeTilknytning: PersondataResult<String?> = PersondataResult.runCatching(InformasjonElement.PDL_GT) { "0123" },
+    erEgenAnsatt: PersondataResult<Boolean> = PersondataResult.runCatching(InformasjonElement.EGEN_ANSATT) { false },
+    navEnhet: PersondataResult<NorgDomain.EnhetKontaktinformasjon?> = PersondataResult.runCatching(InformasjonElement.NORG_NAVKONTOR) { gittNavKontorEnhet() },
+    dkifData: PersondataResult<Dkif.DigitalKontaktinformasjon> = PersondataResult.runCatching(InformasjonElement.DKIF) { digitalKontaktinformasjon },
+    bankkonto: PersondataResult<HentPersonResponse> = PersondataResult.runCatching(InformasjonElement.BANKKONTO) { utenlandskBankkonto },
+    tredjepartsPerson: PersondataResult<Map<String, Persondata.TredjepartsPerson>> = PersondataResult.runCatching(InformasjonElement.PDL_TREDJEPARTSPERSONER) { tredjepartsPersoner }
 ) = PersondataFletter.Data(
     personIdent = personIdent,
     persondata = persondata,


### PR DESCRIPTION
gjøres lik at det er enklere å holde oversikt over hvilke verdier som kan komme fra endepunktet, og hva vi evt må håndtere i frontend
