### PR TITLE
Sett page size til 200 fra ms graph

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADService.kt
@@ -37,6 +37,8 @@ open class AzureADServiceImpl(
                 .apply {
                     path("v1.0/me/memberOf/microsoft.graph.group")
                     parameters.append("\$count", "true")
+                    parameters.append("\$top", "200")
+                    parameters.append("\$select", "displayName")
                 }.buildString()
 
         return try {


### PR DESCRIPTION
Antakeligvis er det en default page size på 100 (dette står ikke nevnt i
dokumentasjonen, men trail and error viser at det nok stemmer) som gjør
at visse identer som har flere enn disse kan risikere å ikke gå gjennom
access control siden vi ikke mottar gruppene som er paginerte.
