### PR TITLE
[OPP-1566] Legge til kafka, sende henvendelse oppdateringer

### DIFF
--- a/.github/workflows/topic.yml
+++ b/.github/workflows/topic.yml
@@ -1,0 +1,36 @@
+name: "Deploy henvendelse oppdatering topic"
+on:
+  push:
+    paths:
+      - nais/topics/**
+      - .github/workflows/topic.yml
+jobs:
+  deploy-topic-to-dev:
+    if: github.ref == 'refs/heads/dev'
+    name: Deploy topic to dev-fss
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Deploy henvendelse-oppdatering-melding topic
+        uses: nais/deploy/actions/deploy@master
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yaml
+          VARS: nais/topics/dev.json
+
+  deploy-topic-to-prod:
+    if: github.ref == 'refs/heads/master'
+    name: Deploy topic to prod-fss
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Deploy henvendelse-oppdatering-melding topic
+        uses: nais/deploy/actions/deploy@master
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yaml
+          VARS: nais/topics/prod.json

--- a/.github/workflows/topic.yml
+++ b/.github/workflows/topic.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
-          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yaml
+          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yml
           VARS: nais/topics/dev.json
 
   deploy-topic-to-prod:
@@ -32,5 +32,5 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
-          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yaml
+          RESOURCE: nais/topics/henvendelse-oppdatering-melding.yml
           VARS: nais/topics/prod.json

--- a/.nais/nais-q0.yml
+++ b/.nais/nais-q0.yml
@@ -177,3 +177,5 @@ spec:
       value: "https://tms-event-api.ekstern.dev.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE
       value: "dev-gcp:min-side:tms-event-api"
+    - name: KAFKA_HENVENDELSE_OPPDATERING_TOPIC
+      value: "personoversikt.henvendelse-oppdatering-melding"

--- a/.nais/nais-q1.yml
+++ b/.nais/nais-q1.yml
@@ -179,3 +179,5 @@ spec:
       value: "https://tms-event-api.ekstern.dev.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE
       value: "dev-gcp:min-side:tms-event-api"
+    - name: KAFKA_HENVENDELSE_OPPDATERING_TOPIC
+      value: "personoversikt.henvendelse-oppdatering-melding"

--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -177,3 +177,5 @@ spec:
       value: "https://person.nav.no/tms-event-api"
     - name: TMS_EVENT_API_SCOPE
       value: "prod-gcp:min-side:tms-event-api"
+    - name: KAFKA_HENVENDELSE_OPPDATERING_TOPIC
+      value: "personoversikt.henvendelse-oppdatering-melding"

--- a/.nais/topics/dev.json
+++ b/.nais/topics/dev.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-dev"
+}

--- a/.nais/topics/henvendelse-oppdatering-melding.yml
+++ b/.nais/topics/henvendelse-oppdatering-melding.yml
@@ -20,7 +20,7 @@ spec:
   acl:
     - team: personoversikt
       application: modiapersonoversikt-api
-      access: readwrite
+      access: write
 #    - team: flex
 #      application:
 #      access: read

--- a/.nais/topics/henvendelse-oppdatering-melding.yml
+++ b/.nais/topics/henvendelse-oppdatering-melding.yml
@@ -21,6 +21,6 @@ spec:
     - team: personoversikt
       application: modiapersonoversikt-api
       access: write
-#    - team: flex
-#      application:
-#      access: read
+    - team: flex
+      application: flex-modia-kontakt-metrikk
+      access: read

--- a/.nais/topics/henvendelse-oppdatering-melding.yml
+++ b/.nais/topics/henvendelse-oppdatering-melding.yml
@@ -1,0 +1,26 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  name: henvendelse-oppdatering-melding
+  namespace: personoversikt
+  labels:
+    team: personoversikt
+  annotations:
+    dcat.data.nav.no/title: "personoversikt.henvendelse-oppdatering-melding"
+    dcat.data.nav.no/description: "Topic for alle henvendelser som produseres av saksbehandlere/veiledere"
+spec:
+  pool: {{kafkaPool}}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 3
+    replication: 2
+    retentionBytes: -1    # Messages will never get deleted because of disk space
+    retentionHours: 730  # Messages are stored for 1 month
+  acl:
+    - team: personoversikt
+      application: modiapersonoversikt-api
+      access: readwrite
+#    - team: flex
+#      application:
+#      access: read

--- a/.nais/topics/prod.json
+++ b/.nais/topics/prod.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "prod-dev"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-serialization-json</artifactId>
+                <version>${serialization.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>
@@ -272,7 +277,17 @@
                 </executions>
                 <configuration>
                     <jvmTarget>17</jvmTarget>
+                    <compilerPlugins>
+                        <plugin>kotlinx-serialization</plugin>
+                    </compilerPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-serialization</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <properties>
         <java.version>17</java.version>
         <kotlin.version>1.7.10</kotlin.version>
+        <serialization.version>1.5.1</serialization.version>
         <mockk.version>1.13.2</mockk.version>
 
         <common.version>2.2022.09.15_07.46-e4fa96eb6813</common.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -365,7 +365,6 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
-            <version>3.0.7</version>
         </dependency>
     </dependencies>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -406,32 +406,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <compilerPlugins>
-                        <plugin>kotlinx-serialization</plugin>
-                    </compilerPlugins>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-maven-serialization</artifactId>
-                        <version>${kotlin.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -186,6 +186,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-datetime-jvm</artifactId>
+            <version>0.4.0</version>
+        </dependency>
 
 
         <dependency>
@@ -350,6 +355,18 @@
             <version>1.3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-serialization-json</artifactId>
+            <version>${serialization.version}</version>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>3.0.7</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -388,6 +405,32 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <compilerPlugins>
+                        <plugin>kotlinx-serialization</plugin>
+                    </compilerPlugins>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-serialization</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/CommonKafkaProps.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/CommonKafkaProps.kt
@@ -1,0 +1,31 @@
+package no.nav.modiapersonoversikt.kafka
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SslConfigs
+import java.util.*
+
+private fun aivenSecurityProps(
+    props: Properties,
+    kafkaEnvironment: KafkaSecurityConfig,
+) {
+    props[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = kafkaEnvironment.aivenSecurityProtocol
+    props[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
+    props[SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG] = "jks"
+    props[SslConfigs.SSL_KEYSTORE_TYPE_CONFIG] = "PKCS12"
+    props[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenTruststoreLocation
+    props[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    props[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = kafkaEnvironment.aivenKeystoreLocation
+    props[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+    props[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = kafkaEnvironment.aivenCredstorePassword
+}
+
+fun commonProducerConfig(props: Properties, brokerUrl: String, clientId: String) {
+    props[ProducerConfig.ACKS_CONFIG] = "all"
+    props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = brokerUrl
+    props[ProducerConfig.CLIENT_ID_CONFIG] = clientId
+    aivenSecurityProps(
+        props,
+        KafkaSecurityConfig()
+    )
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
@@ -10,5 +10,5 @@ open class HenvendelseKafkaConfig {
     open fun henvendelseProducer(
         @Value("\${KAFKA_BROKERS}") kafkaBrokerUrl: String,
         @Value("\${KAFKA_HENVENDELSE_OPPDATERING_TOPIC}") kafkaTopic: String
-    ) = HenvendelseProducerImpl(kafkaBrokerUrl, kafkaTopic)
+    ) = HenvendelseProducerImpl(kafkaBrokerUrl, kafkaTopic, listOf("SYK"))
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
@@ -1,0 +1,14 @@
+package no.nav.modiapersonoversikt.kafka
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class HenvendelseKafkaConfig {
+    @Bean
+    open fun henvendelseProducer(
+        @Value("\${KAFKA_BROKERS}") kafkaBrokerUrl: String,
+        @Value("\${KAFKA_HENVENDELSE_OPPDATERING_TOPIC}") kafkaTopic: String
+    ) = HenvendelseProducerImpl(kafkaBrokerUrl, kafkaTopic)
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseKafkaConfig.kt
@@ -1,8 +1,12 @@
 package no.nav.modiapersonoversikt.kafka
 
+import no.nav.modiapersonoversikt.kafka.dto.HenvendelseKafkaDTO
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.serialization.StringSerializer
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.*
 
 @Configuration
 open class HenvendelseKafkaConfig {
@@ -10,5 +14,13 @@ open class HenvendelseKafkaConfig {
     open fun henvendelseProducer(
         @Value("\${KAFKA_BROKERS}") kafkaBrokerUrl: String,
         @Value("\${KAFKA_HENVENDELSE_OPPDATERING_TOPIC}") kafkaTopic: String
-    ) = HenvendelseProducerImpl(kafkaBrokerUrl, kafkaTopic, listOf("SYK"))
+    ): HenvendelseProducer {
+        val props = Properties()
+        commonProducerConfig(props = Properties(), kafkaBrokerUrl, "modiabrukerdialog-producer")
+        val kafkaProducer = KafkaProducer(props, StringSerializer(), StringSerializer())
+        return HenvendelseProducerImpl(
+            temaSomSkalPubliseres = listOf("SYK"),
+            KafkaPersonoversiktProducerImpl(kafkaProducer, kafkaTopic, HenvendelseKafkaDTO.serializer())
+        )
+    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
@@ -13,7 +13,8 @@ interface HenvendelseProducer {
 
 class HenvendelseProducerImpl(
     kafkaBrokerUrl: String,
-    kafkaTopic: String
+    kafkaTopic: String,
+    private val temaSomSkalPubliseres: List<String>
 ) : HenvendelseProducer {
     private val producer: KafkaPersonoversiktProducer<HenvendelseKafkaDTO>
 
@@ -30,6 +31,8 @@ class HenvendelseProducerImpl(
             tema = henvendelse.gjeldendeTema,
             tidspunkt = henvendelse.opprettetDato.toInstant().toKotlinInstant()
         )
-        producer.sendRecord(message = message)
+        if (temaSomSkalPubliseres.contains(message.tema)) {
+            producer.sendRecord(message = message)
+        }
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
@@ -1,0 +1,36 @@
+package no.nav.modiapersonoversikt.kafka
+
+import kotlinx.datetime.toKotlinInstant
+import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.models.HenvendelseDTO
+import no.nav.modiapersonoversikt.kafka.dto.HenvendelseKafkaDTO
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.serialization.StringSerializer
+import java.util.*
+
+interface HenvendelseProducer {
+    fun sendHenvendelseUpdate(henvendelse: HenvendelseDTO)
+}
+
+class HenvendelseProducerImpl(
+    kafkaBrokerUrl: String,
+    kafkaTopic: String
+) : HenvendelseProducer {
+    private val producer: KafkaPersonoversiktProducer<HenvendelseKafkaDTO>
+
+    init {
+        val props = Properties()
+        commonProducerConfig(props = Properties(), kafkaBrokerUrl, "modiabrukerdialog-producer")
+        val kafkaProducer = KafkaProducer(props, StringSerializer(), StringSerializer())
+        producer = KafkaPersonoversiktProducerImpl(kafkaProducer, kafkaTopic, HenvendelseKafkaDTO.serializer())
+    }
+
+    override fun sendHenvendelseUpdate(henvendelse: HenvendelseDTO) {
+        val message = HenvendelseKafkaDTO(
+            fnr = henvendelse.fnr,
+            tema = henvendelse.gjeldendeTema,
+            tidspunkt = henvendelse.opprettetDato.toInstant().toKotlinInstant()
+        )
+        producer.sendRecord(message = message)
+    }
+}
+

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducer.kt
@@ -33,4 +33,3 @@ class HenvendelseProducerImpl(
         producer.sendRecord(message = message)
     }
 }
-

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaPersonoversiktProducer.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaPersonoversiktProducer.kt
@@ -3,7 +3,7 @@ package no.nav.modiapersonoversikt.kafka
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 import java.util.UUID
 
@@ -12,7 +12,7 @@ interface KafkaPersonoversiktProducer<MESSAGE_TYPE> {
 }
 
 class KafkaPersonoversiktProducerImpl<MESSAGE_TYPE>(
-    private val producer: KafkaProducer<String, String>,
+    private val producer: Producer<String, String>,
     private val topic: String,
     private val messageSerializer: SerializationStrategy<MESSAGE_TYPE>
 ) : KafkaPersonoversiktProducer<MESSAGE_TYPE> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaPersonoversiktProducer.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaPersonoversiktProducer.kt
@@ -1,0 +1,23 @@
+package no.nav.modiapersonoversikt.kafka
+
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import java.util.UUID
+
+interface KafkaPersonoversiktProducer<MESSAGE_TYPE> {
+    fun sendRecord(key: String? = UUID.randomUUID().toString(), message: MESSAGE_TYPE)
+}
+
+class KafkaPersonoversiktProducerImpl<MESSAGE_TYPE>(
+    private val producer: KafkaProducer<String, String>,
+    private val topic: String,
+    private val messageSerializer: SerializationStrategy<MESSAGE_TYPE>
+) : KafkaPersonoversiktProducer<MESSAGE_TYPE> {
+    override fun sendRecord(key: String?, message: MESSAGE_TYPE) {
+        val encodedMessage = Json.encodeToString(messageSerializer, message)
+        producer.send(ProducerRecord(topic, key, encodedMessage))
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaSecurityConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/KafkaSecurityConfig.kt
@@ -1,0 +1,11 @@
+package no.nav.modiapersonoversikt.kafka
+
+import no.nav.personoversikt.common.utils.EnvUtils
+
+data class KafkaSecurityConfig(
+    val aivenCredstorePassword: String = EnvUtils.getRequiredConfig("KAFKA_CREDSTORE_PASSWORD"),
+    val aivenKeystoreLocation: String = EnvUtils.getRequiredConfig("KAFKA_KEYSTORE_PATH"),
+    val aivenSecurityProtocol: String = EnvUtils.getRequiredConfig("KAFKA_SECURITY_PROTOCOL:SSL"),
+    val aivenTruststoreLocation: String = EnvUtils.getRequiredConfig("KAFKA_TRUSTSTORE_PATH"),
+    val aivenSchemaRegistryUrl: String = EnvUtils.getRequiredConfig("KAFKA_SCHEMA_REGISTRY"),
+)

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/dto/HenvendelseKafkaDTO.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/dto/HenvendelseKafkaDTO.kt
@@ -1,0 +1,10 @@
+package no.nav.modiapersonoversikt.kafka.dto
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HenvendelseKafkaDTO(
+    val fnr: String,
+    val tema: String?,
+    val tidspunkt: Instant
+)

--- a/web/src/main/java/no/nav/modiapersonoversikt/kafka/dto/HenvendelseKafkaDTO.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/kafka/dto/HenvendelseKafkaDTO.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class HenvendelseKafkaDTO(
     val fnr: String,
-    val tema: String?,
+    val tema: String,
     val tidspunkt: Instant
 )

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.modiapersonoversikt.rest.dialog
 
+import no.nav.modiapersonoversikt.kafka.HenvendelseProducer
 import no.nav.modiapersonoversikt.rest.dialog.apis.DialogApi
 import no.nav.modiapersonoversikt.rest.dialog.apis.DialogDelsvarApi
 import no.nav.modiapersonoversikt.rest.dialog.apis.DialogMerkApi
@@ -32,6 +33,9 @@ open class DialogConfig {
     @Autowired
     private lateinit var unleashService: UnleashService
 
+    @Autowired
+    private lateinit var henvendelseProducer: HenvendelseProducer
+
     @Bean
     open fun dialogApi(): DialogApi {
         return SfLegacyDialogController(
@@ -39,6 +43,7 @@ open class DialogConfig {
             oppgaveBehandlingService,
             ansattService,
             kodeverk,
+            henvendelseProducer,
             unleashService
         )
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
@@ -3,4 +3,5 @@ package no.nav.modiapersonoversikt.service.unleash
 enum class Feature(val propertyKey: String) {
     SAMPLE_FEATURE("feature.samplerfeature"),
     USE_REST_KONTOREGISTER("modiabrukerdialog.rest.kontoregister.switcher"),
+    SEND_HENVENDELSE_TO_KAFKA("modiapersonoversikt.henvendelse_kafka")
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducerTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/kafka/HenvendelseProducerTest.kt
@@ -1,0 +1,103 @@
+package no.nav.modiapersonoversikt.kafka
+
+import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.models.HenvendelseDTO
+import no.nav.modiapersonoversikt.kafka.dto.HenvendelseKafkaDTO
+import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.common.serialization.Serdes.StringSerde
+import org.junit.jupiter.api.*
+import java.time.OffsetDateTime
+import kotlin.test.assertEquals
+
+private const val TOPIC = "test_topic"
+private val TEMA_SOM_SKAL_PUBLISERES = listOf("SYK")
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HenvendelseProducerTest {
+    var mockProducer: MockProducer<String, String>? = null
+    var henvendelseProducer: HenvendelseProducerImpl? = null
+
+    @BeforeEach
+    fun setUp() {
+        mockProducer = MockProducer(
+            true,
+            StringSerde().serializer(),
+            StringSerde().serializer()
+        )
+
+        val personoversiktProducer = KafkaPersonoversiktProducerImpl(
+            producer = mockProducer!!,
+            topic = TOPIC,
+            messageSerializer = HenvendelseKafkaDTO.serializer()
+        )
+        henvendelseProducer = HenvendelseProducerImpl(
+            temaSomSkalPubliseres = TEMA_SOM_SKAL_PUBLISERES,
+            producer = personoversiktProducer
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockProducer = null
+        henvendelseProducer = null
+    }
+
+    @Test
+    fun `henvendelser blir sendt til kafka`() {
+        val henvendelse = HenvendelseDTO(
+            henvendelseType = HenvendelseDTO.HenvendelseType.CHAT,
+            fnr = "10108000398",
+            aktorId = "10108000398",
+            opprettetDato = OffsetDateTime.parse("2023-05-25T07:57:05.884615Z"),
+            kontorsperre = false,
+            feilsendt = false,
+            kjedeId = "",
+            gjeldendeTema = "SYK"
+        )
+
+        henvendelseProducer!!.sendHenvendelseUpdate(henvendelse = henvendelse)
+
+        val message = mockProducer!!.history().get(0)
+
+        assertEquals(mockProducer!!.history().size, 1)
+        assertEquals<String>(
+            "{\"fnr\":\"10108000398\",\"tema\":\"SYK\",\"tidspunkt\":\"2023-05-25T07:57:05.884615Z\"}",
+            message.value()
+        )
+    }
+
+    @Test
+    fun `henvendelser som ikke har riktig tema blir ikke sendt til kafka`() {
+        val henvendelse = HenvendelseDTO(
+            henvendelseType = HenvendelseDTO.HenvendelseType.CHAT,
+            fnr = "10108000398",
+            aktorId = "10108000398",
+            opprettetDato = OffsetDateTime.now(),
+            kontorsperre = false,
+            feilsendt = false,
+            kjedeId = "",
+            gjeldendeTema = "AAP"
+        )
+
+        henvendelseProducer!!.sendHenvendelseUpdate(henvendelse = henvendelse)
+
+        assertEquals(mockProducer!!.history().size, 0)
+    }
+
+    @Test
+    fun `henvendelser som ikke har tema blir ikke sendt til kafka`() {
+        val henvendelse = HenvendelseDTO(
+            fnr = "10108000398",
+            henvendelseType = HenvendelseDTO.HenvendelseType.CHAT,
+            aktorId = "10108000398",
+            opprettetDato = OffsetDateTime.now(),
+            kontorsperre = false,
+            feilsendt = false,
+            kjedeId = "",
+            gjeldendeTema = null
+        )
+
+        henvendelseProducer!!.sendHenvendelseUpdate(henvendelse = henvendelse)
+
+        assertEquals(mockProducer!!.history().size, 0)
+    }
+}


### PR DESCRIPTION
# Henvendelse oppdateringer på Kafka

Team flex ønsker informasjon om antall meldinger som sendes på temaet SYK. Denne PRen legger til kafka producer som sender alle henvendelser som melding på kafka topic personoversikt.henvendelse-oppdatering-melding. I framtiden kan det være at flere tema blir sendt på dette temaet, så da er konsumentene selv ansvarlig for å filtrere ut meldinger som er relevante.