### PR TITLE
[KAIZEN-0] Fjerner ubrukte felt

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagService.kt
@@ -30,9 +30,6 @@ interface PdlOppslagService {
 
     enum class PdlFelt(val feltnavn: String, val rule: SokKriterieRule) {
         NAVN("fritekst.navn", FUZZY_MATCH),
-        FORNAVN("person.navn.fornavn", FUZZY_MATCH),
-        ETTERNAVN("person.navn.etternavn", FUZZY_MATCH),
-        MELLOMNAVN("person.navn.mellomnavn", FUZZY_MATCH),
         ADRESSE("fritekst.adresser", CONTAINS),
         UTENLANDSK_ID("person.utenlandskIdentifikasjonsnummer.identifikasjonsnummer", EQUALS),
         FODSELSDATO_FRA("person.foedsel.foedselsdato", AFTER),


### PR DESCRIPTION
Etter at navnesøk ble endret til å kun ta inn navn, og ikke lenger spesifiserer at det er fornavn eller etternavn, så vil ikke disse feltene være nødvendige å bruke til søk på navn