### PR TITLE
Håndter henvendelser uten temagruppe bedre

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
@@ -27,7 +27,9 @@ open class ArenaInfotrygdApiConfig {
     @Bean
     open fun arenaInfotrygdApi(): ArenaInfotrygdApi {
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .connectTimeout(15L, TimeUnit.SECONDS)
                 .readTimeout(15L, TimeUnit.SECONDS)
@@ -38,13 +40,11 @@ open class ArenaInfotrygdApiConfig {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         tokenProvider.createMachineToMachineToken(scope)
                     },
-                )
-                .build()
+                ).build()
         return ArenaInfotrygdApiImpl(url, httpClient)
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
@@ -152,6 +152,27 @@ internal class SfHenvendelseServiceImplTest {
     }
 
     @Test
+    internal fun `skal ikke fjerne henvendelse om den ikke har temagruppe`() {
+        every { ansattService.hentAnsattFagomrader(any(), any()) } returns setOf("DAG", "OPP")
+        every { norgApi.hentGeografiskTilknyttning(any()) } returns
+            listOf(
+                EnhetGeografiskTilknyttning(
+                    enhetId = "5678",
+                    geografiskOmraade = "005678",
+                ),
+            )
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns
+            listOf(
+                dummyHenvendelse.copy(gjeldendeTemagruppe = null),
+            )
+
+        val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")
+
+        assertThat(henvendelser).hasSize(1)
+        assertThat(henvendelser[0].gjeldendeTemagruppe).isEqualTo("UKJENT")
+    }
+
+    @Test
     internal fun `skal sortere meldinger kronologisk`() {
         every { ansattService.hentAnsattFagomrader(any(), any()) } returns setOf("DAG", "OPP")
         every { norgApi.hentGeografiskTilknyttning(any()) } returns


### PR DESCRIPTION
Ikke skjul henvendelser som mangler temagruppe. Det er noe feil hos SF
som gjør at vi får flere henvendelser uten temagruppe, som da ikke vises
til veiledere. Det er bedre at vi viser meldingene selv om de mangler
temagruppe slik at de ikke tror at bruker ikke har svart dem når de
forventer svar.
