### PR TITLE
[KAIZEN-0] Endrer mapping av systemKilde

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -357,9 +357,6 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
     private fun hentSisteEndringFraMetadata(metadata: HentPersondata.Metadata): Persondata.SistEndret? {
         return metadata.endringer.maxByOrNull { it.registrert.value }
             ?.let {
-                TjenestekallLogger.logger.info(
-                    "[PDL-KILDE] registrertAv: ${it.registrertAv} systemKilde: ${it.systemkilde} kilde: ${it.kilde}"
-                )
                 Persondata.SistEndret(
                     ident = it.registrertAv,
                     tidspunkt = it.registrert.value,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -373,16 +373,16 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         return when (system) {
             "FREG" -> "folkeregisteret"
             "BD03" -> "bruker"
-            "srvpersonopplysnin" -> "personopplysninger"
+            "srvpersonopplysnin" -> "bruker"
             "PP01" -> "NAV"
             "BD06" -> "NAV"
             "FS22" -> "NAV"
-            "personopplysninger-api" -> "personopplysninger"
+            "personopplysninger-api" -> "bruker"
             "srvperson-forvalter" -> "NAV"
             "IT00" -> "NAV"
-            "srvPdl-Web" -> "PDL"
+            "srvPdl-Web" -> "NAV"
             "BI00" -> "NAV"
-            "pdl-web" -> "PDL"
+            "pdl-web" -> "NAV"
             "SrvOppgRobotNOP" -> "NAV"
             else -> {
                 log.info("[PDL-KILDE] systemKilde: $system")


### PR DESCRIPTION
- [KAIZEN-0] Endrer mapping på noen systemKilder basert på informasjon fra logging
  Ved å se i loggen hvem som er registrertAv for de ulike systemKildene som forekommer, ser vi at det i disse tilfellene er NAV og bruker, så da endres mapping til de respektive verdiene bassert på informasjonen vi får fra hvem som har registrert endringen.

- [KAIZEN-0] Fjerner logging
Vi har nå fått informasjonen vi trenger for å avgjøre hvordan vi best kan mappe systemKilde i forhold til hvem det er registrertAv, så denne ekstra loggingen er ikke lenger nødvendig.