### PR TITLE
[KAIZEN-0] bruke custom nom cache

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.modiapersonoversikt.consumer.nom
 
-import no.nav.common.client.nom.CachedNomClient
 import no.nav.common.client.nom.NomClient
 import no.nav.common.client.nom.NomClientImpl
 import no.nav.common.client.nom.VeilederNavn
@@ -32,7 +31,7 @@ open class NomConfig {
             return DevNomClient()
         }
         val tokenSupplier = { tokenProvider.createMachineToMachineToken(scope) }
-        return CachedNomClient(NomClientImpl(url, tokenSupplier, httpClient))
+        return NullCachingNomClient(NomClientImpl(url, tokenSupplier, httpClient))
     }
 }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NullCachingNomClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NullCachingNomClient.kt
@@ -1,0 +1,49 @@
+package no.nav.modiapersonoversikt.consumer.nom
+
+import com.github.benmanes.caffeine.cache.Cache
+import no.nav.common.client.nom.NomClient
+import no.nav.common.client.nom.VeilederNavn
+import no.nav.common.health.HealthCheckResult
+import no.nav.common.types.identer.NavIdent
+import no.nav.modiapersonoversikt.infrastructure.cache.CacheConfig
+import java.util.*
+import kotlin.time.Duration.Companion.hours
+
+class NullCachingNomClient(
+    private val nomClient: NomClient,
+    private val cache: Cache<NavIdent, Optional<VeilederNavn>> = CacheConfig.createCache(12.hours.inWholeSeconds, 10_000L).build()
+) : NomClient {
+
+    override fun finnNavn(navIdent: NavIdent): VeilederNavn? {
+        return cache.get(navIdent) {
+            Optional.ofNullable(nomClient.finnNavn(navIdent))
+        }?.orElse(null)
+    }
+
+    override fun finnNavn(navIdenter: List<NavIdent>): List<VeilederNavn?> {
+        val out = mutableListOf<VeilederNavn?>()
+        val uncachedIdenter = mutableListOf<NavIdent>()
+
+        navIdenter.forEach { ident ->
+            val cachedValue = cache.getIfPresent(ident)
+            if (cachedValue == null) {
+                uncachedIdenter.add(ident)
+            } else {
+                out.add(cachedValue.orElse(null))
+            }
+        }
+
+        if (uncachedIdenter.isNotEmpty()) {
+            uncachedIdenter.forEach { cache.put(it, Optional.empty()) }
+
+            val nyeVeileder = nomClient.finnNavn(uncachedIdenter)
+            nyeVeileder
+                .filterNotNull()
+                .forEach { cache.put(it.navIdent, Optional.of(it)) }
+            out.addAll(nyeVeileder)
+        }
+
+        return out
+    }
+    override fun checkHealth(): HealthCheckResult = nomClient.checkHealth()
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.kt
@@ -33,14 +33,15 @@ open class CacheConfig {
         }
     }
 
-    private fun CaffeineCacheManager.cache(name: String, time: Int, maximumSize: Int = 1000) {
-        val cache = Caffeine.newBuilder()
-            .recordStats()
-            .expireAfterAccess(Duration.ofSeconds(time.toLong()))
-            .expireAfterWrite(Duration.ofSeconds(time.toLong()))
-            .maximumSize(maximumSize.toLong())
-            .build<Any, Any>()
+    private fun CaffeineCacheManager.cache(name: String, time: Long, maximumSize: Long = 1000) {
+        this.registerCustomCache(name, createCache(time, maximumSize).build())
+    }
 
-        this.registerCustomCache(name, cache)
+    companion object {
+        fun createCache(time: Long, maximumSize: Long = 1000) = Caffeine.newBuilder()
+            .recordStats()
+            .expireAfterAccess(Duration.ofSeconds(time))
+            .expireAfterWrite(Duration.ofSeconds(time))
+            .maximumSize(maximumSize)
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/consumer/nom/NullCachingNomClientTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/consumer/nom/NullCachingNomClientTest.kt
@@ -1,0 +1,68 @@
+package no.nav.modiapersonoversikt.consumer.nom
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.common.client.nom.NomClient
+import no.nav.common.client.nom.VeilederNavn
+import no.nav.common.types.identer.NavIdent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class NullCachingNomClientTest {
+    private val baseClient: NomClient = mockk()
+    private val client = NullCachingNomClient(baseClient)
+    private val navIdent1 = NavIdent("1")
+    private val navIdent2 = NavIdent("2")
+    private val navIdent3 = NavIdent("3")
+    private val veiledere = listOf(
+        VeilederNavn().setNavIdent(navIdent1),
+        null,
+        VeilederNavn().setNavIdent(navIdent3),
+    )
+
+    @Test
+    internal fun `should cache null value`() {
+        every { baseClient.finnNavn(any<NavIdent>()) } returns null
+
+        assertThat(client.finnNavn(navIdent1)).isNull()
+        assertThat(client.finnNavn(navIdent1)).isNull()
+
+        verify(exactly = 1) { baseClient.finnNavn(any<NavIdent>()) }
+    }
+
+    @Test
+    internal fun `should cache null values`() {
+        every { baseClient.finnNavn(any<List<NavIdent>>()) } returns veiledere
+
+        assertThat(client.finnNavn(listOf(navIdent1, navIdent2, navIdent3))).isEqualTo(veiledere)
+        assertThat(client.finnNavn(listOf(navIdent1, navIdent2, navIdent3))).isEqualTo(veiledere)
+
+        assertThat(client.finnNavn(navIdent1)).isEqualTo(veiledere.first())
+        assertThat(client.finnNavn(navIdent2)).isNull()
+        assertThat(client.finnNavn(navIdent3)).isEqualTo(veiledere.last())
+
+        verify(exactly = 1) { baseClient.finnNavn(any<List<NavIdent>>()) }
+        verify(exactly = 0) { baseClient.finnNavn(any<NavIdent>()) }
+    }
+
+    @Test
+    internal fun `should not refetch cached values`() {
+        every { baseClient.finnNavn(navIdent1) } returns veiledere.first()
+        every { baseClient.finnNavn(navIdent2) } returns null
+        every { baseClient.finnNavn(any<List<NavIdent>>()) } answers {
+            val identer = this.args[0] as List<NavIdent>
+            veiledere.filter { identer.contains(it?.navIdent) }
+        }
+
+        client.finnNavn(navIdent1)
+        client.finnNavn(navIdent2)
+        assertThat(client.finnNavn(listOf(navIdent1, navIdent2, navIdent3))).isEqualTo(veiledere)
+
+        verify {
+            baseClient.finnNavn(navIdent1)
+            baseClient.finnNavn(navIdent2)
+            baseClient.finnNavn(listOf(navIdent3))
+        }
+    }
+}


### PR DESCRIPTION
Fungerer veldig likt som `CachedNomClient`, men underliggende cache er basert på `Optional<VeilederNavn>` slik at også null-verdier kan caches

Null-verdier er relevant her fordi Nom ikke holder på informasjon om utløpte identer, e.g folk som har sluttet etc
