### PR TITLE
Ikke logg repoonse body by default.

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -50,7 +50,7 @@ class LoggingInterceptor(
 ) : Interceptor {
     data class Config(
         val ignoreRequestBody: Boolean = false,
-        val ignoreResponseBody: Boolean = false,
+        val ignoreResponseBody: Boolean = true,
     )
 
     companion object {


### PR DESCRIPTION
Vi har ikke kontroll over størrelsen og vi kan logge for mye
informasjon, og potensielt informasjon som ikke trengs/skal logges.
