### PR TITLE
[KAIZEN-0] bytte til bolk-oppslag mot nom

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/salesforce/SfLegacyDialogController.kt
@@ -286,8 +286,9 @@ class SfLegacyDialogController(
                     .plus(meldingFraIdenter ?: emptyList())
             }
             .distinct()
+            .map(::NavIdent)
 
-        val identMap = identer.associateWith { ident -> ansattService.hentVeileder(NavIdent(ident)) }
+        val identMap = ansattService.hentVeiledere(identer).mapKeys { (key, _) -> key.get() }
 
         return DialogMappingContext(temakodeMap, identMap)
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/ansattservice/AnsattService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/ansattservice/AnsattService.kt
@@ -18,6 +18,7 @@ interface AnsattService {
     fun hentEnhetsliste(): List<AnsattEnhet>
     fun hentEnhetsliste(ident: NavIdent): List<AnsattEnhet>
     fun hentVeileder(ident: NavIdent): Veileder
+    fun hentVeiledere(identer: List<NavIdent>): Map<NavIdent, Veileder>
     fun hentVeilederRoller(ident: NavIdent): RolleListe
     fun hentAnsattFagomrader(ident: String, enhet: String): Set<String>
     fun ansatteForEnhet(enhet: AnsattEnhet): List<Ansatt>
@@ -43,16 +44,22 @@ class AnsattServiceImpl @Autowired constructor(
     }
 
     override fun hentVeileder(ident: NavIdent): Veileder {
+        return hentVeiledere(listOf(ident))
+            .getOrDefault(ident, Veileder("", "", ident.get()))
+    }
+
+    override fun hentVeiledere(identer: List<NavIdent>): Map<NavIdent, Veileder> {
         return nomClient
-            .runCatching { finnNavn(ident) }
-            .map {
+            .runCatching { finnNavn(identer) }
+            .getOrDefault(emptyList())
+            .associateBy { it.navIdent }
+            .mapValues { (_, value) ->
                 Veileder(
-                    ident = it.navIdent.get(),
-                    fornavn = it.fornavn,
-                    etternavn = it.etternavn,
+                    ident = value.navIdent.get(),
+                    fornavn = value.fornavn,
+                    etternavn = value.etternavn
                 )
             }
-            .getOrDefault(Veileder("", "", ident.get()))
     }
 
     override fun hentVeilederRoller(ident: NavIdent): RolleListe {

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/ansattservice/AnsattServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/ansattservice/AnsattServiceImplTest.kt
@@ -46,7 +46,7 @@ internal class AnsattServiceImplTest {
 
     @Test
     fun `skal kunne hente navn ansatt`() {
-        every { nomClient.finnNavn(NavIdent("111")) } returns lagNavAnsatt("Kalle", "Karlsson", "111")
+        every { nomClient.finnNavn(listOf(NavIdent("111"))) } returns listOf(lagNavAnsatt("Kalle", "Karlsson", "111"))
 
         val navn = ansattServiceImpl.hentVeileder(NavIdent("111")).navn
 


### PR DESCRIPTION
ved uthenting av meldinger må mange veiledernavn hentes ut,
dette gjøres mer effektivt vha nom bolk-oppslag
