### PR TITLE
[KAIZEN-0] legge til type introspeksjon for saker

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/Typeanalyzers.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/Typeanalyzers.kt
@@ -1,0 +1,14 @@
+package no.nav.modiapersonoversikt.rest
+
+import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist
+import no.nav.personoversikt.common.typeanalyzer.Typeanalyzer
+
+enum class Typeanalyzers(val analyzer: Typeanalyzer) {
+    SAKER(Typeanalyzer())
+}
+
+fun Typeanalyzer.sampleRate(rate: Scientist.ExperimentRate): (Any?) -> Unit = { value ->
+    if (rate.shouldRunExperiment()) {
+        this.capture(value)
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
@@ -12,10 +12,14 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.Audit
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
+import no.nav.modiapersonoversikt.rest.Typeanalyzers
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagServiceConfig
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagServiceImpl
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.typeanalyzer.Formatter
+import no.nav.personoversikt.common.typeanalyzer.KotlinFormat
+import no.nav.personoversikt.common.typeanalyzer.TypescriptFormat
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 
@@ -55,6 +59,16 @@ class InternalController @Autowired constructor(
                     SokPerson(pdlClient).execute(SokPerson.Variables(paging, criteria), systemTokenAuthHeader)
                 }
             }
+    }
+
+    @GetMapping("/types/{name}")
+    fun getTypedefinition(
+        @PathVariable("name") name: String,
+        @RequestParam(value = "format", required = false) formatName: String?,
+    ): String {
+        val report = Typeanalyzers.valueOf(name).analyzer.report()
+        val format = if (formatName == "typescript") TypescriptFormat else KotlinFormat
+        return Formatter(format).print(report)
     }
 
     private val systemTokenAuthHeader: HeadersBuilder = {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
@@ -10,9 +10,12 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.Audit
 import no.nav.modiapersonoversikt.infrastructure.naudit.Audit.Action.READ
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditIdentifier
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
+import no.nav.modiapersonoversikt.infrastructure.scientist.Scientist
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.rest.RestUtils
+import no.nav.modiapersonoversikt.rest.Typeanalyzers
+import no.nav.modiapersonoversikt.rest.sampleRate
 import no.nav.modiapersonoversikt.service.journalforingsaker.SakerService
 import no.nav.modiapersonoversikt.service.saf.SafService
 import no.nav.modiapersonoversikt.service.saf.domain.Dokument
@@ -111,6 +114,7 @@ class SakerController @Autowired constructor(
             ?.variantformat
             ?: ARKIV
 
+    private val captureType = Typeanalyzers.SAKER.analyzer.sampleRate(Scientist.FixedValueRate(0.25))
     private fun byggSakstemaResultat(resultat: ResultatWrapper<List<SakstemaDTO>>): Map<String, Any?> {
         return mapOf(
             "resultat" to resultat.resultat.map {
@@ -125,7 +129,7 @@ class SakerController @Autowired constructor(
                     "harTilgang" to it.harTilgang
                 )
             }
-        )
+        ).also(captureType)
     }
 
     private fun hentBehandlingskjeder(behandlingskjeder: List<Behandlingskjede>): List<Map<String, Any?>> {


### PR DESCRIPTION
det er ønskelig med typesikre (e.g ikke `Map<String, Any>`) respons-typer fra alle endepunkt. Typeanalyzer finner ut av hva disse typene kan være
