### PR TITLE
Ikke overskriv spring config

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/Main.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/Main.java
@@ -45,6 +45,6 @@ public class Main {
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilder()  {
-        return builder -> builder.modules(new JodaModule()).build();
+        return builder -> builder.modulesToInstall(new JodaModule()).build();
     }
 }


### PR DESCRIPTION
`modulesToInstall` legger til i _tillegg_ til spring auto-configuration,
mens `modules` overskriver...