### PR TITLE
[KAIZEN-0] oppdatere veilarboppfolging urler

### DIFF
--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -125,7 +125,7 @@ spec:
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp-q0.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
     - name: VEILARBOPPFOLGINGAPI_URL
-      value: "https://veilarboppfolging-q0.nais.preprod.local/veilarboppfolging/api"
+      value: "https://veilarboppfolging.dev.intern.nav.no/veilarboppfolging/api"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -121,7 +121,7 @@ spec:
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp-q1.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
     - name: VEILARBOPPFOLGINGAPI_URL
-      value: "https://veilarboppfolging-q1.nais.preprod.local/veilarboppfolging/api"
+      value: "https://veilarboppfolging.dev.intern.nav.no/veilarboppfolging/api"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -121,7 +121,7 @@ spec:
     - name: UTBETALING_V1_ENDPOINTURL
       value: "https://wasapp.adeo.no/nav-utbetaldata-ws/virksomhet/Utbetaling_v1"
     - name: VEILARBOPPFOLGINGAPI_URL
-      value: "https://veilarboppfolging.nais.adeo.no/veilarboppfolging/api"
+      value: "https://veilarboppfolging.intern.nav.no/veilarboppfolging/api"
     - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
       value: "https://dkif.nais.adeo.no/ws/DigitalKontaktinformasjon/v1"
     - name: DKIF_REST_URL


### PR DESCRIPTION
Nye dev-ingress har ikke et klart skille på q1/q2 i følge utviklerne.