### PR TITLE
[KAIZEN-0] fjerne midlertidig overgangs variabler

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
@@ -27,14 +27,12 @@ object SakerApi {
     data class Behandlingskjede(
         val status: BehandlingsStatus,
         val sistOppdatert: LocalDateTime,
-        val sistOppdatertV2: LocalDateTime,
     )
 
     data class Dokumentmetadata(
         val id: String,
         val retning: Kommunikasjonsretning,
         val dato: LocalDateTime,
-        val datoV2: LocalDateTime,
         val lestDato: LocalDateTime?,
         val navn: String,
         val journalpostId: String,
@@ -72,7 +70,6 @@ object SakerApi {
         val saksid: String,
         val fagsaksnummer: String?,
         val avsluttet: LocalDateTime?,
-        val avsluttetV2: LocalDateTime?,
         val fagsystem: String,
         val baksystem: Baksystem,
     )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
@@ -57,14 +57,12 @@ object SakerApiMapper {
         private fun mapTilBehandlingskjede(behandlingskjede: Behandlingskjede) = SakerApi.Behandlingskjede(
             status = behandlingskjede.status,
             sistOppdatert = behandlingskjede.sistOppdatert,
-            sistOppdatertV2 = behandlingskjede.sistOppdatert,
         )
 
         private fun mapTilDokumentMetadata(behandlingskjede: DokumentMetadata) = SakerApi.Dokumentmetadata(
             id = UUID.randomUUID().toString(),
             retning = behandlingskjede.retning,
             dato = behandlingskjede.dato,
-            datoV2 = behandlingskjede.dato,
             lestDato = behandlingskjede.lestDato,
             navn = behandlingskjede.navn,
             journalpostId = behandlingskjede.journalpostId,
@@ -100,7 +98,6 @@ object SakerApiMapper {
             saksid = sak.saksId,
             fagsaksnummer = sak.fagsaksnummer,
             avsluttet = sak.avsluttet.map { it.toJavaDateTime() }.orElse(null),
-            avsluttetV2 = sak.avsluttet.map { it.toJavaDateTime() }.orElse(null),
             fagsystem = sak.fagsystem,
             baksystem = sak.baksystem,
         )


### PR DESCRIPTION
frontend bruker ikke lengre V2-variantene etter https://github.com/navikt/modiapersonoversikt/pull/2012