### PR TITLE
feat/opp 1500 sladde arsak

### DIFF
--- a/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
+++ b/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
@@ -56,9 +56,6 @@ changeFile(
      */
     forDefinition("Henvendelse") {
         setRequired("gjeldendeTemagruppe", false)
-        forProperty("henvendelseType") {
-            getTyped<MutableList<String>>("enum").add("CHAT")
-        }
     }
     forDefinition("Markering") {
         setRequired("markertDato", false)
@@ -66,13 +63,6 @@ changeFile(
     }
     forDefinition("Journalpost") {
         setRequired("journalforerNavIdent", false)
-    }
-
-    /**
-     * Regresjon i API fra innføring av IdentType.System
-     */
-    forDefinition("MeldingFra") {
-        setRequired("identType", true)
     }
 }
 

--- a/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
+++ b/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
@@ -68,17 +68,17 @@ changeFile(
     /**
      * Når SF har laget api for innsending av meldingsIDer kan denne fjernes
      */
-    forDefinition("SladdeRequest") {
-        this.getTyped<Json>("properties").put(
-            "meldingId", mapOf(
-                "type" to "array",
-                "items" to mapOf(
-                    "type" to "string"
-                ),
-                "example" to arrayOf("Feil bruker", "Innehold sensitiv informasjon")
-            )
-        )
-    }
+//    forDefinition("SladdeRequest") {
+//        this.getTyped<Json>("properties").put(
+//            "meldingId", mapOf(
+//                "type" to "array",
+//                "items" to mapOf(
+//                    "type" to "string"
+//                ),
+//                "example" to arrayOf("Feil bruker", "Innehold sensitiv informasjon")
+//            )
+//        )
+//    }
 }
 
 /**

--- a/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
+++ b/tjenestespesifikasjoner/manuelle-fikser-for-api.main.kts
@@ -64,6 +64,21 @@ changeFile(
     forDefinition("Journalpost") {
         setRequired("journalforerNavIdent", false)
     }
+
+    /**
+     * Når SF har laget api for innsending av meldingsIDer kan denne fjernes
+     */
+    forDefinition("SladdeRequest") {
+        this.getTyped<Json>("properties").put(
+            "meldingId", mapOf(
+                "type" to "array",
+                "items" to mapOf(
+                    "type" to "string"
+                ),
+                "example" to arrayOf("Feil bruker", "Innehold sensitiv informasjon")
+            )
+        )
+    }
 }
 
 /**

--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
@@ -631,6 +631,13 @@ components:
         kjedeId:
           type: "string"
           example: "a0J3N000004dUBJUA2"
+        meldingId:
+          type: "array"
+          items:
+            type: "string"
+          example:
+          - "Feil bruker"
+          - "Innehold sensitiv informasjon"
       required:
       - "aarsak"
       - "kjedeId"

--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
@@ -26,14 +26,62 @@ paths:
           $ref: "#/components/responses/InternalServerError"
       parameters:
       - $ref: "#/components/parameters/X-Correlation-ID"
+  /henvendelse/sladding/aarsaker/{kjedeId}:
+    get:
+      tags:
+      - "Henvendelse Behandling"
+      description: "Returnerer gyldige sladdeårsaker for en meldingskjede"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  type: "string"
+                example:
+                - "Ikke statlig dialog"
+                - "Sikkerhetshendelse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      parameters:
+      - $ref: "#/components/parameters/X-Correlation-ID"
+      - name: "kjedeId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: "ID til kjeden som har meldinger som skal sladdes"
+  /henvendelse/sladding:
+    post:
+      tags:
+      - "Henvendelse Behandling"
+      description: "Registrerer den gitte meldingen for sladding med den definerte\
+        \ årsakskoden"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SladdeRequest"
+      responses:
+        "200":
+          description: "OK"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      parameters:
+      - $ref: "#/components/parameters/X-Correlation-ID"
   /henvendelse/journal:
     post:
       tags:
-      - "Journal"
+      - "Henvendelse Behandling"
       description: "Endepunkt for igangsettelse av journalføring mot JOARK. Referanse\
         \ til fagsak i overenstemmelse med påkrevd input til [Dokarkiv API](https://dokarkiv-q2.nais.preprod.local/swagger-ui.html#/arkiver-og-journalfoer-rest-controller/opprettJournalpostUsingPOST).\
-        \ Ved blank/null som saksId vil journalposten opprettes som generell sak på\
-        \ tema."
+        \ Ved blank/null som saksId (og fagsaksystem) vil journalposten opprettes\
+        \ som generell sak på tema."
       requestBody:
         required: true
         description: "JSON request med metadata for journalpost"
@@ -475,11 +523,16 @@ components:
           - "OPPMOTE"
           - "DIGITAL"
           example: "DIGITAL"
+        meldingsId:
+          type: "string"
+          description: "Unik id for meldingen i kjeden"
+          example: "a0J3N000004dUBJUA2"
         fra:
           $ref: "#/components/schemas/MeldingFra"
       required:
       - "sendtDato"
       - "fra"
+      - "meldingsId"
     Henvendelse:
       type: "object"
       properties:
@@ -569,6 +622,18 @@ components:
       required:
       - "navn"
       - "kode"
+    SladdeRequest:
+      type: "object"
+      properties:
+        aarsak:
+          type: "string"
+          example: "Sikkerhetshendelse"
+        kjedeId:
+          type: "string"
+          example: "a0J3N000004dUBJUA2"
+      required:
+      - "aarsak"
+      - "kjedeId"
     Error:
       type: "object"
       properties:

--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi-fixed.yaml
@@ -631,13 +631,6 @@ components:
         kjedeId:
           type: "string"
           example: "a0J3N000004dUBJUA2"
-        meldingId:
-          type: "array"
-          items:
-            type: "string"
-          example:
-          - "Feil bruker"
-          - "Innehold sensitiv informasjon"
       required:
       - "aarsak"
       - "kjedeId"

--- a/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi.json
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/src/main/resources/sf-henvendelse/openapi.json
@@ -39,10 +39,81 @@
         ]
       }
     },
+    "/henvendelse/sladding/aarsaker/{kjedeId}": {
+      "get": {
+        "tags": ["Henvendelse Behandling"],
+        "description": "Returnerer gyldige sladdeårsaker for en meldingskjede",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": ["Ikke statlig dialog", "Sikkerhetshendelse"]
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Correlation-ID"
+          },
+          {
+            "name": "kjedeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID til kjeden som har meldinger som skal sladdes"
+          }
+        ]
+      }
+    },
+    "/henvendelse/sladding": {
+      "post": {
+        "tags": ["Henvendelse Behandling"],
+        "description": "Registrerer den gitte meldingen for sladding med den definerte årsakskoden",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SladdeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/X-Correlation-ID"
+          }
+        ]
+      }
+    },
     "/henvendelse/journal": {
       "post": {
-        "tags": ["Journal"],
-        "description": "Endepunkt for igangsettelse av journalføring mot JOARK. Referanse til fagsak i overenstemmelse med påkrevd input til [Dokarkiv API](https://dokarkiv-q2.nais.preprod.local/swagger-ui.html#/arkiver-og-journalfoer-rest-controller/opprettJournalpostUsingPOST). Ved blank/null som saksId vil journalposten opprettes som generell sak på tema.",
+        "tags": ["Henvendelse Behandling"],
+        "description": "Endepunkt for igangsettelse av journalføring mot JOARK. Referanse til fagsak i overenstemmelse med påkrevd input til [Dokarkiv API](https://dokarkiv-q2.nais.preprod.local/swagger-ui.html#/arkiver-og-journalfoer-rest-controller/opprettJournalpostUsingPOST). Ved blank/null som saksId (og fagsaksystem) vil journalposten opprettes som generell sak på tema.",
         "requestBody": {
           "required": true,
           "description": "JSON request med metadata for journalpost",
@@ -578,7 +649,8 @@
             "description": "NAV enhet til avsender hvis identType = NAVIDENT",
             "example": "4100"
           }
-        }
+        },
+        "required": ["identType"]
       },
       "Melding": {
         "type": "object",
@@ -605,18 +677,23 @@
             "enum": ["TELEFON", "OPPMOTE", "DIGITAL"],
             "example": "DIGITAL"
           },
+          "meldingsId": {
+            "type": "string",
+            "description": "Unik id for meldingen i kjeden",
+            "example": "a0J3N000004dUBJUA2"
+          },
           "fra": {
             "$ref": "#/components/schemas/MeldingFra"
           }
         },
-        "required": ["sendtDato", "fra"]
+        "required": ["sendtDato", "fra", "meldingsId"]
       },
       "Henvendelse": {
         "type": "object",
         "properties": {
           "henvendelseType": {
             "type": "string",
-            "enum": ["SAMTALEREFERAT", "MELDINGSKJEDE"]
+            "enum": ["SAMTALEREFERAT", "MELDINGSKJEDE", "CHAT"]
           },
           "fnr": {
             "type": "string",
@@ -718,6 +795,20 @@
           }
         },
         "required": ["navn", "kode"]
+      },
+      "SladdeRequest": {
+        "type": "object",
+        "properties": {
+          "aarsak": {
+            "type": "string",
+            "example": "Sikkerhetshendelse"
+          },
+          "kjedeId": {
+            "type": "string",
+            "example": "a0J3N000004dUBJUA2"
+          }
+        },
+        "required": ["aarsak", "kjedeId"]
       },
       "Error": {
         "type": "object",

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/AuditResources.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/naudit/AuditResources.kt
@@ -53,6 +53,7 @@ class AuditResources {
                 companion object {
                     val Feilsendt = AuditResource("person.henvendelse.merk.feilsendt")
                     val Sladding = AuditResource("person.henvendelse.merk.sladding")
+                    val SladdeArsaker = AuditResource("person.henvendelse.merk.sladding.arsaker")
                     val Lukk = AuditResource("person.henvendelse.merk.lukk")
                 }
             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogMerkController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogMerkController.kt
@@ -47,6 +47,15 @@ class DialogMerkController @Autowired constructor(
             }
     }
 
+    @GetMapping("/sladdearsaker/{kjedeid}")
+    fun hentSladdeArsaker(@PathVariable("kjedeid") kjedeId: String): List<String> {
+        return tilgangskontroll
+            .check(Policies.tilgangTilModia)
+            .get(Audit.describe(READ, Henvendelse.Merk.SladdeArsaker, AuditIdentifier.TRAAD_ID to kjedeId)) {
+                dialogMerkApi.hentSladdeArsaker(kjedeId)
+            }
+    }
+
     @PostMapping("/lukk-traad")
     fun lukkTraad(@RequestBody request: LukkTraadRequest): ResponseEntity<Void> {
         val auditIdentifier = arrayOf(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/apis/DialogMerkApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/apis/DialogMerkApi.kt
@@ -7,6 +7,7 @@ interface DialogMerkApi {
     fun sendTilSladding(request: SendTilSladdingRequest): ResponseEntity<Void>
     fun avsluttGosysOppgave(request: AvsluttGosysOppgaveRequest): ResponseEntity<Void>
     fun lukkTraad(request: LukkTraadRequest): ResponseEntity<Void>
+    fun hentSladdeArsaker(kjedeId: String): List<String>
 }
 
 data class MerkSomFeilsendtRequest(
@@ -16,7 +17,14 @@ data class MerkSomFeilsendtRequest(
 
 data class SendTilSladdingRequest(
     val fnr: String,
-    val traadId: String
+    val traadId: String,
+    val arsak: String?,
+    val meldingId: List<String>?,
+)
+
+data class HentSladdeArsakerRequest(
+    val fnr: String,
+    val traadId: String,
 )
 
 data class AvsluttGosysOppgaveRequest(

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogMerkController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogMerkController.kt
@@ -21,8 +21,16 @@ class SfLegacyDialogMerkController(
     }
 
     override fun sendTilSladding(request: SendTilSladdingRequest): ResponseEntity<Void> {
-        sfHenvendelseService.sendTilSladding(request.traadId)
+        if (request.arsak !== null) {
+            sfHenvendelseService.sendTilSladding(request.traadId, request.arsak, request.meldingId)
+        } else {
+            sfHenvendelseService.sendTilSladding(request.traadId)
+        }
         return ResponseEntity(HttpStatus.OK)
+    }
+
+    override fun hentSladdeArsaker(kjedeId: String): List<String> {
+        return sfHenvendelseService.hentSladdeArsaker(kjedeId)
     }
 
     override fun lukkTraad(request: LukkTraadRequest): ResponseEntity<Void> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -66,7 +66,6 @@ private val logger = LoggerFactory.getLogger(SfHenvendelseServiceImpl::class.jav
 class SfHenvendelseServiceImpl(
     private val henvendelseBehandlingApi: HenvendelseBehandlingApi = SfHenvendelseApiFactory.createHenvendelseBehandlingApi(),
     private val henvendelseInfoApi: HenvendelseInfoApi = SfHenvendelseApiFactory.createHenvendelseInfoApi(),
-    private val henvendelseJournalApi: JournalApi = SfHenvendelseApiFactory.createHenvendelseJournalApi(),
     private val henvendelseOpprettApi: NyHenvendelseApi = SfHenvendelseApiFactory.createHenvendelseOpprettApi(),
     private val pdlOppslagService: PdlOppslagService,
     private val norgApi: NorgApi,
@@ -88,7 +87,6 @@ class SfHenvendelseServiceImpl(
     ) : this(
         SfHenvendelseApiFactory.createHenvendelseBehandlingApi(),
         SfHenvendelseApiFactory.createHenvendelseInfoApi(),
-        SfHenvendelseApiFactory.createHenvendelseJournalApi(),
         SfHenvendelseApiFactory.createHenvendelseOpprettApi(),
         pdlOppslagService,
         norgApi,
@@ -142,7 +140,7 @@ class SfHenvendelseServiceImpl(
         } else {
             null
         }
-        henvendelseJournalApi
+        henvendelseBehandlingApi
             .henvendelseJournalPost(
                 getCallId(),
                 JournalRequestDTO(
@@ -507,6 +505,5 @@ object SfHenvendelseApiFactory {
 
     fun createHenvendelseBehandlingApi() = HenvendelseBehandlingApi(url(), client)
     fun createHenvendelseInfoApi() = HenvendelseInfoApi(url(), client)
-    fun createHenvendelseJournalApi() = JournalApi(url(), client)
     fun createHenvendelseOpprettApi() = NyHenvendelseApi(url(), client)
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -56,7 +56,11 @@ interface SfHenvendelseService {
     fun henvendelseTilhorerBruker(bruker: EksternBruker, kjedeId: String): Boolean
     fun sjekkEierskap(bruker: EksternBruker, henvendelse: HenvendelseDTO): Boolean
     fun merkSomFeilsendt(kjedeId: String)
+
+    @Deprecated("Skal sende med årsak")
     fun sendTilSladding(kjedeId: String)
+    fun sendTilSladding(kjedeId: String, arsak: String, meldingId: List<String>?)
+    fun hentSladdeArsaker(kjedeId: String): List<String>
     fun lukkTraad(kjedeId: String)
 
     fun ping()
@@ -244,6 +248,7 @@ class SfHenvendelseServiceImpl(
         henvendelseBehandlingApi.client.request<Map<String, Any?>, Unit>(request).throwIfError()
     }
 
+    @Deprecated("Skal sende med årsak")
     override fun sendTilSladding(kjedeId: String) {
         val request: RequestConfig<Map<String, Any?>> = createPatchRequest(
             kjedeId.fixKjedeId(),
@@ -251,6 +256,24 @@ class SfHenvendelseServiceImpl(
                 .set(HenvendelseDTO::sladding).to(true)
         )
         henvendelseBehandlingApi.client.request<Map<String, Any?>, Unit>(request).throwIfError()
+    }
+
+    override fun sendTilSladding(kjedeId: String, arsak: String, meldingId: List<String>?) {
+        henvendelseBehandlingApi.henvendelseSladdingPostRequestConfig(
+            xCorrelationID = getCallId(),
+            sladdeRequestDTO = SladdeRequestDTO(
+                kjedeId = kjedeId,
+                aarsak = arsak,
+                meldingId = meldingId
+            )
+        )
+    }
+
+    override fun hentSladdeArsaker(kjedeId: String): List<String> {
+        return henvendelseBehandlingApi.henvendelseSladdingAarsakerKjedeIdGet(
+            xCorrelationID = getCallId(),
+            kjedeId = kjedeId
+        )
     }
 
     override fun lukkTraad(kjedeId: String) {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -264,7 +264,8 @@ class SfHenvendelseServiceImpl(
             sladdeRequestDTO = SladdeRequestDTO(
                 kjedeId = kjedeId,
                 aarsak = arsak,
-                meldingId = meldingId
+                // TODO sende med liste over meldingsIder bare SF er klare
+                // meldingId = meldingId
             )
         )
     }

--- a/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/policies/HenvendelseTilhorerBrukerPolicyTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/infrastructure/tilgangskontroll/kabac/policies/HenvendelseTilhorerBrukerPolicyTest.kt
@@ -13,6 +13,7 @@ import no.nav.modiapersonoversikt.service.sfhenvendelse.SfHenvendelseService
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.*
 
 internal class HenvendelseTilhorerBrukerPolicyTest {
     private val policy = KabacTestUtils.PolicyTester(HenvendelseTilhorerBrukerPolicy)
@@ -56,6 +57,7 @@ internal class HenvendelseTilhorerBrukerPolicyTest {
         journalposter = null,
         meldinger = listOf(
             MeldingDTO(
+                meldingsId = UUID.randomUUID().toString(),
                 fritekst = "Melding innhold",
                 sendtDato = OffsetDateTime.of(2021, 2, 2, 12, 37, 37, 0, ZoneOffset.UTC),
                 fra = MeldingFraDTO(

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
@@ -11,7 +11,6 @@ import no.nav.modiapersonoversikt.consumer.norg.NorgApi
 import no.nav.modiapersonoversikt.consumer.norg.NorgDomain.EnhetGeografiskTilknyttning
 import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.apis.HenvendelseBehandlingApi
 import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.apis.HenvendelseInfoApi
-import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.apis.JournalApi
 import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.apis.NyHenvendelseApi
 import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.models.*
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
@@ -23,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.*
 
 internal class SfHenvendelseServiceImplTest {
     companion object {
@@ -38,7 +38,6 @@ internal class SfHenvendelseServiceImplTest {
 
     private val henvendelseBehandlingApi: HenvendelseBehandlingApi = mockk()
     private val henvendelseInfoApi: HenvendelseInfoApi = mockk()
-    private val henvendelseJournalApi: JournalApi = mockk()
     private val henvendelseOpprettApi: NyHenvendelseApi = mockk()
     private val pdlOppslagService: PdlOppslagService = mockk()
     private val norgApi: NorgApi = mockk()
@@ -48,7 +47,6 @@ internal class SfHenvendelseServiceImplTest {
         SfHenvendelseServiceImpl(
             henvendelseBehandlingApi,
             henvendelseInfoApi,
-            henvendelseJournalApi,
             henvendelseOpprettApi,
             pdlOppslagService,
             norgApi,
@@ -149,6 +147,7 @@ internal class SfHenvendelseServiceImplTest {
             dummyHenvendelse.copy(
                 meldinger = listOf(
                     MeldingDTO(
+                        meldingsId = UUID.randomUUID().toString(),
                         fritekst = "Andre melding",
                         sendtDato = OffsetDateTime.of(2021, 2, 2, 12, 37, 37, 0, ZoneOffset.UTC),
                         fra = MeldingFraDTO(
@@ -157,6 +156,7 @@ internal class SfHenvendelseServiceImplTest {
                         )
                     ),
                     MeldingDTO(
+                        meldingsId = UUID.randomUUID().toString(),
                         fritekst = "Første melding",
                         sendtDato = OffsetDateTime.of(2021, 2, 1, 12, 37, 37, 0, ZoneOffset.UTC),
                         fra = MeldingFraDTO(
@@ -190,6 +190,7 @@ internal class SfHenvendelseServiceImplTest {
         journalposter = null,
         meldinger = listOf(
             MeldingDTO(
+                meldingsId = UUID.randomUUID().toString(),
                 fritekst = "Melding innhold",
                 sendtDato = OffsetDateTime.of(2021, 2, 2, 12, 37, 37, 0, ZoneOffset.UTC),
                 fra = MeldingFraDTO(

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/mock-sf-meldinger.json
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/mock-sf-meldinger.json
@@ -6,6 +6,7 @@
     "opprettetDato": "2021-08-28T16:49:23.000+0200",
     "meldinger": [
       {
+        "meldingsId": "random1",
         "sendtDato": "2021-08-28T16:49:23.000+0200",
         "lestDato": null,
         "kanal": "DIGITAL",


### PR DESCRIPTION
- [OPP-1500] oppdatere sf api-spec med sladdearsak
- [OPP-1500,OPP-1501] oppdatere api med meldings liste som skal sladdes

`arsak` og `meldingId` feltene er optional per idag, siden vi ikke kan begynne å sende med disse før Salesforce er klare med sine apier.