### PR TITLE
[KAIZEN-0] state på rydding i sakerapi

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
@@ -6,6 +6,7 @@ import no.nav.modiapersonoversikt.commondomain.sak.Feilmelding
 import no.nav.modiapersonoversikt.service.saf.domain.Dokument.DokumentStatus
 import no.nav.modiapersonoversikt.service.saf.domain.Kommunikasjonsretning
 import no.nav.modiapersonoversikt.service.sakstema.domain.BehandlingsStatus
+import java.time.LocalDateTime
 
 object SakerApi {
     data class Resultat(
@@ -19,6 +20,7 @@ object SakerApi {
         val behandlingskjeder: List<Behandlingskjede>,
         val dokumentMetadata: List<Dokumentmetadata>,
         val tilhørendeSaker: List<Sak>,
+        val tilhorendeSaker: List<Sak>,
         val feilkoder: List<Int>,
         val harTilgang: Boolean,
     )
@@ -26,6 +28,7 @@ object SakerApi {
     data class Behandlingskjede(
         val status: BehandlingsStatus,
         val sistOppdatert: LegacyDato,
+        val sistOppdatertV2: LocalDateTime,
     )
 
     data class LegacyDato(
@@ -41,6 +44,7 @@ object SakerApi {
         val id: String,
         val retning: Kommunikasjonsretning,
         val dato: LegacyDato,
+        val datoV2: LocalDateTime,
         val navn: String,
         val journalpostId: String,
         val hoveddokument: Dokument,
@@ -48,12 +52,15 @@ object SakerApi {
         val avsender: Entitet,
         val mottaker: Entitet,
         val tilhørendeSaksid: String,
+        val tilhorendeSaksid: String,
         val tilhørendeFagsaksid: String?,
+        val tilhorendeFagsaksid: String?,
         val baksystem: Set<Baksystem>,
         val temakode: String,
         val temakodeVisning: String,
         val ettersending: Boolean,
         val erJournalført: Boolean,
+        val erJournalfort: Boolean,
         val feil: Feil,
     )
 
@@ -77,6 +84,7 @@ object SakerApi {
         val saksid: String,
         val fagsaksnummer: String?,
         val avsluttet: LegacyDato?,
+        val avsluttetV2: LocalDateTime?,
         val fagsystem: String,
         val baksystem: Baksystem,
     )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
@@ -9,7 +9,6 @@ import no.nav.modiapersonoversikt.service.sakstema.domain.Behandlingskjede
 import no.nav.modiapersonoversikt.service.sakstema.domain.Sak
 import no.nav.modiapersonoversikt.service.sakstema.domain.Sakstema
 import no.nav.modiapersonoversikt.utils.ConvertionUtils.toJavaDateTime
-import no.nav.modiapersonoversikt.utils.ConvertionUtils.toJavaTime
 import no.nav.personoversikt.common.kabac.Decision
 import org.joda.time.DateTime
 import java.time.LocalDateTime

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
@@ -8,6 +8,8 @@ import no.nav.modiapersonoversikt.service.saf.domain.DokumentMetadata
 import no.nav.modiapersonoversikt.service.sakstema.domain.Behandlingskjede
 import no.nav.modiapersonoversikt.service.sakstema.domain.Sak
 import no.nav.modiapersonoversikt.service.sakstema.domain.Sakstema
+import no.nav.modiapersonoversikt.utils.ConvertionUtils.toJavaDateTime
+import no.nav.modiapersonoversikt.utils.ConvertionUtils.toJavaTime
 import no.nav.personoversikt.common.kabac.Decision
 import org.joda.time.DateTime
 import java.time.LocalDateTime
@@ -41,13 +43,15 @@ object SakerApiMapper {
         fun mapTilResultat(sakstemaer: List<Sakstema>) = SakerApi.Resultat(
             sakstemaer.map { sakstema ->
                 val harTilgang = tematilgang[sakstema.temakode] ?: false
+                val tilhorendeSaker = sakstema.tilhorendeSaker.map(::mapTilTilhorendeSak)
                 SakerApi.Sakstema(
                     temakode = sakstema.temakode,
                     temanavn = sakstema.temanavn,
                     erGruppert = sakstema.erGruppert,
                     behandlingskjeder = sakstema.behandlingskjeder.map(::mapTilBehandlingskjede),
                     dokumentMetadata = sakstema.dokumentMetadata.map(::mapTilDokumentMetadata),
-                    tilhørendeSaker = sakstema.tilhorendeSaker.map(::mapTilTilhorendeSak),
+                    tilhørendeSaker = tilhorendeSaker,
+                    tilhorendeSaker = tilhorendeSaker,
                     feilkoder = sakstema.feilkoder,
                     harTilgang = harTilgang,
                 )
@@ -56,13 +60,15 @@ object SakerApiMapper {
 
         private fun mapTilBehandlingskjede(behandlingskjede: Behandlingskjede) = SakerApi.Behandlingskjede(
             status = behandlingskjede.status,
-            sistOppdatert = toLegacyData(behandlingskjede.sistOppdatert)
+            sistOppdatert = toLegacyData(behandlingskjede.sistOppdatert),
+            sistOppdatertV2 = behandlingskjede.sistOppdatert,
         )
 
         private fun mapTilDokumentMetadata(behandlingskjede: DokumentMetadata) = SakerApi.Dokumentmetadata(
             id = UUID.randomUUID().toString(),
             retning = behandlingskjede.retning,
             dato = toLegacyData(behandlingskjede.dato),
+            datoV2 = behandlingskjede.dato,
             navn = behandlingskjede.navn,
             journalpostId = behandlingskjede.journalpostId,
             hoveddokument = mapTilDokument(behandlingskjede.hoveddokument),
@@ -70,12 +76,15 @@ object SakerApiMapper {
             avsender = behandlingskjede.avsender,
             mottaker = behandlingskjede.mottaker,
             tilhørendeSaksid = behandlingskjede.tilhorendeSakid,
+            tilhorendeSaksid = behandlingskjede.tilhorendeSakid,
             tilhørendeFagsaksid = behandlingskjede.tilhorendeFagsakId,
+            tilhorendeFagsaksid = behandlingskjede.tilhorendeFagsakId,
             baksystem = behandlingskjede.baksystem,
             temakode = behandlingskjede.temakode,
             temakodeVisning = behandlingskjede.temakodeVisning,
             ettersending = false,
             erJournalført = behandlingskjede.isErJournalfort,
+            erJournalfort = behandlingskjede.isErJournalfort,
             feil = SakerApi.Feil(
                 inneholderFeil = behandlingskjede.feilWrapper?.inneholderFeil ?: false,
                 feilmelding = behandlingskjede.feilWrapper?.feilmelding
@@ -97,6 +106,7 @@ object SakerApiMapper {
             saksid = sak.saksId,
             fagsaksnummer = sak.fagsaksnummer,
             avsluttet = toLegacyData(sak.avsluttet),
+            avsluttetV2 = sak.avsluttet.map { it.toJavaDateTime() }.orElse(null),
             fagsystem = sak.fagsystem,
             baksystem = sak.baksystem,
         )

--- a/web/src/main/java/no/nav/modiapersonoversikt/utils/ConvertionUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/utils/ConvertionUtils.kt
@@ -1,6 +1,7 @@
 package no.nav.modiapersonoversikt.utils
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 object ConvertionUtils {
     @JvmStatic
@@ -13,7 +14,15 @@ object ConvertionUtils {
         return LocalDate.of(this.year, this.monthOfYear, this.dayOfMonth)
     }
 
+    @JvmStatic
+    fun org.joda.time.LocalDateTime.toJavaDateTime(): LocalDateTime {
+        return LocalDateTime.of(this.year, this.monthOfYear, this.dayOfMonth, this.hourOfDay, this.minuteOfHour, this.secondOfMinute)
+    }
+
     fun org.joda.time.DateTime.toJavaTime(): LocalDate {
         return this.toLocalDate().toJavaTime()
+    }
+    fun org.joda.time.DateTime.toJavaDateTime(): LocalDateTime {
+        return this.toLocalDateTime().toJavaDateTime()
     }
 }


### PR DESCRIPTION
Ønsker å bruke ISO8601 når datoer sendes via json fremfor ett eget custom format.
La derfor til "V2" av alle datoer på nytt format slik at frontend kan oppdateres ved en passende anledning.

Det er ikke ønskelig med "æøå" i koden, felter med ett av disse tegnene er duplisert med følgende mapping:

æ -> e
ø -> o
å -> a
