### PR TITLE
[OPP-1508] Refaktorere hvordan RestClient blir initialisert med metrikklytter

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/Main.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/Main.java
@@ -5,6 +5,7 @@ import no.nav.common.utils.EnvironmentUtils;
 import no.nav.common.utils.NaisUtils;
 
 import no.nav.common.utils.SslUtils;
+import no.nav.modiapersonoversikt.config.MetricsConfig;
 import no.nav.modiapersonoversikt.consumer.ldap.LDAP;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,7 +26,7 @@ public class Main {
         SslUtils.setupTruststore();
         // Overstyrer appnavn slik at vi er sikre på at vi later som vi er modiabrukerdialog. ;)
         EnvironmentUtils.setProperty("NAIS_APP_NAME", "modiabrukerdialog", PUBLIC);
-
+        MetricsConfig.setup();
         SpringApplication.run(Main.class, args);
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/MetricsConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/MetricsConfig.kt
@@ -3,8 +3,7 @@ package no.nav.modiapersonoversikt.config
 import io.micrometer.core.instrument.binder.okhttp3.OkHttpMetricsEventListener
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import no.nav.common.rest.client.RestClient
-import no.nav.modiapersonoversikt.service.unleash.Feature
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.utils.MaskingUtils
 import okhttp3.Request
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,12 +15,9 @@ open class MetricsConfig {
     @Autowired
     lateinit var prometheusMeterRegistry: PrometheusMeterRegistry
 
-    @Autowired
-    lateinit var unleash: UnleashService
-
     @PostConstruct
     fun setup() {
-        if (unleash.isEnabled(Feature.USE_REST_CLIENT_METRICS)) {
+        if (EnvironmentUtils.isDevelopment().orElse(false)) {
             initRestClientWithMetricsListener()
         }
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/MetricsConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/MetricsConfig.kt
@@ -1,41 +1,38 @@
 package no.nav.modiapersonoversikt.config
 
 import io.micrometer.core.instrument.binder.okhttp3.OkHttpMetricsEventListener
+import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import no.nav.common.rest.client.RestClient
-import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.utils.MaskingUtils
 import okhttp3.Request
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import javax.annotation.PostConstruct
 
 @Configuration
-open class MetricsConfig {
-    @Autowired
-    lateinit var prometheusMeterRegistry: PrometheusMeterRegistry
+open class MetricsConfig() {
+    companion object {
+        private val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
 
-    @PostConstruct
-    fun setup() {
-        if (EnvironmentUtils.isDevelopment().orElse(false)) {
-            initRestClientWithMetricsListener()
+        @JvmStatic
+        fun setup() {
+            RestClient.setBaseClient(
+                RestClient.baseClientBuilder().eventListener(
+                    buildEventListener().uriMapper(::buildUriMap)
+                        .build()
+                ).build()
+            )
+        }
+
+        private fun buildEventListener(): OkHttpMetricsEventListener.Builder {
+            return OkHttpMetricsEventListener.builder(registry, "okhttp.requests")
+        }
+
+        private fun buildUriMap(req: Request): String {
+            return MaskingUtils.maskSensitiveInfo(req.url().encodedPath())
         }
     }
 
-    private fun initRestClientWithMetricsListener() {
-        RestClient.setBaseClient(
-            RestClient.baseClientBuilder().eventListener(
-                buildEventListener().uriMapper(::buildUriMap)
-                    .build()
-            ).build()
-        )
-    }
-
-    private fun buildEventListener(): OkHttpMetricsEventListener.Builder {
-        return OkHttpMetricsEventListener.builder(prometheusMeterRegistry, "okhttp.requests")
-    }
-
-    private fun buildUriMap(req: Request): String {
-        return MaskingUtils.maskSensitiveInfo(req.url().encodedPath())
-    }
+    @Bean
+    open fun prometheusMeterRegistry() = registry
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
@@ -3,5 +3,4 @@ package no.nav.modiapersonoversikt.service.unleash
 enum class Feature(val propertyKey: String) {
     SAMPLE_FEATURE("feature.samplerfeature"),
     USE_REST_KONTOREGISTER("modiabrukerdialog.rest.kontoregister.switcher"),
-    USE_REST_CLIENT_METRICS("modiapersonoversikt.use_rest_client_metrics"),
 }


### PR DESCRIPTION
[OPP-1508] Refaktorere hvordan RestClient blir initialisert med metrikklytter


Revert "[OPP-1508] Add metricslistener to OkHttpClient"
Revert "Revert "[OPP-1508] Add metricslistener to OkHttpClient""

This reverts commit d116b72d74f53a947d0088804f8fe457ca5b8fbe.
