### PR TITLE
[KAIZEN-0] fix/mini env

### DIFF
--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -98,24 +98,10 @@ spec:
       value: "dev-fss:teamdokumenthandtering:saf-q0"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp-q0.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SERVER_AKTIVITETSPLAN_URL
-      value: "https://app-q0.adeo.no"
-    - name: SERVER_ARENA_URL
-      value: "http://arena-q0.adeo.no/forms/arenaMod_q0.html"
     - name: SERVER_DREK_URL
       value: "https://pdl-web.dev.intern.nav.no/rekvirerdnummer"
-    - name: SERVER_GOSYS_URL
-      value: "https://wasapp-q0.adeo.no"
     - name: SERVER_NORG2_FRONTEND_URL
       value: "https://norg2-frontend.nais.preprod.local"
-    - name: SERVER_PESYS_URL
-      value: "https://wasapp-q0.adeo.no"
-    - name: SERVER_VEILARBPORTEFOLJEFLATEFS_URL
-      value: "https://app-q0.adeo.no/veilarbportefoljeflatefs"
-    - name: SERVER_AAREG_URL
-      value: "https://modapp-q0.adeo.no/aareg-web"
-    - name: TJENESTER_URL
-      value: "https://tjenester-q0.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
     - name: REST_UTBETALING_ENDPOINTURL
@@ -126,10 +112,6 @@ spec:
       value: "https://veilarboppfolging.dev.intern.nav.no/veilarboppfolging/api"
     - name: VEILARBOPPFOLGINGAPI_SCOPE
       value: "dev-fss:pto:veilarboppfolging"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
-      value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
-    - name: DKIF_REST_URL
-      value: "https://dkif.dev.adeo.no/"
     - name: KRR_REST_URL
       value: "https://digdir-krr-proxy.dev.intern.nav.no/"
     - name: KRR_SCOPE
@@ -170,14 +152,8 @@ spec:
       value: "dev-fss:oppgavehandtering:oppgave"
     - name: NORG2_BASEURL
       value: "https://app-q0.adeo.no/norg2"
-    - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
-      value: "0 0 7,19 * * *"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
-    - name: FJERN_SOKNADER_FOR_DATO
-      value: "2014-12-09"
-    - name: HASTEKASSERING_TILGANG
-      value: "Z992323,Z990366,Z990083,Z990351"
     - name: INTERNAL_TILGANG
       value: "Z990351,Z994123,Z994404"
     - name: CXF_SECURE_LOG
@@ -196,8 +172,6 @@ spec:
       value: "dev-gcp:nom:skjermede-personer-pip"
     - name: ARENA_SAK_VEDTAK_URL
       value: "https://arena-q0.adeo.no/arena_ws/services/ArenaSakVedtakService"
-    - name: DITTNAV_EVENTER_MODIA_URL
-      value: "https://app-q0.adeo.no/dittnav-eventer-modia"
     - name: TMS_EVENT_API_URL
       value: "https://tms-event-api.ekstern.dev.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -98,24 +98,10 @@ spec:
       value: "dev-fss:teamdokumenthandtering:saf-q1"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp-q1.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SERVER_AKTIVITETSPLAN_URL
-      value: "https://app-q1.adeo.no"
-    - name: SERVER_ARENA_URL
-      value: "http://arena-q1.adeo.no/forms/arenaMod_q1.html"
     - name: SERVER_DREK_URL
       value: "https://pdl-web.dev.intern.nav.no/rekvirerdnummer"
-    - name: SERVER_GOSYS_URL
-      value: "https://wasapp-q1.adeo.no"
     - name: SERVER_NORG2_FRONTEND_URL
       value: "https://norg2-frontend.nais.preprod.local"
-    - name: SERVER_PESYS_URL
-      value: "https://wasapp-q1.adeo.no"
-    - name: SERVER_VEILARBPORTEFOLJEFLATEFS_URL
-      value: "https://app-q1.adeo.no/veilarbportefoljeflatefs"
-    - name: SERVER_AAREG_URL
-      value: "https://modapp-q1.adeo.no/aareg-web"
-    - name: TJENESTER_URL
-      value: "https://tjenester-q1.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
     - name: REST_UTBETALING_ENDPOINTURL
@@ -126,10 +112,6 @@ spec:
       value: "https://veilarboppfolging.dev.intern.nav.no/veilarboppfolging/api"
     - name: VEILARBOPPFOLGINGAPI_SCOPE
       value: "dev-fss:pto:veilarboppfolging"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
-      value: "https://dkif.nais.preprod.local/ws/DigitalKontaktinformasjon/v1"
-    - name: DKIF_REST_URL
-      value: "https://dkif.dev.adeo.no/"
     - name: KRR_REST_URL
       value: "https://digdir-krr-proxy.dev.intern.nav.no/"
     - name: KRR_SCOPE
@@ -172,14 +154,8 @@ spec:
       value: "dev-fss:oppgavehandtering:oppgave-q1"
     - name: NORG2_BASEURL
       value: "https://app-q1.adeo.no/norg2"
-    - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
-      value: "0 0 7,19 * * *"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
-    - name: FJERN_SOKNADER_FOR_DATO
-      value: "2014-12-09"
-    - name: HASTEKASSERING_TILGANG
-      value: "Z992323,Z990366,Z990083,Z990351"
     - name: INTERNAL_TILGANG
       value: "Z990351,Z994123,Z994404,Z994673"
     - name: CXF_SECURE_LOG
@@ -198,8 +174,6 @@ spec:
       value: "dev-gcp:nom:skjermede-personer-pip"
     - name: ARENA_SAK_VEDTAK_URL
       value: "https://arena-q1.adeo.no/arena_ws/services/ArenaSakVedtakService"
-    - name: DITTNAV_EVENTER_MODIA_URL
-      value: "https://app-q1.adeo.no/dittnav-eventer-modia"
     - name: TMS_EVENT_API_URL
       value: "https://tms-event-api.ekstern.dev.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -98,24 +98,10 @@ spec:
       value: "prod-fss:teamdokumenthandtering:saf"
     - name: SAKOGBEHANDLING_ENDPOINTURL
       value: "https://modapp.adeo.no/sakogbehandling/ws/SakOgBehandling_v1"
-    - name: SERVER_AKTIVITETSPLAN_URL
-      value: "https://app.adeo.no"
-    - name: SERVER_ARENA_URL
-      value: "http://arena.adeo.no/forms/arenaMod.html"
     - name: SERVER_DREK_URL
       value: "https://pdl-web.intern.nav.no/rekvirerdnummer"
-    - name: SERVER_GOSYS_URL
-      value: "https://wasapp.adeo.no"
     - name: SERVER_NORG2_FRONTEND_URL
       value: "https://norg2-frontend.nais.adeo.no"
-    - name: SERVER_PESYS_URL
-      value: "https://wasapp.adeo.no"
-    - name: SERVER_VEILARBPORTEFOLJEFLATEFS_URL
-      value: "https://app.adeo.no/veilarbportefoljeflatefs"
-    - name: SERVER_AAREG_URL
-      value: "https://modapp.adeo.no/aareg-web"
-    - name: TJENESTER_URL
-      value: "https://tjenester.nav.no"
     - name: UNLEASH_API_URL
       value: "https://unleash.nais.io/api/"
     - name: REST_UTBETALING_ENDPOINTURL
@@ -126,10 +112,6 @@ spec:
       value: "https://veilarboppfolging.intern.nav.no/veilarboppfolging/api"
     - name: VEILARBOPPFOLGINGAPI_SCOPE
       value: "prod-fss:pto:veilarboppfolging"
-    - name: VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
-      value: "https://dkif.nais.adeo.no/ws/DigitalKontaktinformasjon/v1"
-    - name: DKIF_REST_URL
-      value: "https://dkif.nais.adeo.no/"
     - name: KRR_REST_URL
       value: "https://digdir-krr-proxy.intern.nav.no/"
     - name: KRR_SCOPE
@@ -170,14 +152,8 @@ spec:
       value: "prod-fss:oppgavehandtering:oppgave"
     - name: NORG2_BASEURL
       value: "https://app.adeo.no/norg2"
-    - name: PREFETCH_NORG_ANSATTLISTE_SCHEDULE
-      value: "0 0 7,19 * * *"
     - name: SAKSOVERSIKT_PRODSETTNINGSDATO
       value: "2016-06-04"
-    - name: FJERN_SOKNADER_FOR_DATO
-      value: "2014-12-09"
-    - name: HASTEKASSERING_TILGANG
-      value: "G110867,S111498,W152868,N127626,B152650,B152650,B114736,H110866,J121487,O122413,T110884,V114843,E110861,U136854"
     - name: INTERNAL_TILGANG
       value: "U143410"
     - name: CXF_SECURE_LOG
@@ -196,8 +172,6 @@ spec:
       value: "prod-gcp:nom:skjermede-personer-pip"
     - name: ARENA_SAK_VEDTAK_URL
       value: "https://arena.adeo.no/arena_ws/services/ArenaSakVedtakService"
-    - name: DITTNAV_EVENTER_MODIA_URL
-      value: "https://app.adeo.no/dittnav-eventer-modia"
     - name: TMS_EVENT_API_URL
       value: "https://person.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE

--- a/README.md
+++ b/README.md
@@ -27,29 +27,9 @@ Cacheoppsettet er ikke blocking, dvs at dersom to tråder spør med like keys vi
 
 ### Faste jobber
 
-* Populering av cache for ansatte i Enheter fra NORG via `ScheduledAnsattListePrefetch` to ganger daglig
-
-Denne jobben henter alle enheter og deretter henter alle ansatte i de respektive enhetene. Dette gjøres med kall mot NORG.
-Bakgrunnen for at denne har blitt til en fast jobb var et ønske om å få ned svartidene for henting av ansatte for alle brukere.
-Tidspunktet for kjøring av jobben bestemmes av en property `PREFETCH_NORG_ANSATTLISTE_SCHEDULE` under fasitressursen `modiabrukerdialog.properties`. Formatet er Springs `@Scheduled`
-cron-format. Jobben bør kjøre utenfor saksbehandlernes arbeidstider, som også er tider når NORG har kapasitet til å svare raskere.
-
-Dersom propertyen ikke finnes eller inneholder feil vil applikasjonen feile under oppstart med tilsvarende
-
-    // Propertyen finnes ikke
-    java.lang.IllegalStateException: Encountered invalid @Scheduled method 'prefetchAnsattListe': Could not resolve placeholder 'PREFETCH_NORG_ANSATTLISTE_SCHEDULE' in string value "${PREFETCH_NORG_ANSATTLISTE_SCHEDULE}"
-
-    // En del av cron-uttrykket er feil
-    java.lang.IllegalStateException: Encountered invalid @Scheduled method 'prefetchAnsattListe': For input string: "7x19"
-
 * Oppdatering av kodeverk for Arkivtemaer
 
 Denne jobben oppdaterer kodeverk for Arkivtemaer ved midnatt hver dag.
-
-* Sletting av Wicket resource cache
-
-Wicket har en evig cache på string-resources brukt av applikasjonen, noe som gjør at enonictekster bare blir hentet ved oppstart.
-Denne jobben kjøres derfor hver halvtime for å få oppdatert data fra enonic.
 
 
 ## Oppstart av appen på Jetty

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/baseurls/BaseUrlsController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/baseurls/BaseUrlsController.kt
@@ -13,6 +13,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/rest/baseurls")
 class BaseUrlsController @Autowired
 constructor(private val tilgangskontroll: Tilgangskontroll) {
+    private val baseurls = BaseUrls(
+        norg2Frontend = EnvironmentUtils.getRequiredProperty("SERVER_NORG2_FRONTEND_URL"),
+        drek = EnvironmentUtils.getRequiredProperty("SERVER_DREK_URL"),
+        personforvalter = EnvironmentUtils.getRequiredProperty("PERSONFORVALTER_URL"),
+    )
 
     @GetMapping
     fun hent(): Map<String, Any?> {
@@ -23,20 +28,28 @@ constructor(private val tilgangskontroll: Tilgangskontroll) {
             }
     }
 
-    private fun getBaseUrls(): List<BaseUrl> {
-        val baseUrls = ArrayList<BaseUrl>()
-        baseUrls.add(BaseUrl(key = "norg2-frontend", url = EnvironmentUtils.getRequiredProperty("SERVER_NORG2_FRONTEND_URL")))
-        baseUrls.add(BaseUrl(key = "gosys", url = EnvironmentUtils.getRequiredProperty("SERVER_GOSYS_URL")))
-        baseUrls.add(BaseUrl(key = "arena", url = EnvironmentUtils.getRequiredProperty("SERVER_ARENA_URL")))
-        baseUrls.add(BaseUrl(key = "drek", url = EnvironmentUtils.getRequiredProperty("SERVER_DREK_URL")))
-        baseUrls.add(BaseUrl(key = "aktivitetsplan", url = EnvironmentUtils.getRequiredProperty("SERVER_AKTIVITETSPLAN_URL")))
-        baseUrls.add(BaseUrl(key = "pesys", url = EnvironmentUtils.getRequiredProperty("SERVER_PESYS_URL")))
-        baseUrls.add(BaseUrl(key = "aareg", url = EnvironmentUtils.getRequiredProperty("SERVER_AAREG_URL")))
-        baseUrls.add(BaseUrl(key = "veilarbportefoljeflatefs", url = EnvironmentUtils.getRequiredProperty("SERVER_VEILARBPORTEFOLJEFLATEFS_URL")))
-        baseUrls.add(BaseUrl(key = "personforvalter", url = EnvironmentUtils.getRequiredProperty("PERSONFORVALTER_URL")))
-
-        return baseUrls
+    @GetMapping("/v2")
+    fun hentV2(): BaseUrls {
+        return tilgangskontroll
+            .check(Policies.tilgangTilModia)
+            .get(skipAuditLog()) {
+                baseurls
+            }
     }
+
+    private fun getBaseUrls(): List<BaseUrl> {
+        return buildList {
+            add(BaseUrl(key = "norg2-frontend", url = baseurls.norg2Frontend))
+            add(BaseUrl(key = "drek", url = baseurls.drek))
+            add(BaseUrl(key = "personforvalter", url = baseurls.personforvalter))
+        }
+    }
+
+    data class BaseUrls(
+        val norg2Frontend: String,
+        val drek: String,
+        val personforvalter: String,
+    )
 
     data class BaseUrl(
         val key: String = "",


### PR DESCRIPTION
- [KAIZEN-0] forenkle baseurls endepunkt
- [KAIZEN-0] fjerne ubrukte miljøvariebler fra nais.yml
  Følgende variabler er fjernet siden de ikke er ibruk i kodebasen: 
  - SERVER_AKTIVITETSPLAN_URL
  - SERVER_ARENA_URL
  - SERVER_GOSYS_URL
  - SERVER_PESYS_URL
  - SERVER_VEILARBPORTEFOLJEFLATEFS_URL
  - SERVER_AAREG_URL
  - TJENESTER_URL
  - VIRKSOMHET_DIGITALKONTAKINFORMASJON_V1_ENDPOINTURL
  - DKIF_REST_URL
  - PREFETCH_NORG_ANSATTLISTE_SCHEDULE
  - FJERN_SOKNADER_FOR_DATO
  - HASTEKASSERING_TILGANG
  - DITTNAV_EVENTER_MODIA_URL
