### PR TITLE
[PROD][KAIZEN-0] endre tilgang for tema og fjerne duplikater

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
@@ -48,7 +48,7 @@ class InternalController @Autowired constructor(
             .check(Policies.kanBrukeInternal)
             .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Personalia, AuditIdentifier.FNR to fnr)) {
                 runBlocking {
-                    DebugPersondata(pdlClient).execute(DebugPersondata.Variables(fnr))
+                    DebugPersondata(pdlClient).execute(DebugPersondata.Variables(fnr), systemTokenAuthHeader)
                 }
             }
     }


### PR DESCRIPTION
- har man tilgang til ett av de journalførte temaene så skal det være nok til å gi innsikt i meldingen

- Tråder bestående av flere samtalereferat vil ha duplikate innslag av journalposter siden i SF er ikke referatene sammenslåtte, og ved merging i API så blir ikke duplikate journalposter håndtert av dem.