### PR TITLE
[KAIZEN-0] flytte dkif-experiment til service-nivå

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/dkif/DkifConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/dkif/DkifConfig.kt
@@ -1,11 +1,16 @@
 package no.nav.modiapersonoversikt.consumer.dkif
 
 import DigDirServiceImpl
+import no.nav.common.health.HealthCheckResult
+import no.nav.common.health.selftest.SelfTestCheck
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist
 import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.DigitalKontaktinformasjonV1
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 
 @Configuration
 open class DkifConfig {
@@ -27,5 +32,43 @@ open class DkifConfig {
             EnvironmentUtils.getRequiredProperty("DIG_DIR_REST_URL"),
             machineToMachineTokenClient
         )
+    }
+
+    @Bean
+    @Primary
+    open fun dkifService(
+        @Qualifier("DkifSoap") soapService: Dkif.Service,
+        @Qualifier("DigDirRest") restService: Dkif.Service,
+    ): Dkif.Service {
+        return object : Dkif.Service {
+            private val digDirExperiment = Scientist.createExperiment<Dkif.DigitalKontaktinformasjon>(
+                Scientist.Config(
+                    name = "digdir",
+                    experimentRate = Scientist.FixedValueRate(0.1)
+                )
+            )
+
+            override fun hentDigitalKontaktinformasjon(fnr: String): Dkif.DigitalKontaktinformasjon {
+                return digDirExperiment.run(
+                    control = { soapService.hentDigitalKontaktinformasjon(fnr) },
+                    experiment = { restService.hentDigitalKontaktinformasjon(fnr) },
+                )
+            }
+
+            override fun ping(): SelfTestCheck {
+                return SelfTestCheck(
+                    "DkifExperiment",
+                    false
+                ) {
+                    try {
+                        soapService.ping()
+                        restService.ping()
+                        HealthCheckResult.healthy()
+                    } catch (e: Exception) {
+                        HealthCheckResult.unhealthy(e)
+                    }
+                }
+            }
+        }
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataConfig.kt
@@ -8,7 +8,6 @@ import no.nav.modiapersonoversikt.infrastructure.kabac.Kabac
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.modiapersonoversikt.service.kontonummer.KontonummerService
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -17,7 +16,7 @@ open class PersondataConfig {
     @Bean
     open fun persondataService(
         pdl: PdlOppslagService,
-        @Qualifier("DkifSoap") dkif: Dkif.Service,
+        dkif: Dkif.Service,
         norgApi: NorgApi,
         skjermedePersonerApi: SkjermedePersonerApi,
         kontonummerService: KontonummerService,

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/kontaktinformasjon/KontaktinformasjonControllerTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/kontaktinformasjon/KontaktinformasjonControllerTest.kt
@@ -20,8 +20,7 @@ private val SIST_OPPDATERT = LocalDate.of(2012, 12, 27)
 class KontaktinformasjonControllerTest {
 
     private val dkifService: Dkif.Service = mockk()
-    private val digDirRestService: Dkif.Service = mockk()
-    private val controller = KontaktinformasjonController(dkifService, digDirRestService, TilgangskontrollMock.get())
+    private val controller = KontaktinformasjonController(dkifService, TilgangskontrollMock.get())
 
     @BeforeEach
     fun before() {


### PR DESCRIPTION
gjør det enklere å gjenbruke på tvers av applikasjonen, og blir nå automatisk også brukt av PersondataService
