### PR TITLE
[PROD] Fiks for manglende saksId på saker

### DIFF
--- a/tjenestespesifikasjoner/saf-api/src/main/resources/saf/schema.graphql
+++ b/tjenestespesifikasjoner/saf-api/src/main/resources/saf/schema.graphql
@@ -297,6 +297,12 @@ type Journalpost {
     # * Returneres kun for utgående journalposter
     utsendingsinfo: Utsendingsinfo
 
+    # Regel for innsyn for denne journalposten. Verdi er "BRUK_STANDARDREGLER" om innsyn ikke er overstyrt.
+    innsynsregel: String!
+
+    # Menneskevennlig beskrivelse av aktuell innsynsregel.
+    innsynsregelBeskrivelse: String!
+
     # Liste over fagspesifikke metadata som er tilknyttet journalpost.
     tilleggsopplysninger: [Tilleggsopplysning]
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
@@ -1,5 +1,6 @@
 package no.nav.modiapersonoversikt.service.journalforingsaker;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.joda.time.DateTime;
 
@@ -48,6 +49,7 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
             && FAGSYSTEMKODE_ARENA.equals(sak.fagsystemKode)
             && SAKSTYPE_MED_FAGSAK.equals(sak.sakstype);
 
+    @JsonGetter
     public String getSaksIdVisning() {
         if(fagsystemSaksId != null) return fagsystemSaksId;
         else if (saksId != null) return saksId;

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
@@ -232,6 +232,7 @@ class SakerServiceImplTest {
         private val SakId_3 = "3"
         private val FagsystemSakId_3 = "33"
         private val SakId_4 = "4"
+        private val SakId_5 = "5"
 
         private fun earlierDateTimeWithOffSet(offset: Long) = LocalDateTime.now().minusDays(offset)
 
@@ -276,6 +277,15 @@ class SakerServiceImplTest {
                                     fagsakId = null,
                                     sakstype = Sakstype.GENERELL_SAK,
                                     tema = Tema.STO,
+                                ),
+                                Sak(
+                                    arkivsaksnummer = SakId_5,
+                                    arkivsaksystem = null,
+                                    datoOpprettet = earlierDateTimeWithOffSet(5),
+                                    fagsaksystem = FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK,
+                                    fagsakId = null,
+                                    sakstype = Sakstype.GENERELL_SAK,
+                                    tema = Tema.BIL,
                                 ),
                             ),
                     ),


### PR DESCRIPTION
En eller annen endring, antakeligvis kotlin compiler eller jackson, har gjort at denne getteren ikke ble kalt og serialisert. Problemet manifesterte seg kun når man bygger jaren, og dukket ikke opp i tester, men å slenge på en `JsonGetter` annotation fikser problemet :shrug: 