### PR TITLE
[KAIZEN-0] fikse linting script

### DIFF
--- a/linting.sh
+++ b/linting.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 if [[ -z "$CI" ]];then
   ktlint '*/src/main/**/*.kt' '*/src/test/**/*.kt' --reporter=plain?group_by_file --color --experimental $@
 else


### PR DESCRIPTION
bash ligger ikke nødvendigvis på samme sted på ulike maskiner eller OS,
ved å bruke /usr/bin/env så brukes første "bash" program som finnes i $PATH og det burde derfor fungere på alle *nix OS
