### PR TITLE
[PROD][KAIZEN-0] utvidet funksjonalitet til tjenestekall logger

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/TjenestekallLogger.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/TjenestekallLogger.kt
@@ -1,16 +1,38 @@
 package no.nav.modiapersonoversikt.infrastructure
 
+import net.logstash.logback.marker.Markers
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.Marker
 
 object TjenestekallLogger {
     private val tjenestekallLogg = LoggerFactory.getLogger("SecureLog")
+    const val LOGTYPE = "logtype"
+    enum class Level {
+        INFO, WARN, ERROR
+    }
 
-    fun info(header: String, fields: Map<String, Any?>) = tjenestekallLogg.info(format(header, fields))
-    fun warn(header: String, fields: Map<String, Any?>) = tjenestekallLogg.warn(format(header, fields))
-    fun error(header: String, fields: Map<String, Any?>) = tjenestekallLogg.error(format(header, fields))
-    fun error(header: String, fields: Map<String, Any?>, throwable: Throwable) =
-        tjenestekallLogg.error(format(header, fields), throwable)
+    fun raw(
+        level: Level,
+        header: String,
+        fields: Map<String, Any?>,
+        tags: Map<String, Any?> = emptyMap(),
+        exception: Throwable? = null,
+    ) {
+        val message = format(header, fields)
+        val logcall: (Marker, String, Throwable?) -> Unit = when (level) {
+            Level.INFO -> tjenestekallLogg::info
+            Level.WARN -> tjenestekallLogg::warn
+            Level.ERROR -> tjenestekallLogg::error
+        }
+        logcall(Markers.appendEntries(tags), message, exception)
+    }
+
+    fun info(header: String, fields: Map<String, Any?>, tags: Map<String, Any?> = emptyMap()) = raw(Level.INFO, header, fields, tags)
+    fun warn(header: String, fields: Map<String, Any?>, tags: Map<String, Any?> = emptyMap()) = raw(Level.WARN, header, fields, tags)
+    fun error(header: String, fields: Map<String, Any?>, tags: Map<String, Any?> = emptyMap()) = raw(Level.ERROR, header, fields, tags)
+    fun error(header: String, fields: Map<String, Any?>, tags: Map<String, Any?> = emptyMap(), throwable: Throwable) =
+        raw(Level.ERROR, header, fields, tags, throwable)
 
     val logger: Logger = tjenestekallLogg
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
@@ -81,7 +81,11 @@ class LoggingGraphqlClient(
             response
         } catch (exception: Exception) {
             log.error("Feilet ved oppslag mot $name (ID: $callId)", exception)
-            TjenestekallLogger.error("$name-response: $callId ($requestId)", mapOf("exception" to exception))
+            TjenestekallLogger.error(
+                header = "$name-response: $callId ($requestId)",
+                fields = mapOf("exception" to exception.message),
+                throwable = exception
+            )
             val error = GraphQLError("Feilet ved oppslag mot $name (ID: $callId)")
             GraphQLResponse(errors = listOf(error))
         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -92,11 +92,15 @@ class LoggingInterceptor(
             .onFailure { exception ->
                 log.error("$name-response-error (ID: $callId / $requestId)", exception)
                 TjenestekallLogger.error(
-                    "$name-response-error: $callId ($requestId))",
-                    mapOf(
-                        "exception" to exception,
+                    header = "$name-response-error: $callId ($requestId))",
+                    fields = mapOf(
+                        "exception" to exception.message,
                         "time" to timer.measure()
-                    )
+                    ),
+                    tags = mapOf(
+                        "time" to timer.measure()
+                    ),
+                    throwable = exception
                 )
             }
             .getOrThrow()
@@ -105,20 +109,26 @@ class LoggingInterceptor(
 
         if (response.code() in 200..299) {
             TjenestekallLogger.info(
-                "$name-response: $callId ($requestId)",
-                mapOf(
+                header = "$name-response: $callId ($requestId)",
+                fields = mapOf(
                     "status" to "${response.code()} ${response.message()}",
                     "time" to timer.measure(),
                     "body" to responseBody
+                ),
+                tags = mapOf(
+                    "time" to timer.measure(),
                 )
             )
         } else {
             TjenestekallLogger.error(
-                "$name-response-error: $callId ($requestId)",
-                mapOf(
+                header = "$name-response-error: $callId ($requestId)",
+                fields = mapOf(
                     "status" to "${response.code()} ${response.message()}",
                     "time" to timer.measure(),
                     "body" to responseBody
+                ),
+                tags = mapOf(
+                    "time" to timer.measure(),
                 )
             )
         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/Audit.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/Audit.kt
@@ -1,6 +1,8 @@
 package no.nav.modiapersonoversikt.infrastructure.naudit
 
+import net.logstash.logback.marker.Markers
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
+import no.nav.modiapersonoversikt.infrastructure.TjenestekallLogger
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier.DENY_REASON
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier.FAIL_REASON
 import org.slf4j.LoggerFactory
@@ -91,6 +93,7 @@ class Audit {
             return WithDataDescriptor(action, resourceType, extractIdentifiers)
         }
 
+        private val auditMarker = Markers.appendEntries(mapOf(TjenestekallLogger.LOGTYPE to "audit"))
         private fun logInternal(action: Action, resourceType: AuditResource, identifiers: Array<Pair<AuditIdentifier, String?>>) {
             val subject = AuthContextUtils.getIdent()
             val logline = listOfNotNull(
@@ -105,7 +108,7 @@ class Audit {
             )
                 .joinToString(" ")
 
-            tjenestekallLogg.info(logline)
+            tjenestekallLogg.info(auditMarker, logline)
             cefLogger.log(CEFEvent(action, resourceType, subject.orElse("-"), identifiers))
         }
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/utbetaling/UtbetalingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/utbetaling/UtbetalingController.kt
@@ -90,10 +90,11 @@ class UtbetalingController @Autowired constructor(
     }
 
     fun utbetalingSammenligning(
+        markers: Scientist.Markers,
         wsUtbetalinger: List<UtbetalingDomain.Utbetaling>,
         anyTry: Scientist.UtilityClasses.Try<Any?>
-    ): Map<String, Any?> {
-        if (anyTry.isFailure) return emptyMap()
+    ) {
+        if (anyTry.isFailure) return
         val restUtbetalinger = anyTry.getOrThrow() as List<UtbetalingDomain.Utbetaling>
 
         val transformerteWsUtbetalinger = wsUtbetalinger
@@ -138,11 +139,10 @@ class UtbetalingController @Autowired constructor(
                 )
             }
         val (ok, controlJson, experimentJson) = Scientist.compareAndSerialize(transformerteWsUtbetalinger, transformerteRestUtbetalinger)
+
         // Overskriver standard scientist felter etter å ha gjort en sammenligning med de kjente endringene i apiet
-        return mapOf(
-            "ok" to ok,
-            "control" to controlJson,
-            "experiment" to experimentJson,
-        )
+        markers.fieldAndTag("ok", ok)
+        markers.field("control", controlJson)
+        markers.field("experiment", experimentJson)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/utbetaling/UtbetalingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/utbetaling/UtbetalingController.kt
@@ -121,7 +121,7 @@ class UtbetalingController @Autowired constructor(
                             // SOAP returnerer dummy-objekt ved manglende arbeidsgiver. Dette feltet blir null i rest-apiet
                             arbeidsgiver = if (ytelse.arbeidsgiver?.orgnr == "000000000") null else ytelse.arbeidsgiver
                         )
-                    }.sortedWith(compareBy({ it.ytelseskomponentersum }, { it.periode?.start }))
+                    }.sortedWith(compareBy({ it.type }, { it.bilagsnummer }, { it.ytelseskomponentersum }, { it.periode?.start }))
                 )
             }
         // Sorterer mest mulig på samme måte for å få sammenligningen til å gi "ok: true"
@@ -134,7 +134,7 @@ class UtbetalingController @Autowired constructor(
                         ytelse.copy(
                             ytelseskomponentListe = ytelse.ytelseskomponentListe.sortedBy { it.ytelseskomponentbelop }
                         )
-                    }.sortedWith(compareBy({ it.ytelseskomponentersum }, { it.periode?.start }))
+                    }.sortedWith(compareBy({ it.type }, { it.bilagsnummer }, { it.ytelseskomponentersum }, { it.periode?.start }))
                 )
             }
         val (ok, controlJson, experimentJson) = Scientist.compareAndSerialize(transformerteWsUtbetalinger, transformerteRestUtbetalinger)

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/scientist/ScientistTest.kt
@@ -13,7 +13,7 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(header).contains("[SCIENCE] DummyExperiment")
                 }
             )
@@ -26,8 +26,9 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(fields).containsEntry("ok", true)
+                    assertThat(tags).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
                     assertThat(fields).containsKey("experiment")
                 }
@@ -41,12 +42,15 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(fields).containsEntry("ok", false)
+                    assertThat(tags).containsEntry("ok", false)
                     assertThat(fields).containsKey("control")
                     assertThat(fields).containsKey("controlTime")
+                    assertThat(tags).containsKey("controlTime")
                     assertThat(fields).containsKey("experiment")
                     assertThat(fields).containsKey("experimentTime")
+                    assertThat(tags).containsKey("experimentTime")
                     assertThat((fields["control"] as String)).isEqualTo("\"Hello\"")
                     assertThat((fields["experiment"] as String)).isEqualTo("\"World\"")
                 }
@@ -61,7 +65,7 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(0.7),
-                reporter = { _, _ -> experimentsRun++ }
+                reporter = { _, _, _, _ -> experimentsRun++ }
             )
         )
         repeat(1000) {
@@ -77,7 +81,7 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(0.1),
-                reporter = { _, _ -> experimentsRun++ }
+                reporter = { _, _, _, _ -> experimentsRun++ }
             )
         )
         repeat(1000) {
@@ -106,12 +110,15 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(fields).containsEntry("ok", true)
+                    assertThat(tags).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
                     assertThat(fields).containsKey("controlTime")
+                    assertThat(tags).containsKey("controlTime")
                     assertThat(fields).containsKey("experiment")
                     assertThat(fields).containsKey("experimentTime")
+                    assertThat(tags).containsKey("experimentTime")
                 }
             )
         ).run({ controlResult }, { experimentResult })
@@ -141,12 +148,15 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(fields).containsEntry("ok", true)
+                    assertThat(tags).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
                     assertThat(fields).containsKey("controlTime")
+                    assertThat(tags).containsKey("controlTime")
                     assertThat(fields).containsKey("experiment")
                     assertThat(fields).containsKey("experimentTime")
+                    assertThat(tags).containsKey("experimentTime")
                 }
             )
         ).run({ controlResult }, { experimentResult })
@@ -158,22 +168,23 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { header, fields ->
+                reporter = { header, fields, tags, _ ->
                     assertThat(fields).containsEntry("ok", true)
+                    assertThat(tags).containsEntry("ok", true)
                     assertThat(fields).containsKey("control")
                     assertThat(fields).containsKey("experiment")
                     assertThat(fields).containsKey("control-extra")
                     assertThat(fields).containsKey("experiment-extra")
+                    assertThat(tags).containsKey("tag-extra")
                 }
             )
         ).runIntrospected(
             control = { "Hello, World" },
             experiment = { "Hello, World" },
-            dataFields = { control, triedExperiment ->
-                mapOf(
-                    "control-extra" to 1,
-                    "experiment-extra" to "value"
-                )
+            dataFields = { markers, control, triedExperiment ->
+                markers.field("control-extra", 1)
+                markers.field("experiment-extra", "value")
+                markers.tag("tag-extra", "value")
             }
         )
     }
@@ -185,7 +196,7 @@ internal class ScientistTest {
             Scientist.Config(
                 name = "DummyExperiment",
                 experimentRate = Scientist.FixedValueRate(1.0),
-                reporter = { _, _ ->
+                reporter = { _, _, _, _ ->
                     val endTime = System.currentTimeMillis()
                     assertThat(endTime - startTime).isCloseTo(2000, Percentage.withPercentage(15.0))
                 }


### PR DESCRIPTION
ved bruk av fields og tags kan man styre hvilke verdier som blir lagt inn i "message" i loggen, og hvilke felter som blir søkbare/indekserte av kibana

Legger til felles marker felt til de fleste kall til tjenestekallloggen `logtype` som gjør det enkelt å finne igjen logglinjer fra en spesifik komponent, f.eks audit eller scientist
