### PR TITLE
[KAIZEN-0] legge til operationname for graphql spørringer

### DIFF
--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentAdressebeskyttelse.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentAdressebeskyttelse.graphql
@@ -1,4 +1,4 @@
-query($ident: ID!){
+query hentAdressebeskyttelse($ident: ID!){
     hentPerson(ident: $ident) {
         adressebeskyttelse {
             gradering

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentAktorid.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentAktorid.graphql
@@ -1,4 +1,4 @@
-query($ident: ID!, $grupper: [IdentGruppe!]!){
+query hentAktorid($ident: ID!, $grupper: [IdentGruppe!]!){
     hentIdenter(ident: $ident, grupper: $grupper, historikk: false) {
         identer {
             ident

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentGeografiskTilknyttning.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentGeografiskTilknyttning.graphql
@@ -1,4 +1,4 @@
-query($ident: ID!){
+query hentGeografiskTilknyttning($ident: ID!){
     hentGeografiskTilknytning(ident: $ident) {
         gtType
         gtKommune

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentIdenter.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentIdenter.graphql
@@ -1,4 +1,4 @@
-query($ident: ID!){
+query hentIdenter($ident: ID!){
     hentIdenter(ident: $ident, historikk: true) {
         identer {
             ident

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentPersondata.graphql
@@ -66,7 +66,7 @@ fragment biPerson on RelatertBiPerson {
     kjoenn
 }
 
-query($ident: ID!){
+query hentPersondata($ident: ID!){
     hentGeografiskTilknytning(ident: $ident) {
         gtType
         gtKommune

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentTredjepartspersondata.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/hentTredjepartspersondata.graphql
@@ -1,4 +1,4 @@
-query($identer: [ID!]!){
+query hentTredjepartspersondata($identer: [ID!]!){
     hentPersonBolk(identer: $identer) {
         ident
         person {

--- a/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/sokPerson.graphql
+++ b/tjenestespesifikasjoner/pdl-api/src/main/resources/pdl/queries/sokPerson.graphql
@@ -1,4 +1,4 @@
-query($paging: Paging, $criteria: [Criterion]) {
+query sokPerson($paging: Paging, $criteria: [Criterion]) {
     sokPerson(paging: $paging, criteria: $criteria) {
         hits {
             score

--- a/tjenestespesifikasjoner/saf-api/src/main/resources/saf/queries/hentBrukersDokumenter.graphql
+++ b/tjenestespesifikasjoner/saf-api/src/main/resources/saf/queries/hentBrukersDokumenter.graphql
@@ -1,4 +1,4 @@
-query($brukerId: BrukerIdInput!) {
+query hentBrukersDokumenter($brukerId: BrukerIdInput!) {
     dokumentoversiktBruker(
         brukerId: $brukerId,
         journalstatuser: [JOURNALFOERT, FERDIGSTILT, EKSPEDERT],

--- a/tjenestespesifikasjoner/saf-api/src/main/resources/saf/queries/hentbrukerssaker.graphql
+++ b/tjenestespesifikasjoner/saf-api/src/main/resources/saf/queries/hentbrukerssaker.graphql
@@ -1,4 +1,4 @@
-query($brukerId: BrukerIdInput!) {
+query hentBrukersSaker($brukerId: BrukerIdInput!) {
     saker(brukerId: $brukerId) {
         arkivsaksnummer
         arkivsaksystem

--- a/tjenestespesifikasjoner/saf-api/src/main/resources/saf/schema.graphql
+++ b/tjenestespesifikasjoner/saf-api/src/main/resources/saf/schema.graphql
@@ -626,13 +626,9 @@ enum Kanal {
     # Forsendelsen inneholder en komplett chatdialog (inngående og utgående meldinger) mellom en bruker og en veileder i NAV.
     NAV_NO_CHAT
 
-    # Brevet er sendt via digital post til virksomhet.
+    # Brevet er sendt til virksomhet som taushetsbelagt digital post.
     # * Brukes for utgående journalposter.
-    DPV
-
-    # Brevet er sendt via digital post til virksomhet som sensitiv post.
-    # * Brukes for utgående journalposter.
-    DPVS
+    DPVT
 
     # Forsendelsen har ingen kjent kanal.
     UKJENT

--- a/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/SafService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/legacy/sak/service/saf/SafService.kt
@@ -8,7 +8,7 @@ import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersDokumenter
 import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersDokumenter.Journalposttype
-import no.nav.modiapersonoversikt.consumer.saf.generated.Hentbrukerssaker
+import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersSaker
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.*
 import no.nav.modiapersonoversikt.legacy.sak.providerdomain.Baksystem
@@ -30,7 +30,7 @@ interface SafService {
         variantFormat: Dokument.Variantformat
     ): TjenesteResultatWrapper
 
-    fun hentSaker(ident: String): GraphQLResponse<Hentbrukerssaker.Result>
+    fun hentSaker(ident: String): GraphQLResponse<HentBrukersSaker.Result>
 }
 
 private val SAF_GRAPHQL_BASEURL: String = EnvironmentUtils.getRequiredProperty("SAF_GRAPHQL_URL")
@@ -83,24 +83,24 @@ class SafServiceImpl : SafService {
         }
     }
 
-    override fun hentSaker(ident: String): GraphQLResponse<Hentbrukerssaker.Result> {
+    override fun hentSaker(ident: String): GraphQLResponse<HentBrukersSaker.Result> {
         val variables = if (ident.length == 11) {
-            Hentbrukerssaker.Variables(
-                Hentbrukerssaker.BrukerIdInput(
+            HentBrukersSaker.Variables(
+                HentBrukersSaker.BrukerIdInput(
                     id = ident,
-                    type = Hentbrukerssaker.BrukerIdType.FNR
+                    type = HentBrukersSaker.BrukerIdType.FNR
                 )
             )
         } else {
-            Hentbrukerssaker.Variables(
-                Hentbrukerssaker.BrukerIdInput(
+            HentBrukersSaker.Variables(
+                HentBrukersSaker.BrukerIdInput(
                     id = ident,
-                    type = Hentbrukerssaker.BrukerIdType.AKTOERID
+                    type = HentBrukersSaker.BrukerIdType.AKTOERID
                 )
             )
         }
         return runBlocking {
-            Hentbrukerssaker(graphQLClient)
+            HentBrukersSaker(graphQLClient)
                 .execute(variables, userTokenAuthorizationHeaders)
         }
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SafDebugController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SafDebugController.kt
@@ -3,7 +3,7 @@ package no.nav.modiapersonoversikt.rest.saker
 import com.expediagroup.graphql.types.GraphQLResponse
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
-import no.nav.modiapersonoversikt.consumer.saf.generated.Hentbrukerssaker
+import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersSaker
 import no.nav.modiapersonoversikt.infrastructure.naudit.Audit
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
@@ -23,7 +23,7 @@ class SafDebugController @Autowired constructor(
     private val safService: SafService
 ) {
     @GetMapping("/{ident}/fnr")
-    fun hentSafSakerFnr(@PathVariable("ident") ident: String): GraphQLResponse<Hentbrukerssaker.Result> {
+    fun hentSafSakerFnr(@PathVariable("ident") ident: String): GraphQLResponse<HentBrukersSaker.Result> {
         return tilgangskontroll
             .check(Policies.tilgangTilBruker(Fnr(ident)))
             .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Saker, AuditIdentifier.FNR to ident)) {
@@ -32,7 +32,7 @@ class SafDebugController @Autowired constructor(
     }
 
     @GetMapping("/{ident}/aktorid")
-    fun hentSafSakerAktorId(@PathVariable("ident") ident: String): GraphQLResponse<Hentbrukerssaker.Result> {
+    fun hentSafSakerAktorId(@PathVariable("ident") ident: String): GraphQLResponse<HentBrukersSaker.Result> {
         return tilgangskontroll
             .check(Policies.tilgangTilBruker(AktorId(ident)))
             .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Saker, AuditIdentifier.FNR to ident)) {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/saker/kilder/SafSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/saker/kilder/SafSaker.kt
@@ -1,6 +1,6 @@
 package no.nav.modiapersonoversikt.service.saker.kilder
 
-import no.nav.modiapersonoversikt.consumer.saf.generated.Hentbrukerssaker
+import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersSaker
 import no.nav.modiapersonoversikt.legacy.sak.service.saf.SafService
 import no.nav.modiapersonoversikt.service.saker.Sak
 import no.nav.modiapersonoversikt.service.saker.SakerKilde
@@ -23,8 +23,8 @@ class SafSaker(private val service: SafService) : SakerKilde {
                     temaKode = it.tema?.name ?: ""
                     fagsystemKode = it.fagsaksystem ?: ""
                     sakstype = when (it.sakstype) {
-                        Hentbrukerssaker.Sakstype.FAGSAK -> "MFS"
-                        Hentbrukerssaker.Sakstype.GENERELL_SAK -> "GEN"
+                        HentBrukersSaker.Sakstype.FAGSAK -> "MFS"
+                        HentBrukersSaker.Sakstype.GENERELL_SAK -> "GEN"
                         else -> throw IllegalStateException("Ukjent sakstype: ${it.sakstype}")
                     }
                 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/saker/SakerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/saker/SakerServiceImplTest.kt
@@ -13,7 +13,7 @@ import no.nav.common.auth.context.AuthContext
 import no.nav.common.auth.context.UserRole
 import no.nav.common.log.MDCConstants
 import no.nav.common.utils.EnvironmentUtils
-import no.nav.modiapersonoversikt.consumer.saf.generated.Hentbrukerssaker
+import no.nav.modiapersonoversikt.consumer.saf.generated.HentBrukersSaker
 import no.nav.modiapersonoversikt.legacy.sak.service.saf.SafService
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.modiapersonoversikt.service.saker.Sak.*
@@ -222,76 +222,76 @@ class SakerServiceImplTest {
         const val FagsystemSakId_3 = "33"
         const val SakId_4 = "4"
 
-        fun earlierDateTimeWithOffSet(offset: Long) = Hentbrukerssaker.DateTime(
+        fun earlierDateTimeWithOffSet(offset: Long) = HentBrukersSaker.DateTime(
             LocalDateTime.now().minusDays(offset)
         )
 
-        fun createSaksliste(): GraphQLResponse<Hentbrukerssaker.Result> {
+        fun createSaksliste(): GraphQLResponse<HentBrukersSaker.Result> {
             return GraphQLResponse(
-                data = Hentbrukerssaker.Result(
+                data = HentBrukersSaker.Result(
                     saker = listOf(
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = SakId_1,
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(4),
                             fagsakId = FagsystemSakId_1,
                             fagsaksystem = "IT01",
-                            sakstype = Hentbrukerssaker.Sakstype.FAGSAK,
+                            sakstype = HentBrukersSaker.Sakstype.FAGSAK,
                             tema = null
                         ),
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = SakId_2,
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(3),
                             fagsaksystem = "IT01",
                             fagsakId = FagsystemSakId_2,
-                            sakstype = Hentbrukerssaker.Sakstype.FAGSAK,
+                            sakstype = HentBrukersSaker.Sakstype.FAGSAK,
                             tema = null
                         ),
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = SakId_3,
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(5),
                             fagsaksystem = "IT01",
                             fagsakId = FagsystemSakId_3,
-                            sakstype = Hentbrukerssaker.Sakstype.FAGSAK,
+                            sakstype = HentBrukersSaker.Sakstype.FAGSAK,
                             tema = null
                         ),
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = SakId_4,
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(5),
                             fagsaksystem = null,
                             fagsakId = null,
-                            sakstype = Hentbrukerssaker.Sakstype.GENERELL_SAK,
-                            tema = Hentbrukerssaker.Tema.STO
+                            sakstype = HentBrukersSaker.Sakstype.GENERELL_SAK,
+                            tema = HentBrukersSaker.Tema.STO
                         )
                     )
                 )
             )
         }
 
-        fun createOppfolgingSaksliste(): GraphQLResponse<Hentbrukerssaker.Result> {
+        fun createOppfolgingSaksliste(): GraphQLResponse<HentBrukersSaker.Result> {
             return GraphQLResponse(
-                data = Hentbrukerssaker.Result(
+                data = HentBrukersSaker.Result(
                     saker = listOf(
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = "4",
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(0),
                             fagsaksystem = "AO01",
                             fagsakId = "44",
-                            sakstype = Hentbrukerssaker.Sakstype.FAGSAK,
-                            tema = Hentbrukerssaker.Tema.OPP
+                            sakstype = HentBrukersSaker.Sakstype.FAGSAK,
+                            tema = HentBrukersSaker.Tema.OPP
                         ),
-                        Hentbrukerssaker.Sak(
+                        HentBrukersSaker.Sak(
                             arkivsaksnummer = "5",
                             arkivsaksystem = null,
                             datoOpprettet = earlierDateTimeWithOffSet(3),
                             fagsaksystem = "FS22",
                             fagsakId = null,
-                            sakstype = Hentbrukerssaker.Sakstype.GENERELL_SAK,
-                            tema = Hentbrukerssaker.Tema.OPP
+                            sakstype = HentBrukersSaker.Sakstype.GENERELL_SAK,
+                            tema = HentBrukersSaker.Tema.OPP
                         )
                     )
                 )


### PR DESCRIPTION
gjør det litt enklere å identifisere graphql-requester i loggene, siden operationname er noe vi logger for requesten
