### PR TITLE
Fix bug der error i ms graph API fyller cache med feil verdi

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADService.kt
@@ -38,7 +38,7 @@ open class AzureADServiceImpl(
     private val json = Json { ignoreUnknownKeys = true }
     private val log = LoggerFactory.getLogger(AzureADServiceImpl::class.java)
 
-    @Cacheable
+    @Cacheable(unless = "#result.size()==0")
     override fun hentRollerForVeileder(veilederIdent: NavIdent): List<String> {
         val userToken = AuthContextUtils.requireToken()
         val url =


### PR DESCRIPTION
Vi returnerer `emptyList()` i catch blokken ved feilende API kall. Da
håndterer cachen dette som gyldig output og den tomme listen er cachet
til senere. Vi ignorerer å cache tomme lister for å unngå dette
problemet.