### PR TITLE
[KAIZEN-0] fjerne duplikate journalposter

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -117,6 +117,7 @@ class SfHenvendelseServiceImpl(
             .map(kassertInnhold(OffsetDateTime.now()))
             .map(journalfortTemaTilgang(tematilganger))
             .map(::sorterMeldinger)
+            .map(::unikeJournalposter)
     }
 
     override fun hentHenvendelse(kjedeId: String): HenvendelseDTO {
@@ -396,6 +397,12 @@ class SfHenvendelseServiceImpl(
     private fun sorterMeldinger(henvendelse: HenvendelseDTO): HenvendelseDTO {
         return henvendelse.copy(
             meldinger = henvendelse.meldinger?.sortedBy { it.sendtDato }
+        )
+    }
+
+    private fun unikeJournalposter(henvendelse: HenvendelseDTO): HenvendelseDTO {
+        return henvendelse.copy(
+            journalposter = henvendelse.journalposter?.distinctBy { Pair(it.journalfortTema, it.fagsakId) }
         )
     }
 


### PR DESCRIPTION
Tråder bestående av flere samtalereferat vil ha duplikate innslag av journalposter siden i SF er ikke referatene sammenslåtte, og ved merging i API så blir ikke duplikate journalposter håndtert av dem.
