### PR TITLE
[KAIZEN-0] sikre at caching wrapper følger samme api som underliggende tjeneste

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.modiapersonoversikt.consumer.nom
 
-import no.nav.common.client.nom.CachedNomClient
 import no.nav.common.client.nom.NomClient
 import no.nav.common.client.nom.NomClientImpl
 import no.nav.common.client.nom.VeilederNavn
@@ -32,7 +31,7 @@ open class NomConfig {
             return DevNomClient()
         }
         val tokenSupplier = { tokenProvider.createMachineToMachineToken(scope) }
-        return CachedNomClient(NomClientImpl(url, tokenSupplier, httpClient))
+        return NullCachingNomClient(NomClientImpl(url, tokenSupplier, httpClient))
     }
 }
 


### PR DESCRIPTION
NomClientImpl vil aldri returnere `null` eller ha `null` elementer i listen.
Skrevet om NullCachingNomClient til å følge samme mønster med exceptions og fjerner null-elementer i listen om informasjon ikke finnes
