### PR TITLE
[PROD][KAIZEN-0] fjerne automatisk nullability fra kabac 

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/kabac/Kabac.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/kabac/Kabac.kt
@@ -24,7 +24,7 @@ object Kabac {
     }
 
     interface PolicyInformationPoint<TValue> : AttributeKey<TValue> {
-        fun provide(ctx: EvaluationContext): TValue?
+        fun provide(ctx: EvaluationContext): TValue
     }
     interface PolicyDecisionPoint {
         fun install(informationPoint: PolicyInformationPoint<*>): PolicyDecisionPoint

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersAktorIdPip.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersAktorIdPip.kt
@@ -13,8 +13,11 @@ class BrukersAktorIdPip(private val pdl: PdlOppslagService) : Kabac.PolicyInform
         override val key = CommonAttributes.AKTOR_ID
     }
 
-    override fun provide(ctx: EvaluationContext): AktorId? {
+    override fun provide(ctx: EvaluationContext): AktorId {
         val fnr = ctx.getValue(CommonAttributes.FNR)
-        return pdl.hentAktorId(fnr.get())?.let(::AktorId)
+        val aktorid = checkNotNull(pdl.hentAktorId(fnr.get())) {
+            "Fant ikke aktor id for $fnr"
+        }
+        return AktorId(aktorid)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersDiskresjonskodePip.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersDiskresjonskodePip.kt
@@ -7,12 +7,12 @@ import no.nav.modiapersonoversikt.infrastructure.kabac.utils.Key
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.kabac.CommonAttributes
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
 
-class BrukersDiskresjonskodePip(private val pdl: PdlOppslagService) : Kabac.PolicyInformationPoint<BrukersDiskresjonskodePip.Kode> {
+class BrukersDiskresjonskodePip(private val pdl: PdlOppslagService) : Kabac.PolicyInformationPoint<BrukersDiskresjonskodePip.Kode?> {
     enum class Kode { KODE6, KODE7 }
 
     override val key = Companion.key
-    companion object : Kabac.AttributeKey<Kode> {
-        override val key = Key<Kode>(BrukersDiskresjonskodePip::class.java.simpleName)
+    companion object : Kabac.AttributeKey<Kode?> {
+        override val key = Key<Kode?>(BrukersDiskresjonskodePip::class.java.simpleName)
     }
 
     override fun provide(ctx: EvaluationContext): Kode? {

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersFnrPip.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/BrukersFnrPip.kt
@@ -13,8 +13,11 @@ class BrukersFnrPip(private val pdl: PdlOppslagService) : Kabac.PolicyInformatio
         override val key = CommonAttributes.FNR
     }
 
-    override fun provide(ctx: EvaluationContext): Fnr? {
+    override fun provide(ctx: EvaluationContext): Fnr {
         val aktorId = ctx.getValue(CommonAttributes.AKTOR_ID)
-        return pdl.hentFnr(aktorId.get())?.let(::Fnr)
+        val fnr = checkNotNull(pdl.hentFnr(aktorId.get())) {
+            "Fant ikke fnr for $aktorId"
+        }
+        return Fnr(fnr)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/NavIdentPip.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/providers/NavIdentPip.kt
@@ -8,7 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.kabac.utils.Key
 object NavIdentPip : Kabac.PolicyInformationPoint<NavIdent> {
     override val key = Key<NavIdent>(NavIdentPip)
 
-    override fun provide(ctx: EvaluationContext): NavIdent? {
-        return ctx.getValue(AuthContextPip).navIdent.orElse(null)
+    override fun provide(ctx: EvaluationContext): NavIdent {
+        return ctx.getValue(AuthContextPip).requireNavIdent()
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/enumkodeverk/Fagsystem.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/enumkodeverk/Fagsystem.kt
@@ -8,9 +8,18 @@ enum class Fagsystem(private val systemnavn: String) : EnumKodeverk.WithValue<St
     OEBS("OeBS"),
     PP01("Pesys"),
     V2("V2"),
-    UFM("Unntak"),
+    UFM("Unntak fra medlemskap"),
     FS36("Vedtaksløsning Foreldrepenger"),
-    BISYS("Kopiert inn i Bisys");
+    BISYS("Kopiert inn i Bisys"),
+    K9("Sykdom i familien"),
+    FS38("Melosys"),
+    OB36("UR"),
+    BA("Barnetrygd"),
+    EF("Enslig forsørger)"),
+    HJELPEMIDLER("Hjelpemidler"),
+    OMSORGSPENGER("Omsorgspenger"),
+    SUPSTONAD("Supplerende Stønad"),
+    KONT("Kontantstøtte");
 
     override fun getValue(): String = this.systemnavn
 }


### PR DESCRIPTION
Hovedendringen er i `PIP::provider` hvor `TValue?` er endret til `TValue`.
Tidligere godtok pip'ene at man returnerte null selvom kontrakten til pip'en var å returnere en `TValue`, dette gjorde at policies og andre pip'er kunne havne i en situasjon hvor de fikk en nullpointerexception.

Endringen medfører nå at man må være eksplisitt om man ønsker å returnere null verdier, dette tvinger da policies til å håndtere disse fremover.