### PR TITLE
[KAIZEN-0] legge til type analyse av data fra oppfolgingscontorller

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/Typeanalyzers.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/Typeanalyzers.kt
@@ -5,7 +5,8 @@ import no.nav.personoversikt.common.typeanalyzer.Capture
 import no.nav.personoversikt.common.typeanalyzer.Typeanalyzer
 
 enum class Typeanalyzers(val analyzer: Typeanalyzer) {
-    SAKER(SamplingTypeanalyzer(Rate.FixedValue(0.05)))
+    OPPFOLGING_STATUS(SamplingTypeanalyzer(Rate.FixedValue(0.05))),
+    OPPFOLGING_YTELSER(SamplingTypeanalyzer(Rate.FixedValue(0.05)))
 }
 
 class SamplingTypeanalyzer(private val rate: Rate) : Typeanalyzer() {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/oppfolging/OppfolgingController.kt
@@ -18,6 +18,7 @@ import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources.Person
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.rest.JODA_DATOFORMAT
+import no.nav.modiapersonoversikt.rest.Typeanalyzers
 import org.joda.time.IllegalFieldValueException
 import org.joda.time.LocalDate
 import org.slf4j.LoggerFactory
@@ -46,7 +47,7 @@ class OppfolgingController @Autowired constructor(
                     "erUnderOppfolging" to oppfolging.erUnderOppfolging,
                     "veileder" to hentVeileder(oppfolging.veileder),
                     "enhet" to hentEnhet(oppfolging.oppfolgingsenhet)
-                )
+                ).also(Typeanalyzers.OPPFOLGING_STATUS.analyzer::capture)
             }
     }
 
@@ -75,7 +76,7 @@ class OppfolgingController @Autowired constructor(
                     "vedtaksdato" to kontraktResponse.vedtaksdato?.toString(JODA_DATOFORMAT),
                     "sykefraværsoppfølging" to hentSyfoPunkt(kontraktResponse.syfoPunkter),
                     "ytelser" to hentYtelser(ytelserResponse.ytelser)
-                )
+                ).also(Typeanalyzers.OPPFOLGING_YTELSER.analyzer::capture)
             }
     }
 }


### PR DESCRIPTION
ønsker å bevege oss bort fra å returnere `Map<String, Any?>` slik at det blir enklere å holde oversikt på nullability i frontend etc
