### PR TITLE
[KAIZEN-0] legge til AuthHeaderCapture til thread-swapper

### DIFF
--- a/web/src/test/java/no/nav/modiapersonoversikt/utils/ConcurrencyUtilsTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/utils/ConcurrencyUtilsTest.kt
@@ -23,7 +23,7 @@ internal class ConcurrencyUtilsTest {
         ConcurrencyUtils.inParallel(taskA, taskB)
         val endTime = System.currentTimeMillis()
 
-        assertThat(endTime - startTime).isCloseTo(1000, withPercentage(15.0))
+        assertThat(endTime - startTime).isCloseTo(1000, withPercentage(30.0))
     }
 
     @Test


### PR DESCRIPTION
Om deler av koden kjøres i parallell så må vi passe på at threadlocals blir kopiert over til de nye trådene slik at eventuelle kall til tjenester blir kjørt med riktig auth-headers etc
