### PR TITLE
[KAIZEN-0] hente ut regional-enheter via norgs organisering api

### DIFF
--- a/tjenestespesifikasjoner/norg-api/pom.xml
+++ b/tjenestespesifikasjoner/norg-api/pom.xml
@@ -59,7 +59,7 @@
                             <packageName>no.nav.modiapersonoversikt.legacy.api.domain.norg.generated</packageName>
                             <modelNameSuffix>DTO</modelNameSuffix>
                             <templateDirectory>${project.basedir}/../openapi-templates</templateDirectory>
-                            <apisToGenerate>Arbeidsfordeling,Enhet,Enhetskontaktinfo</apisToGenerate>
+                            <apisToGenerate>Arbeidsfordeling,Enhet,Enhetskontaktinfo,Organisering</apisToGenerate>
                             <configOptions>
                                 <useTags>true</useTags>
                                 <enumPropertyNaming>original</enumPropertyNaming>

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgApi.kt
@@ -15,6 +15,7 @@ import no.nav.modiapersonoversikt.infrastructure.types.Pingable
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.apis.ArbeidsfordelingApi
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.apis.EnhetApi
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.apis.EnhetskontaktinfoApi
+import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.apis.OrganiseringApi
 import no.nav.modiapersonoversikt.legacy.api.domain.norg.generated.models.*
 import no.nav.modiapersonoversikt.utils.Retry
 import no.nav.modiapersonoversikt.utils.isNumeric
@@ -70,6 +71,7 @@ class NorgApiImpl(
     private var lastUpdateOfCache: LocalDateTime? = null
     private val navkontorCache = createNorgCache<String, Enhet>()
     private val gtCache = createNorgCache<String, List<EnhetGeografiskTilknyttning>>()
+    private val regionalkontorCache = createNorgCache<EnhetId, EnhetId>()
 
     private val retry = Retry(
         Retry.Config(
@@ -83,6 +85,7 @@ class NorgApiImpl(
     private val arbeidsfordelingApi = ArbeidsfordelingApi(url, httpClient)
     private val enhetApi = EnhetApi(url, httpClient)
     private val enhetKontaktInfoApi = EnhetskontaktinfoApi(url, httpClient)
+    private val organiseringApi = OrganiseringApi(url, httpClient)
 
     init {
         hentEnheterOgKontaktinformasjon()
@@ -141,7 +144,13 @@ class NorgApiImpl(
     }
 
     override fun hentRegionalEnhet(enhet: EnhetId): EnhetId? {
-        return cache[enhet]?.overordnetEnhet
+        return regionalkontorCache.get(enhet) { enhetId ->
+            organiseringApi.getAllOrganiseringerForEnhetUsingGET(enhetId.get())
+                .firstOrNull { it.orgType == "FYLKE" }
+                ?.organiserer
+                ?.nr
+                ?.let(::EnhetId)
+        }
     }
 
     override fun hentBehandlendeEnheter(
@@ -182,7 +191,7 @@ class NorgApiImpl(
     }
 
     override fun ping() = SelfTestCheck(
-        "NorgApi via $url (${cache.size}, ${gtCache.estimatedSize()}, ${navkontorCache.estimatedSize()})",
+        "NorgApi via $url (${cache.size}, ${gtCache.estimatedSize()}, ${navkontorCache.estimatedSize()}, ${regionalkontorCache.estimatedSize()})",
         false
     ) {
         val limit = LocalDateTime.now(clock).minus(cacheRetention).plus(cacheGraceperiod)


### PR DESCRIPTION
Overordnet enhet kan ikke brukes da dette feltet er null i visse tilfeller, f.eks for enhet 0696 selvom enheten har en tilhørighet til en fylkes-enhet.
