### PR TITLE
Vis språk som ukjent dersom det ikke er satt

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -989,11 +989,11 @@ class PersondataFletter(val kodeverk: EnhetligKodeverk.Service) {
         val tegnsprak: MutableList<Persondata.KodeBeskrivelse<String>> = mutableListOf()
 
         data.persondata.tilrettelagtKommunikasjon.map {
-            if (it.talespraaktolk != null && it.talespraaktolk!!.spraak != null) {
-                talesprak.add(kodeverk.hentKodeBeskrivelse(Kodeverk.SPRAK, it.talespraaktolk!!.spraak!!))
+            if (it.talespraaktolk != null) {
+                talesprak.add(kodeverk.hentKodeBeskrivelse(Kodeverk.SPRAK, it.talespraaktolk?.spraak ?: "ukjent"))
             }
-            if (it.tegnspraaktolk != null && it.tegnspraaktolk!!.spraak != null) {
-                tegnsprak.add(kodeverk.hentKodeBeskrivelse(Kodeverk.SPRAK, it.tegnspraaktolk!!.spraak!!))
+            if (it.tegnspraaktolk != null) {
+                tegnsprak.add(kodeverk.hentKodeBeskrivelse(Kodeverk.SPRAK, it.tegnspraaktolk?.spraak ?: "ukjent"))
             }
         }
 


### PR DESCRIPTION
Det er mulig at Tolk er satt, men med spraak er null. Da trengs det tolk
men man vet ikke hvilket språk. Dette håndteres ikke i dag.
