### PR TITLE
[KAIZEN-0] ikke printe verdier flere ganger i abac-rapport

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/kabac/impl/EvaluationContextImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/kabac/impl/EvaluationContextImpl.kt
@@ -19,7 +19,7 @@ class EvaluationContextImpl(
         return keystack.withCycleDetection(key) {
             if (cache.containsKey(key)) {
                 val value = cache[key] as TValue
-                report("Requested $key, cache-hit: $value")
+                report("Requested $key, cache-hit")
                 value
             } else {
                 val provider = register[key]


### PR DESCRIPTION
spesielt rolle-listen til veileder kan være stor, og er unødvendig å logge flere ganger siden den er cached innen for en evaluering
