### PR TITLE
Unleash logger

### DIFF
--- a/web/.nais/dev.yml
+++ b/web/.nais/dev.yml
@@ -31,9 +31,10 @@ spec:
     enabled: true
   resources:
     requests:
-      cpu: 50m
+      cpu: 10m
       memory: 1024Mi
     limits:
+      cpu: 1000m
       memory: 2048Mi
   ingresses:
     - https://modiapersonoversikt-api.intern.dev.nav.no

--- a/web/.nais/dev.yml
+++ b/web/.nais/dev.yml
@@ -31,11 +31,10 @@ spec:
     enabled: true
   resources:
     requests:
-      cpu: 1000m
-      memory: 4096Mi
+      cpu: 50m
+      memory: 1024Mi
     limits:
-      cpu: 2000m
-      memory: 8192Mi
+      memory: 2048Mi
   ingresses:
     - https://modiapersonoversikt-api.intern.dev.nav.no
   leaderElection: true

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
@@ -15,7 +15,7 @@ open class InterceptorConfig {
         tjenestekallLogger: TjenestekallLogger,
     ): TjenestekallLoggingInterceptorFactory =
         { name, interceptor ->
-            LoggingInterceptor(unleashService, name, tjenestekallLogger, interceptor)
+            LoggingInterceptor(unleashService, tjenestekallLogger, name, interceptor)
         }
 }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
@@ -1,0 +1,22 @@
+package no.nav.modiapersonoversikt.config.interceptor
+
+import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogger
+import okhttp3.Request
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class InterceptorConfig {
+    @Bean
+    open fun loggingInterceptorFactory(
+        unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
+    ): TjenestekallLoggingInterceptorFactory =
+        { name, interceptor ->
+            LoggingInterceptor(unleashService, name, tjenestekallLogger, interceptor)
+        }
+}
+
+typealias TjenestekallLoggingInterceptorFactory = (name: String, interceptor: (Request) -> String) -> LoggingInterceptor

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/InterceptorConfig.kt
@@ -3,14 +3,13 @@ package no.nav.modiapersonoversikt.config.interceptor
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.personoversikt.common.logging.TjenestekallLogger
-import okhttp3.Request
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 open class InterceptorConfig {
     @Bean
-    open fun loggingInterceptorFactory(
+    open fun tjenestekallLoggingInterceptorFactory(
         unleashService: UnleashService,
         tjenestekallLogger: TjenestekallLogger,
     ): TjenestekallLoggingInterceptorFactory =
@@ -18,5 +17,3 @@ open class InterceptorConfig {
             LoggingInterceptor(unleashService, tjenestekallLogger, name, interceptor)
         }
 }
-
-typealias TjenestekallLoggingInterceptorFactory = (name: String, interceptor: (Request) -> String) -> LoggingInterceptor

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/TjenestekallLoggingInterceptorFactory.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/interceptor/TjenestekallLoggingInterceptorFactory.kt
@@ -1,0 +1,6 @@
+package no.nav.modiapersonoversikt.config.interceptor
+
+import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import okhttp3.Request
+
+typealias TjenestekallLoggingInterceptorFactory = (name: String, interceptor: (Request) -> String) -> LoggingInterceptor

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/logg/LoggConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/logg/LoggConfig.kt
@@ -1,0 +1,17 @@
+package no.nav.modiapersonoversikt.config.logg
+
+import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogg
+import no.nav.personoversikt.common.logging.TjenestekallLogger
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class LoggConfig {
+    @Bean
+    open fun tjenestekallLogger(unleashService: UnleashService): TjenestekallLogger =
+        UnleashTjenestekallLogger(
+            TjenestekallLogg,
+            unleashService,
+        )
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/logg/UnleashTjenestekallLogger.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/logg/UnleashTjenestekallLogger.kt
@@ -14,7 +14,7 @@ class UnleashTjenestekallLogger(
         fields: Map<String, Any?>,
         tags: Map<String, Any?>,
         throwable: Throwable?,
-    ) = logIfEnabled { info(header, fields, tags, throwable) }
+    ) = logIfEnabled { delegate.info(header, fields, tags, throwable) }
 
     override fun warn(
         header: String,

--- a/web/src/main/java/no/nav/modiapersonoversikt/config/logg/UnleashTjenestekallLogger.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/config/logg/UnleashTjenestekallLogger.kt
@@ -1,0 +1,45 @@
+package no.nav.modiapersonoversikt.config.logg
+
+import no.nav.modiapersonoversikt.service.unleash.Feature
+import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogger
+import org.slf4j.Marker
+
+class UnleashTjenestekallLogger(
+    private val delegate: TjenestekallLogger,
+    private val unleashService: UnleashService,
+) : TjenestekallLogger {
+    override fun info(
+        header: String,
+        fields: Map<String, Any?>,
+        tags: Map<String, Any?>,
+        throwable: Throwable?,
+    ) = logIfEnabled { info(header, fields, tags, throwable) }
+
+    override fun warn(
+        header: String,
+        fields: Map<String, Any?>,
+        tags: Map<String, Any?>,
+        throwable: Throwable?,
+    ) = delegate.warn(header, fields, tags, throwable)
+
+    override fun error(
+        header: String,
+        fields: Map<String, Any?>,
+        tags: Map<String, Any?>,
+        throwable: Throwable?,
+    ) = delegate.error(header, fields, tags, throwable)
+
+    override fun raw(
+        level: TjenestekallLogger.Level,
+        message: String,
+        markers: Marker?,
+        throwable: Throwable?,
+    ) = delegate.raw(level, message, markers, throwable)
+
+    private inline fun logIfEnabled(block: TjenestekallLogger.() -> Unit) {
+        if (unleashService.isEnabled(Feature.TJENESTEKALL_LOGGING)) {
+            delegate.block()
+        }
+    }
+}

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
@@ -10,6 +10,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.exchangeOnBehalfOfToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -26,6 +27,7 @@ open class ArenaInfotrygdApiConfig {
     open fun arenaInfotrygdApi(
         oboTokenProvider: OnBehalfOfTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): ArenaInfotrygdApi {
         val httpClient: OkHttpClient =
             RestClient
@@ -36,7 +38,7 @@ open class ArenaInfotrygdApiConfig {
                 .readTimeout(15L, TimeUnit.SECONDS)
                 .writeTimeout(15L, TimeUnit.SECONDS)
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "ArenaInfotrygdApi") { request ->
+                    LoggingInterceptor(unleashService, "ArenaInfotrygdApi", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/arenainfotrygdproxy/ArenaInfotrygdApiConfig.kt
@@ -3,14 +3,12 @@ package no.nav.modiapersonoversikt.consumer.arenainfotrygdproxy
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.exchangeOnBehalfOfToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -26,8 +24,7 @@ open class ArenaInfotrygdApiConfig {
     @Bean
     open fun arenaInfotrygdApi(
         oboTokenProvider: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): ArenaInfotrygdApi {
         val httpClient: OkHttpClient =
             RestClient
@@ -38,7 +35,7 @@ open class ArenaInfotrygdApiConfig {
                 .readTimeout(15L, TimeUnit.SECONDS)
                 .writeTimeout(15L, TimeUnit.SECONDS)
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "ArenaInfotrygdApi", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("ArenaInfotrygdApi") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/axsys/AxsysConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/axsys/AxsysConfig.kt
@@ -11,6 +11,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
@@ -28,16 +29,20 @@ open class AxsysConfig {
     lateinit var tokenProvider: MachineToMachineTokenClient
 
     @Bean
-    open fun axsys(unleashService: UnleashService): AxsysClient {
+    open fun axsys(
+        unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
+    ): AxsysClient {
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Axsys") {
+                    LoggingInterceptor(unleashService, "Axsys", tjenestekallLogger) {
                         // Optimalt sett burde denne hentes fra requesten, men det sendes ikke noe tilsvarende callId til axsys
                         getCallId()
                     },
-                )
-                .build()
+                ).build()
         val tokenSupplier = {
             tokenProvider.createMachineToMachineToken(downstreamApi)
         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/axsys/AxsysConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/axsys/AxsysConfig.kt
@@ -6,14 +6,11 @@ import no.nav.common.client.axsys.CachedAxsysClient
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -25,20 +22,17 @@ open class AxsysConfig {
         val downstreamApi = DownstreamApi.parse(EnvironmentUtils.getRequiredProperty("AXSYS_SCOPE"))
     }
 
-    @Autowired
-    lateinit var tokenProvider: MachineToMachineTokenClient
-
     @Bean
     open fun axsys(
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
+        tokenProvider: MachineToMachineTokenClient,
     ): AxsysClient {
         val httpClient: OkHttpClient =
             RestClient
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Axsys", tjenestekallLogger) {
+                    tjenestekallLoggingInterceptorFactory("Axsys") {
                         // Optimalt sett burde denne hentes fra requesten, men det sendes ikke noe tilsvarende callId til axsys
                         getCallId()
                     },

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/brukernotifikasjon/BrukernotifikasjonConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/brukernotifikasjon/BrukernotifikasjonConfig.kt
@@ -3,14 +3,12 @@ package no.nav.modiapersonoversikt.consumer.brukernotifikasjon
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.exchangeOnBehalfOfToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -23,8 +21,7 @@ open class BrukernotifikasjonConfig {
     @Bean
     open fun brukernotifikasjonService(
         oboTokenProvider: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): Brukernotifikasjon.Service {
         val authInterceptor =
             HeadersInterceptor {
@@ -39,7 +36,7 @@ open class BrukernotifikasjonConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Brukernotifikasjon", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Brukernotifikasjon") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/brukernotifikasjon/BrukernotifikasjonConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/brukernotifikasjon/BrukernotifikasjonConfig.kt
@@ -10,6 +10,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.exchangeOnBehalfOfToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -23,6 +24,7 @@ open class BrukernotifikasjonConfig {
     open fun brukernotifikasjonService(
         oboTokenProvider: OnBehalfOfTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): Brukernotifikasjon.Service {
         val authInterceptor =
             HeadersInterceptor {
@@ -32,16 +34,17 @@ open class BrukernotifikasjonConfig {
             }
 
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Brukernotifikasjon") { request ->
+                    LoggingInterceptor(unleashService, "Brukernotifikasjon", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(authInterceptor)
+                ).addInterceptor(authInterceptor)
                 .build()
         return BrukernotifikasjonService(
             BrukernotifikasjonClient(

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontoregister/KontoregisterConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontoregister/KontoregisterConfig.kt
@@ -13,6 +13,7 @@ import no.nav.modiapersonoversikt.infrastructure.ping.Pingable
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
@@ -26,29 +27,30 @@ open class KontoregisterConfig {
     open fun kontoregisterApi(
         tokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ) = KontoregisterV1Api(
         basePath = url,
         httpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Kontoregister") { request ->
+                    LoggingInterceptor(unleashService, "Kontoregister", tjenestekallLogger) { request ->
                         requireNotNull(request.header("nav-call-id")) {
                             "Kall uten \"nav-call-id\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         tokenClient.createMachineToMachineToken(scope)
                     },
-                )
-                .build(),
+                ).build(),
     )
 
     @Bean
     @Conditional(InDevCondition::class)
-    open fun kontoregisterPing(client: KontoregisterV1Api): Pingable {
-        return Pingable {
+    open fun kontoregisterPing(client: KontoregisterV1Api): Pingable =
+        Pingable {
             SelfTestCheck("Kontoregister - V1", false) {
                 try {
                     client.hentValutakoder()
@@ -58,5 +60,4 @@ open class KontoregisterConfig {
                 }
             }
         }
-    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontoregister/KontoregisterConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/kontoregister/KontoregisterConfig.kt
@@ -6,14 +6,12 @@ import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import no.nav.modiapersonoversikt.config.InDevCondition
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.kontoregister.generated.apis.KontoregisterV1Api
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.ping.Pingable
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
@@ -26,8 +24,7 @@ open class KontoregisterConfig {
     @Bean
     open fun kontoregisterApi(
         tokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ) = KontoregisterV1Api(
         basePath = url,
         httpClient =
@@ -35,7 +32,7 @@ open class KontoregisterConfig {
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Kontoregister", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Kontoregister") { request ->
                         requireNotNull(request.header("nav-call-id")) {
                             "Kall uten \"nav-call-id\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrConfig.kt
@@ -3,9 +3,8 @@ package no.nav.modiapersonoversikt.consumer.krr
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
 import no.nav.personoversikt.common.logging.TjenestekallLogger
@@ -20,7 +19,7 @@ open class KrrConfig {
     @Primary
     open fun krrService(
         machineToMachineTokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         tjenestekallLogger: TjenestekallLogger,
     ): Krr.Service {
         val scope = DownstreamApi.parse(EnvironmentUtils.getRequiredProperty("KRR_SCOPE"))
@@ -29,7 +28,7 @@ open class KrrConfig {
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "digdir-krr-proxy", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("digdir-krr-proxy") { request ->
                         requireNotNull(request.header("Nav-Call-Id"))
                     },
                 ).addInterceptor(

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.modiapersonoversikt.consumer.krr
 
-import KrrServiceImpl
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils
@@ -9,6 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -21,25 +21,27 @@ open class KrrConfig {
     open fun krrService(
         machineToMachineTokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): Krr.Service {
         val scope = DownstreamApi.parse(EnvironmentUtils.getRequiredProperty("KRR_SCOPE"))
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "digdir-krr-proxy") { request ->
+                    LoggingInterceptor(unleashService, "digdir-krr-proxy", tjenestekallLogger) { request ->
                         requireNotNull(request.header("Nav-Call-Id"))
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         machineToMachineTokenClient.createMachineToMachineToken(scope)
                     },
-                )
-                .build()
+                ).build()
 
         return KrrServiceImpl(
             EnvironmentUtils.getRequiredProperty("KRR_REST_URL"),
             httpClient,
+            tjenestekallLogger,
         )
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/nom/NomConfig.kt
@@ -9,12 +9,10 @@ import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.types.identer.NavIdent
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -27,15 +25,14 @@ open class NomConfig {
     @Bean
     open fun nom(
         tokenProvider: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): NomClient {
         val httpClient: OkHttpClient =
             RestClient
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Nom", tjenestekallLogger) {
+                    tjenestekallLoggingInterceptorFactory("Nom") {
                         // Optimalt sett burde denne hentes fra requesten, men det sendes ikke noe tilsvarende callId til Nom
                         getCallId()
                     },

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgConfig.kt
@@ -5,6 +5,7 @@ import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,19 +16,23 @@ open class NorgConfig {
     private val url: String = EnvironmentUtils.getRequiredProperty("NORG2_BASEURL")
 
     @Bean
-    open fun norgApi(unleashService: UnleashService): NorgApi {
+    open fun norgApi(
+        unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
+    ): NorgApi {
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .connectTimeout(30L, TimeUnit.SECONDS)
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Norg2") { request ->
+                    LoggingInterceptor(unleashService, "Norg2", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .build()
+                ).build()
 
         return NorgApiImpl(url, httpClient)
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/norg/NorgConfig.kt
@@ -2,10 +2,8 @@ package no.nav.modiapersonoversikt.consumer.norg
 
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,10 +14,7 @@ open class NorgConfig {
     private val url: String = EnvironmentUtils.getRequiredProperty("NORG2_BASEURL")
 
     @Bean
-    open fun norgApi(
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
-    ): NorgApi {
+    open fun norgApi(tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory): NorgApi {
         val httpClient: OkHttpClient =
             RestClient
                 .baseClient()
@@ -27,7 +22,7 @@ open class NorgConfig {
                 .connectTimeout(30L, TimeUnit.SECONDS)
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Norg2", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Norg2") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlFullmaktApi/PdlFullmaktConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlFullmaktApi/PdlFullmaktConfig.kt
@@ -10,6 +10,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
@@ -27,25 +28,25 @@ open class PdlFullmaktConfig {
     lateinit var unleashService: UnleashService
 
     @Bean
-    open fun pdlFullmakt(): PdlFullmaktApi {
+    open fun pdlFullmakt(tjenestekallLogger: TjenestekallLogger): PdlFullmaktApi {
         val oboTokenProvider = tokenProvider.bindTo(scope)
 
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "PdlFullmaktApi") { request ->
+                    LoggingInterceptor(unleashService, "PdlFullmaktApi", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         AuthContextUtils.requireBoundedClientOboToken(oboTokenProvider)
                     },
-                )
-                .build()
+                ).build()
 
         return PdlFullmaktApiImpl(url, httpClient)
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlFullmaktApi/PdlFullmaktConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlFullmaktApi/PdlFullmaktConfig.kt
@@ -3,16 +3,13 @@ package no.nav.modiapersonoversikt.consumer.pdlFullmaktApi
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,14 +18,11 @@ open class PdlFullmaktConfig {
     private val scope = DownstreamApi.parse(getRequiredProperty("PDL_FULLMAKT_SCOPE"))
     private val url: String = getRequiredProperty("PDL_FULLMAKT_URL")
 
-    @Autowired
-    lateinit var tokenProvider: OnBehalfOfTokenClient
-
-    @Autowired
-    lateinit var unleashService: UnleashService
-
     @Bean
-    open fun pdlFullmakt(tjenestekallLogger: TjenestekallLogger): PdlFullmaktApi {
+    open fun pdlFullmakt(
+        tokenProvider: OnBehalfOfTokenClient,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
+    ): PdlFullmaktApi {
         val oboTokenProvider = tokenProvider.bindTo(scope)
 
         val httpClient: OkHttpClient =
@@ -37,7 +31,7 @@ open class PdlFullmaktConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "PdlFullmaktApi", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("PdlFullmaktApi") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlPip/PdlPipConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/pdlPip/PdlPipConfig.kt
@@ -3,15 +3,13 @@ package no.nav.modiapersonoversikt.consumer.pdlPip
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
 import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -20,12 +18,10 @@ open class PdlPipConfig {
     private val scope = DownstreamApi.parse(getRequiredProperty("PDL_PIP_SCOPE"))
     private val url: String = getRequiredProperty("PDL_PIP_URL")
 
-    @Autowired
-    lateinit var tokenProvider: MachineToMachineTokenClient
-
     @Bean
     open fun pdlPip(
-        unleashService: UnleashService,
+        tokenProvider: MachineToMachineTokenClient,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         tjenestekallLogger: TjenestekallLogger,
     ): PdlPipApi {
         val httpClient: OkHttpClient =
@@ -34,7 +30,7 @@ open class PdlPipConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "PdlPipApi", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("PdlPipApi") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingConfig.kt
@@ -8,6 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.maskinporten.MaskinportenClient
 import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.InnkrevingskravClient
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -20,13 +21,14 @@ open class SkatteetatenInnkrevingConfig {
     open fun httpClient(
         maskinportenClient: MaskinportenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): OkHttpClient =
         RestClient
             .baseClient()
             .newBuilder()
             .addInterceptor(XCorrelationIdInterceptor())
             .addInterceptor(
-                LoggingInterceptor(unleashService, "SkatteetatenInnkreving") { request ->
+                LoggingInterceptor(unleashService, "SkatteetatenInnkreving", tjenestekallLogger) { request ->
                     requireNotNull(request.header("X-Correlation-ID")) {
                         "Kall uten \"X-Correlation-ID\" er ikke lov"
                     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingConfig.kt
@@ -1,14 +1,13 @@
 package no.nav.modiapersonoversikt.consumer.skatteetaten.innkreving
 
 import no.nav.common.rest.client.RestClient
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.skatteetaten.innkreving.api.generated.apis.KravdetaljerApi
 import no.nav.modiapersonoversikt.consumer.skatteetaten.innkreving.api.generated.infrastructure.ApiClient
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.maskinporten.MaskinportenClient
 import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.InnkrevingskravClient
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -20,15 +19,14 @@ open class SkatteetatenInnkrevingConfig {
     @Bean("skatteetatenOppdragsinnkrevingClient")
     open fun httpClient(
         maskinportenClient: MaskinportenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): OkHttpClient =
         RestClient
             .baseClient()
             .newBuilder()
             .addInterceptor(XCorrelationIdInterceptor())
             .addInterceptor(
-                LoggingInterceptor(unleashService, "SkatteetatenInnkreving", tjenestekallLogger) { request ->
+                tjenestekallLoggingInterceptorFactory("SkatteetatenInnkreving") { request ->
                     requireNotNull(request.header("X-Correlation-ID")) {
                         "Kall uten \"X-Correlation-ID\" er ikke lov"
                     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
@@ -3,15 +3,12 @@ package no.nav.modiapersonoversikt.consumer.skjermedePersoner
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -20,13 +17,10 @@ open class SkjermedePersonerConfig {
     private val scope = DownstreamApi.parse(getRequiredProperty("SKJERMEDE_PERSONER_SCOPE"))
     private val url: String = getRequiredProperty("SKJERMEDE_PERSONER_PIP_URL")
 
-    @Autowired
-    lateinit var tokenProvider: MachineToMachineTokenClient
-
     @Bean
     open fun skjermedePersoner(
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tokenProvider: MachineToMachineTokenClient,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): SkjermedePersonerApi {
         val httpClient: OkHttpClient =
             RestClient
@@ -34,7 +28,7 @@ open class SkjermedePersonerConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "SkjermedePersoner", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("SkjermedePersoner") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/skjermedePersoner/SkjermedePersonerConfig.kt
@@ -9,6 +9,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
@@ -23,23 +24,26 @@ open class SkjermedePersonerConfig {
     lateinit var tokenProvider: MachineToMachineTokenClient
 
     @Bean
-    open fun skjermedePersoner(unleashService: UnleashService): SkjermedePersonerApi {
+    open fun skjermedePersoner(
+        unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
+    ): SkjermedePersonerApi {
         val httpClient: OkHttpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "SkjermedePersoner") { request ->
+                    LoggingInterceptor(unleashService, "SkjermedePersoner", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         tokenProvider.createMachineToMachineToken(scope)
                     },
-                )
-                .build()
+                ).build()
         return SkjermedePersonerApiImpl(url, httpClient)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/tiltakspenger/TiltakspengerConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/tiltakspenger/TiltakspengerConfig.kt
@@ -3,13 +3,14 @@ package no.nav.modiapersonoversikt.consumer.tiltakspenger
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.tiltakspenger.generated.apis.TiltakspengerApi
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
-import no.nav.modiapersonoversikt.infrastructure.http.*
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,8 +22,7 @@ open class TiltakspengerConfig {
     @Bean
     open fun tiltakspengerApi(
         onBehalfOfTokenClient: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): TiltakspengerService {
         val oboTokenProvider = onBehalfOfTokenClient.bindTo(scope)
 
@@ -40,7 +40,7 @@ open class TiltakspengerConfig {
                                 )
                             },
                         ).addInterceptor(
-                            LoggingInterceptor(unleashService, "TiltaksPenger", tjenestekallLogger) { request ->
+                            tjenestekallLoggingInterceptorFactory("TiltaksPenger") { request ->
                                 requireNotNull(request.header("nav-call-id")) {
                                     "Kall uten \"nav-call-id\" er ikke lov"
                                 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/utbetaling/UtbetalingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/utbetaling/UtbetalingConfig.kt
@@ -4,10 +4,14 @@ import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import no.nav.modiapersonoversikt.api.domain.utbetaling.generated.apis.UtbetaldataV2Api
-import no.nav.modiapersonoversikt.infrastructure.http.*
+import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -20,29 +24,29 @@ open class UtbetalingConfig {
     open fun utbetalingV2Api(
         tokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ) = UtbetaldataV2Api(
         basePath = basePath,
         httpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(
                     HeadersInterceptor {
                         mapOf(
                             "nav-call-id" to getCallId(),
                         )
                     },
-                )
-                .addInterceptor(
-                    LoggingInterceptor(unleashService, "UtbetaldataV2") { request ->
+                ).addInterceptor(
+                    LoggingInterceptor(unleashService, "UtbetaldataV2", tjenestekallLogger) { request ->
                         requireNotNull(request.header("nav-call-id")) {
                             "Kall uten \"nav-call-id\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         tokenClient.createMachineToMachineToken(scope)
                     },
-                )
-                .build(),
+                ).build(),
     )
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/utbetaling/UtbetalingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/utbetaling/UtbetalingConfig.kt
@@ -4,14 +4,12 @@ import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import no.nav.modiapersonoversikt.api.domain.utbetaling.generated.apis.UtbetaldataV2Api
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -23,8 +21,7 @@ open class UtbetalingConfig {
     @Bean
     open fun utbetalingV2Api(
         tokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ) = UtbetaldataV2Api(
         basePath = basePath,
         httpClient =
@@ -38,7 +35,7 @@ open class UtbetalingConfig {
                         )
                     },
                 ).addInterceptor(
-                    LoggingInterceptor(unleashService, "UtbetaldataV2", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("UtbetaldataV2") { request ->
                         requireNotNull(request.header("nav-call-id")) {
                             "Kall uten \"nav-call-id\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
@@ -3,17 +3,15 @@ package no.nav.modiapersonoversikt.consumer.veilarboppfolging
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.infrastructure.ping.ConsumerPingable
 import no.nav.modiapersonoversikt.infrastructure.ping.Pingable
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,8 +26,7 @@ open class ArbeidsrettetOppfolgingConfig {
     open fun oppfolgingsApi(
         ansattService: AnsattService,
         onBehalfOfTokenClient: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): ArbeidsrettetOppfolging.Service {
         val httpClient =
             RestClient
@@ -37,7 +34,7 @@ open class ArbeidsrettetOppfolgingConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Oppfolging", tjenestekallLogger) {
+                    tjenestekallLoggingInterceptorFactory("Oppfolging") {
                         requireNotNull(it.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
@@ -13,6 +13,7 @@ import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,6 +29,7 @@ open class ArbeidsrettetOppfolgingConfig {
         ansattService: AnsattService,
         onBehalfOfTokenClient: OnBehalfOfTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): ArbeidsrettetOppfolging.Service {
         val httpClient =
             RestClient
@@ -35,7 +37,7 @@ open class ArbeidsrettetOppfolgingConfig {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Oppfolging") {
+                    LoggingInterceptor(unleashService, "Oppfolging", tjenestekallLogger) {
                         requireNotNull(it.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -43,10 +43,10 @@ object OkHttpUtils {
 }
 
 class LoggingInterceptor(
-    val unleashService: UnleashService,
-    val name: String,
+    private val unleashService: UnleashService,
     private val tjenestekallLogger: TjenestekallLogger,
-    val callIdExtractor: (Request) -> String,
+    private val name: String,
+    private val callIdExtractor: (Request) -> String,
 ) : Interceptor {
     private val log = LoggerFactory.getLogger(LoggingInterceptor::class.java)
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -12,9 +12,10 @@ import no.nav.common.log.MDCConstants
 import no.nav.common.utils.IdUtils
 import no.nav.modiapersonoversikt.service.unleash.Feature
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
-import no.nav.personoversikt.common.logging.TjenestekallLogg
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
+import no.nav.personoversikt.common.logging.TjenestekallLogger
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
 import okio.Buffer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -39,22 +40,18 @@ object OkHttpUtils {
                         .withCreatorVisibility(Visibility.NONE),
                 )
             }
-
-    object MediaTypes {
-        val JSON: MediaType = requireNotNull("application/json; charset=utf-8".toMediaType())
-    }
 }
 
 class LoggingInterceptor(
     val unleashService: UnleashService,
     val name: String,
+    private val tjenestekallLogger: TjenestekallLogger,
     val callIdExtractor: (Request) -> String,
 ) : Interceptor {
     private val log = LoggerFactory.getLogger(LoggingInterceptor::class.java)
 
-    private fun Request.peekContent(): String? {
-        val logRequestBodyEnabled = unleashService.isEnabled(Feature.LOG_REQUEST_BODY)
-        if (!logRequestBodyEnabled) return "IGNORED"
+    private fun Request.peekContent(): String {
+        if (!unleashService.isEnabled(Feature.LOG_REQUEST_BODY)) return "IGNORED"
         val copy = this.newBuilder().build()
         val buffer = Buffer()
         copy.body?.writeTo(buffer)
@@ -62,9 +59,8 @@ class LoggingInterceptor(
         return buffer.readUtf8()
     }
 
-    private fun Response.peekContent(): String? {
-        val logResponseBodyEnabled = unleashService.isEnabled(Feature.LOG_RESPONSE_BODY)
-        if (!logResponseBodyEnabled) return "IGNORED"
+    private fun Response.peekContent(): String {
+        if (!unleashService.isEnabled(Feature.LOG_RESPONSE_BODY)) return "IGNORED"
         return when {
             this.header("Content-Length") == "0" -> "Content-Length: 0, didn't try to peek at body"
             this.code == 204 -> "StatusCode: 204, didn't try to peek at body"
@@ -78,7 +74,7 @@ class LoggingInterceptor(
         val requestId = IdUtils.generateId()
         val requestBody = request.peekContent()
 
-        TjenestekallLogg.info(
+        tjenestekallLogger.info(
             "$name-request: $callId ($requestId)",
             mapOf(
                 "url" to request.url.toString(),
@@ -92,7 +88,7 @@ class LoggingInterceptor(
             runCatching { chain.proceed(request) }
                 .onFailure { exception ->
                     log.error("$name-response-error (ID: $callId / $requestId)", exception)
-                    TjenestekallLogg.error(
+                    tjenestekallLogger.error(
                         header = "$name-response-error: $callId ($requestId))",
                         fields =
                             mapOf(
@@ -105,13 +101,12 @@ class LoggingInterceptor(
                             ),
                         throwable = exception,
                     )
-                }
-                .getOrThrow()
+                }.getOrThrow()
 
         val responseBody = response.peekContent()
 
         if (response.code in 200..299) {
-            TjenestekallLogg.info(
+            tjenestekallLogger.info(
                 header = "$name-response: $callId ($requestId)",
                 fields =
                     mapOf(
@@ -125,7 +120,7 @@ class LoggingInterceptor(
                     ),
             )
         } else {
-            TjenestekallLogg.error(
+            tjenestekallLogger.error(
                 header = "$name-response-error: $callId ($requestId)",
                 fields =
                     mapOf(
@@ -143,12 +138,15 @@ class LoggingInterceptor(
     }
 }
 
-private inline fun Long.measure(): Long = System.currentTimeMillis() - this
+private fun Long.measure(): Long = System.currentTimeMillis() - this
 
-open class HeadersInterceptor(val headersProvider: () -> Map<String, String>) : Interceptor {
+open class HeadersInterceptor(
+    val headersProvider: () -> Map<String, String>,
+) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val builder =
-            chain.request()
+            chain
+                .request()
                 .newBuilder()
         headersProvider()
             .forEach { (name, value) -> builder.addHeader(name, value) }
@@ -157,12 +155,15 @@ open class HeadersInterceptor(val headersProvider: () -> Map<String, String>) : 
     }
 }
 
-class XCorrelationIdInterceptor : HeadersInterceptor({
-    mapOf("X-Correlation-ID" to getCallId())
-})
+class XCorrelationIdInterceptor :
+    HeadersInterceptor({
+        mapOf("X-Correlation-ID" to getCallId())
+    })
 
-class AuthorizationInterceptor(val tokenProvider: () -> String) : HeadersInterceptor({
-    mapOf("Authorization" to "Bearer ${tokenProvider()}")
-})
+class AuthorizationInterceptor(
+    tokenProvider: () -> String,
+) : HeadersInterceptor({
+        mapOf("Authorization" to "Bearer ${tokenProvider()}")
+    })
 
 fun getCallId(): String = MDC.get(MDCConstants.MDC_CALL_ID) ?: UUID.randomUUID().toString()

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/internal/InternalController.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.pdl.generated.SokPerson
 import no.nav.modiapersonoversikt.consumer.pdl.generated.inputs.Criterion
 import no.nav.modiapersonoversikt.consumer.pdl.generated.inputs.Paging
@@ -16,14 +17,12 @@ import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.RestConstants
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersBuilder
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingGraphqlClient
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.naudit.Audit
 import no.nav.modiapersonoversikt.infrastructure.naudit.AuditResources
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.rest.Typeanalyzers
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagServiceConfig
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
 import no.nav.modiapersonoversikt.utils.exchangeOnBehalfOfToken
@@ -51,7 +50,7 @@ class InternalController
         private val machineToMachineTokenClient: MachineToMachineTokenClient,
         private val onBehalfOfTokenClient: OnBehalfOfTokenClient,
         private val tilgangskontroll: Tilgangskontroll,
-        private val unleashService: UnleashService,
+        private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         private val tjenestekallLogger: TjenestekallLogger,
     ) {
         private val pdlApiUrl: URL = EnvironmentUtils.getRequiredProperty("PDL_API_URL").let(::URL)
@@ -134,7 +133,7 @@ class InternalController
                         config {
                         }
                         addInterceptor(
-                            LoggingInterceptor(unleashService, "PDL", tjenestekallLogger) { request ->
+                            tjenestekallLoggingInterceptorFactory("PDL") { request ->
                                 requireNotNull(request.header("X-Correlation-ID")) {
                                     "Kall uten \"X-Correlation-ID\" er ikke lov"
                                 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataConfig.kt
@@ -9,6 +9,7 @@ import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.modiapersonoversikt.service.kontonummer.KontonummerService
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
 import no.nav.personoversikt.common.kabac.Kabac
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -25,8 +26,9 @@ open class PersondataConfig {
         policyEnforcementPoint: Kabac.PolicyEnforcementPoint,
         kodeverk: EnhetligKodeverk.Service,
         pdlFullmakt: PdlFullmaktApi,
-    ): PersondataService {
-        return PersondataServiceImpl(
+        tjenestekallLogger: TjenestekallLogger,
+    ): PersondataService =
+        PersondataServiceImpl(
             pdl,
             pdlFullmakt,
             krrService,
@@ -36,6 +38,6 @@ open class PersondataConfig {
             oppfolgingConfig,
             policyEnforcementPoint,
             kodeverk,
+            tjenestekallLogger,
         )
-    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADServiceConfig.kt
@@ -8,6 +8,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.bindTo
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,15 +20,17 @@ open class AzureADServiceConfig {
     open fun azureADService(
         oboflowTokenProvider: OnBehalfOfTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): AzureADService {
         val httpClient =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "AzureAd") {
+                    LoggingInterceptor(unleashService, "AzureAd", tjenestekallLogger) {
                         getCallId()
                     },
-                )
-                .build()
+                ).build()
 
         return AzureADServiceImpl(
             tokenClient = oboflowTokenProvider.bindTo(EnvironmentUtils.getRequiredProperty("MS_GRAPH_SCOPE")),

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/azure/AzureADServiceConfig.kt
@@ -1,14 +1,12 @@
 package no.nav.modiapersonoversikt.service.azure
 
-import io.ktor.http.*
+import io.ktor.http.Url
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,15 +17,14 @@ open class AzureADServiceConfig {
     @Bean
     open fun azureADService(
         oboflowTokenProvider: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): AzureADService {
         val httpClient =
             RestClient
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "AzureAd", tjenestekallLogger) {
+                    tjenestekallLoggingInterceptorFactory("AzureAd") {
                         getCallId()
                     },
                 ).build()

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkConfig.kt
@@ -1,12 +1,11 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk
 
 import no.nav.common.token_client.client.MachineToMachineTokenClient
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.*
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.felleskodeverk.FellesKodeverk
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.sfhenvendelse.SfHenvendelseKodeverk
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -15,28 +14,24 @@ open class EnhetligKodeverkConfig {
     @Bean
     open fun enhetligKodeverk(
         machineToMachineTokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): EnhetligKodeverk.Service =
         EnhetligKodeverkServiceImpl(
             KodeverkProviders(
                 fellesKodeverk =
                     FellesKodeverk.Provider(
                         machineToMachineTokenClient,
-                        unleashService,
-                        tjenestekallLogger,
+                        tjenestekallLoggingInterceptorFactory,
                     ),
                 sfHenvendelseKodeverk =
                     SfHenvendelseKodeverk.Provider(
                         machineToMachineTokenClient,
-                        unleashService,
-                        tjenestekallLogger,
+                        tjenestekallLoggingInterceptorFactory,
                     ),
                 oppgaveKodeverk =
                     OppgaveKodeverk.Provider(
                         machineToMachineTokenClient,
-                        unleashService,
-                        tjenestekallLogger,
+                        tjenestekallLoggingInterceptorFactory,
                     ),
             ),
         )

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkConfig.kt
@@ -6,6 +6,7 @@ import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.fel
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.sfhenvendelse.SfHenvendelseKodeverk
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -15,13 +16,28 @@ open class EnhetligKodeverkConfig {
     open fun enhetligKodeverk(
         machineToMachineTokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
-    ): EnhetligKodeverk.Service {
-        return EnhetligKodeverkServiceImpl(
+        tjenestekallLogger: TjenestekallLogger,
+    ): EnhetligKodeverk.Service =
+        EnhetligKodeverkServiceImpl(
             KodeverkProviders(
-                fellesKodeverk = FellesKodeverk.Provider(machineToMachineTokenClient, unleashService),
-                sfHenvendelseKodeverk = SfHenvendelseKodeverk.Provider(machineToMachineTokenClient, unleashService),
-                oppgaveKodeverk = OppgaveKodeverk.Provider(machineToMachineTokenClient, unleashService),
+                fellesKodeverk =
+                    FellesKodeverk.Provider(
+                        machineToMachineTokenClient,
+                        unleashService,
+                        tjenestekallLogger,
+                    ),
+                sfHenvendelseKodeverk =
+                    SfHenvendelseKodeverk.Provider(
+                        machineToMachineTokenClient,
+                        unleashService,
+                        tjenestekallLogger,
+                    ),
+                oppgaveKodeverk =
+                    OppgaveKodeverk.Provider(
+                        machineToMachineTokenClient,
+                        unleashService,
+                        tjenestekallLogger,
+                    ),
             ),
         )
-    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/felleskodeverk/FellesKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/felleskodeverk/FellesKodeverk.kt
@@ -4,30 +4,26 @@ import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.utils.EnvironmentUtils
 import no.nav.modiapersonoversikt.config.AppConstants
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.kodeverk.generated.apis.KodeverkApi
 import no.nav.modiapersonoversikt.consumer.kodeverk.generated.models.GetKodeverkKoderBetydningerResponseDTO
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
 object FellesKodeverk {
     class Provider(
         private val machineToMachineTokenClient: MachineToMachineTokenClient,
-        private val unleashService: UnleashService,
-        private val tjenestekallLogger: TjenestekallLogger,
+        private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         private val fellesKodeverk: KodeverkApi =
             createKodeverkApi(
                 machineToMachineTokenClient,
-                unleashService,
-                tjenestekallLogger,
+                tjenestekallLoggingInterceptorFactory,
             ),
     ) : EnhetligKodeverk.KodeverkProvider<String, String> {
         override fun hentKodeverk(kodeverkNavn: String): EnhetligKodeverk.Kodeverk<String, String> {
@@ -56,8 +52,7 @@ object FellesKodeverk {
 
     internal fun createKodeverkApi(
         machineToMachineTokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): KodeverkApi {
         val url = EnvironmentUtils.getRequiredProperty("FELLES_KODEVERK_URL")
         val downstreamApi = DownstreamApi.parse(EnvironmentUtils.getRequiredProperty("FELLES_KODEVERK_SCOPE"))
@@ -68,7 +63,7 @@ object FellesKodeverk {
                 .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Felleskodeverk", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Felleskodeverk") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveKodeverk.kt
@@ -15,6 +15,7 @@ import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
 import no.nav.modiapersonoversikt.service.oppgavebehandling.OppgaveApiFactory
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.createMachineToMachineToken
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
@@ -22,7 +23,13 @@ object OppgaveKodeverk {
     class Provider(
         private val machineToMachineTokenClient: MachineToMachineTokenClient,
         private val unleashService: UnleashService,
-        val oppgaveKodeverk: KodeverkApi = createKodeverkApi(machineToMachineTokenClient, unleashService),
+        private val tjenestekallLogger: TjenestekallLogger,
+        val oppgaveKodeverk: KodeverkApi =
+            createKodeverkApi(
+                machineToMachineTokenClient,
+                unleashService,
+                tjenestekallLogger,
+            ),
     ) : EnhetligKodeverk.KodeverkProvider<String, Tema> {
         override fun hentKodeverk(kodeverkNavn: String): EnhetligKodeverk.Kodeverk<String, Tema> {
             val respons =
@@ -68,73 +75,78 @@ object OppgaveKodeverk {
     fun createKodeverkApi(
         machineToMachineTokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
+        tjenestekallLogger: TjenestekallLogger,
     ): KodeverkApi {
         val client =
-            RestClient.baseClient().newBuilder()
+            RestClient
+                .baseClient()
+                .newBuilder()
                 .addInterceptor(XCorrelationIdInterceptor())
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "OppgaveKodeverk") { request ->
+                    LoggingInterceptor(unleashService, "OppgaveKodeverk", tjenestekallLogger) { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
                     },
-                )
-                .addInterceptor(
+                ).addInterceptor(
                     AuthorizationInterceptor {
                         machineToMachineTokenClient.createMachineToMachineToken(OppgaveApiFactory.downstreamApi)
                     },
-                )
-                .build()
+                ).build()
 
         return KodeverkApi(OppgaveApiFactory.url, client)
     }
 
-    internal fun parseTilKodeverk(respons: List<KodeverkkombinasjonDTO>): Map<String, Tema> {
-        return respons.filter { !OppgaveOverstyring.underkjenteTemaer.contains(it.tema.tema) }.map {
-            Tema(
-                kode = it.tema.tema,
-                tekst = it.tema.term,
-                oppgavetyper = hentOppgavetyper(it.oppgavetyper, it.tema.tema),
-                prioriteter = hentPrioriteter(it),
-                underkategorier = hentUnderkategorier(it.gjelderverdier),
-            )
-        }.sortedBy { it.tekst }.associateBy { it.kode }
-    }
+    internal fun parseTilKodeverk(respons: List<KodeverkkombinasjonDTO>): Map<String, Tema> =
+        respons
+            .filter { !OppgaveOverstyring.underkjenteTemaer.contains(it.tema.tema) }
+            .map {
+                Tema(
+                    kode = it.tema.tema,
+                    tekst = it.tema.term,
+                    oppgavetyper = hentOppgavetyper(it.oppgavetyper, it.tema.tema),
+                    prioriteter = hentPrioriteter(it),
+                    underkategorier = hentUnderkategorier(it.gjelderverdier),
+                )
+            }.sortedBy { it.tekst }
+            .associateBy { it.kode }
 
-    private fun hentPrioriteter(oppgaveKodeverk: KodeverkkombinasjonDTO): List<Prioritet> {
-        return OppgaveOverstyring.overstyrtKodeverk.tema[oppgaveKodeverk.tema.tema]?.prioriteter
+    private fun hentPrioriteter(oppgaveKodeverk: KodeverkkombinasjonDTO): List<Prioritet> =
+        OppgaveOverstyring.overstyrtKodeverk.tema[oppgaveKodeverk.tema.tema]?.prioriteter
             ?: OppgaveOverstyring.overstyrtKodeverk.prioriteter
-    }
 
-    private fun hentUnderkategorier(gjelderverdier: List<GjelderDTO>?): List<Underkategori> {
-        return gjelderverdier?.map { gjelder ->
-            Underkategori(
-                kode = listOf(gjelder.behandlingstema, gjelder.behandlingstype).joinToString(":") { it ?: "" },
-                tekst = listOfNotNull(gjelder.behandlingstemaTerm, gjelder.behandlingstypeTerm).joinToString(" - "),
-                erGyldig = true,
-            )
-        }?.sortedBy { it.tekst }
+    private fun hentUnderkategorier(gjelderverdier: List<GjelderDTO>?): List<Underkategori> =
+        gjelderverdier
+            ?.map { gjelder ->
+                Underkategori(
+                    kode = listOf(gjelder.behandlingstema, gjelder.behandlingstype).joinToString(":") { it ?: "" },
+                    tekst = listOfNotNull(gjelder.behandlingstemaTerm, gjelder.behandlingstypeTerm).joinToString(" - "),
+                    erGyldig = true,
+                )
+            }?.sortedBy { it.tekst }
             ?: emptyList()
-    }
 
     private fun hentOppgavetyper(
         oppgavetyper: List<OppgavetypeDTO>,
         tema: String,
-    ): List<Oppgavetype> {
-        return oppgavetyper.filter { OppgaveOverstyring.godkjenteOppgavetyper.contains(it.oppgavetype) }.map {
-            Oppgavetype(
-                kode = it.oppgavetype,
-                tekst = it.term,
-                dagerFrist = hentFrist(tema, it.oppgavetype),
-            )
-        }.sortedBy { it.tekst }
-    }
+    ): List<Oppgavetype> =
+        oppgavetyper
+            .filter { OppgaveOverstyring.godkjenteOppgavetyper.contains(it.oppgavetype) }
+            .map {
+                Oppgavetype(
+                    kode = it.oppgavetype,
+                    tekst = it.term,
+                    dagerFrist = hentFrist(tema, it.oppgavetype),
+                )
+            }.sortedBy { it.tekst }
 
     private fun hentFrist(
         tema: String,
         oppgavetype: String,
-    ): Int {
-        return OppgaveOverstyring.overstyrtKodeverk.tema[tema]?.oppgavetyper?.get(oppgavetype)?.frist
+    ): Int =
+        OppgaveOverstyring.overstyrtKodeverk.tema[tema]
+            ?.oppgavetyper
+            ?.get(oppgavetype)
+            ?.frist
             ?: OppgaveOverstyring.overstyrtKodeverk.frist
-    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveApiFactory.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveApiFactory.kt
@@ -2,12 +2,10 @@ package no.nav.modiapersonoversikt.service.oppgavebehandling
 
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.apis.OppgaveApi
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 
 object OppgaveApiFactory {
     val url: String = EnvironmentUtils.getRequiredProperty("OPPGAVE_BASEURL")
@@ -15,15 +13,14 @@ object OppgaveApiFactory {
 
     fun createClient(
         tokenProvider: () -> String,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): OppgaveApi {
         val client =
             RestClient
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "Oppgave", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Oppgave") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveBehandlingServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveBehandlingServiceConfig.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.bindTo
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -20,14 +21,15 @@ open class OppgaveBehandlingServiceConfig {
         oboTokenClient: OnBehalfOfTokenClient,
         machineToMachineTokenClient: MachineToMachineTokenClient,
         unleashService: UnleashService,
-    ): OppgaveBehandlingService {
-        return RestOppgaveBehandlingServiceImpl(
+        tjenestekallLogger: TjenestekallLogger,
+    ): OppgaveBehandlingService =
+        RestOppgaveBehandlingServiceImpl(
             pdlOppslagService = pdlOppslagService,
             ansattService = ansattService,
             tilgangskontroll = tilgangskontroll,
             oboTokenClient = oboTokenClient.bindTo(OppgaveApiFactory.downstreamApi),
             unleashService = unleashService,
             machineToMachineTokenClient = machineToMachineTokenClient.bindTo(OppgaveApiFactory.downstreamApi),
+            tjenestekallLogger = tjenestekallLogger,
         )
-    }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveBehandlingServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OppgaveBehandlingServiceConfig.kt
@@ -2,12 +2,11 @@ package no.nav.modiapersonoversikt.service.oppgavebehandling
 
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -20,16 +19,14 @@ open class OppgaveBehandlingServiceConfig {
         tilgangskontroll: Tilgangskontroll,
         oboTokenClient: OnBehalfOfTokenClient,
         machineToMachineTokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): OppgaveBehandlingService =
         RestOppgaveBehandlingServiceImpl(
             pdlOppslagService = pdlOppslagService,
             ansattService = ansattService,
             tilgangskontroll = tilgangskontroll,
             oboTokenClient = oboTokenClient.bindTo(OppgaveApiFactory.downstreamApi),
-            unleashService = unleashService,
             machineToMachineTokenClient = machineToMachineTokenClient.bindTo(OppgaveApiFactory.downstreamApi),
-            tjenestekallLogger = tjenestekallLogger,
+            tjenestekallLoggingInterceptorFactory = tjenestekallLoggingInterceptorFactory,
         )
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -5,6 +5,7 @@ import no.nav.common.types.identer.NavIdent
 import no.nav.modiapersonoversikt.commondomain.Behandling
 import no.nav.modiapersonoversikt.commondomain.Temagruppe
 import no.nav.modiapersonoversikt.commondomain.parseV2BehandlingString
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.apis.OppgaveApi
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.GetOppgaverResponseJsonDTO
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.OppgaveJsonDTO
@@ -22,13 +23,11 @@ import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.defaultEnhetGi
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.leggTilBeskrivelse
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.paginering
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedMachineToMachineTokenClient
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import no.nav.modiapersonoversikt.utils.SafeListAggregate
 import no.nav.personoversikt.common.kabac.Decision
 import no.nav.personoversikt.common.logging.Logging
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import java.time.Clock
@@ -42,16 +41,15 @@ class RestOppgaveBehandlingServiceImpl(
     private val tilgangskontroll: Tilgangskontroll,
     private val oboTokenClient: BoundedOnBehalfOfTokenClient,
     private val machineToMachineTokenClient: BoundedMachineToMachineTokenClient,
-    private val unleashService: UnleashService,
-    private val tjenestekallLogger: TjenestekallLogger,
+    private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     private val apiClient: OppgaveApi =
         OppgaveApiFactory.createClient({
             AuthContextUtils.requireBoundedClientOboToken(oboTokenClient)
-        }, unleashService, tjenestekallLogger),
+        }, tjenestekallLoggingInterceptorFactory),
     private val systemApiClient: OppgaveApi =
         OppgaveApiFactory.createClient({
             machineToMachineTokenClient.createMachineToMachineToken()
-        }, unleashService, tjenestekallLogger),
+        }, tjenestekallLoggingInterceptorFactory),
     private val clock: Clock = Clock.systemDefaultZone(),
 ) : OppgaveBehandlingService {
     private val tjenestekallLogg = Logging.secureLog

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/pdl/PdlOppslagServiceConfig.kt
@@ -5,9 +5,8 @@ import io.ktor.client.engine.okhttp.OkHttp
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingGraphqlClient
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
 import no.nav.personoversikt.common.logging.TjenestekallLogger
@@ -25,7 +24,7 @@ open class PdlOppslagServiceConfig {
     open fun pdlOppslagService(
         machineToMachineTokenClient: MachineToMachineTokenClient,
         oboTokenClient: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         tjenestekallLogger: TjenestekallLogger,
     ): PdlOppslagService {
         val gqlHttpClient =
@@ -34,7 +33,7 @@ open class PdlOppslagServiceConfig {
                     config {
                     }
                     addInterceptor(
-                        LoggingInterceptor(unleashService, "PDL", tjenestekallLogger) { request ->
+                        tjenestekallLoggingInterceptorFactory("PDL") { request ->
                             requireNotNull(request.header("X-Correlation-ID")) {
                                 "Kall uten \"X-Correlation-ID\" er ikke lov"
                             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/saf/SafConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/saf/SafConfig.kt
@@ -5,12 +5,11 @@ import io.ktor.client.engine.okhttp.OkHttp
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.LoggingGraphqlClient
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
@@ -27,8 +26,8 @@ open class SafConfig {
 
     @Bean
     open fun safService(
-        unleashService: UnleashService,
         oboTokenClient: OnBehalfOfTokenClient,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
         tjenestekallLogger: TjenestekallLogger,
     ): SafService {
         val client: OkHttpClient =
@@ -40,7 +39,7 @@ open class SafConfig {
                         this.httpHeaders(oboTokenClient.bindTo(downstreamapi))
                     },
                 ).addInterceptor(
-                    LoggingInterceptor(unleashService, "Saf", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("Saf") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }
@@ -53,7 +52,7 @@ open class SafConfig {
                     config {
                     }
                     addInterceptor(
-                        LoggingInterceptor(unleashService, "saf-gql", tjenestekallLogger) { request ->
+                        tjenestekallLoggingInterceptorFactory("saf-gql") { request ->
                             requireNotNull(request.header("X-Correlation-ID")) {
                                 "Kall uten \"X-Correlation-ID\" er ikke lov"
                             }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseConfig.kt
@@ -3,16 +3,14 @@ package no.nav.modiapersonoversikt.service.sfhenvendelse
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.norg.NorgApi
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.ping.ConsumerPingable
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
 import no.nav.modiapersonoversikt.service.sfhenvendelse.SfHenvendelseApiFactory.asTokenProvider
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import kotlin.time.Duration.Companion.seconds
@@ -27,8 +25,7 @@ open class SfHenvendelseConfig {
         ansattService: AnsattService,
         oboTokenClient: OnBehalfOfTokenClient,
         machineToMachineTokenClient: MachineToMachineTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): SfHenvendelseService {
         val oboTokenClient = oboTokenClient.bindTo(SfHenvendelseApiFactory.downstreamApi())
         val httpClient =
@@ -36,7 +33,7 @@ open class SfHenvendelseConfig {
                 .baseClient()
                 .newBuilder()
                 .addInterceptor(
-                    LoggingInterceptor(unleashService, "SF-Henvendelse", tjenestekallLogger) { request ->
+                    tjenestekallLoggingInterceptorFactory("SF-Henvendelse") { request ->
                         requireNotNull(request.header("X-Correlation-ID")) {
                             "Kall uten \"X-Correlation-ID\" er ikke lov"
                         }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusConfig.kt
@@ -3,17 +3,15 @@ package no.nav.modiapersonoversikt.service.soknadsstatus
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.apis.SoknadsstatusControllerApi
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.getCallId
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import okhttp3.OkHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,16 +26,14 @@ open class SoknadsstatusConfig {
     @Bean
     open fun soknadsstatusService(
         tokenClient: OnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
-    ) = SoknadsstatusServiceImpl(tokenClient.bindTo(downstreamApi), unleashService, tjenestekallLogger)
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
+    ) = SoknadsstatusServiceImpl(tokenClient.bindTo(downstreamApi), tjenestekallLoggingInterceptorFactory)
 }
 
 object SoknadsstatusApiFactory {
     private fun createClient(
         tokenProvider: () -> String,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     ): OkHttpClient =
         RestClient
             .baseClient()
@@ -49,7 +45,7 @@ object SoknadsstatusApiFactory {
                     )
                 },
             ).addInterceptor(
-                LoggingInterceptor(unleashService, "ModiaSoknadsstatusV1", tjenestekallLogger) { request ->
+                tjenestekallLoggingInterceptorFactory("ModiaSoknadsstatusV1") { request ->
                     requireNotNull(request.header("nav-call-id")) {
                         "Kall uten \"nav-call-id\" er ikke lov"
                     }
@@ -63,9 +59,11 @@ object SoknadsstatusApiFactory {
 
     fun createSoknadsstatusApi(
         oboClient: BoundedOnBehalfOfTokenClient,
-        unleashService: UnleashService,
-        tjenestekallLogger: TjenestekallLogger,
-    ) = SoknadsstatusControllerApi(url, createClient(oboClient.asTokenProvider(), unleashService, tjenestekallLogger))
+        tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
+    ) = SoknadsstatusControllerApi(
+        url,
+        createClient(oboClient.asTokenProvider(), tjenestekallLoggingInterceptorFactory),
+    )
 
     private fun BoundedOnBehalfOfTokenClient.asTokenProvider(): () -> String =
         {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusService.kt
@@ -8,6 +8,7 @@ import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.model
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.models.Hendelse
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
 
@@ -30,21 +31,19 @@ interface SoknadsstatusService {
 open class SoknadsstatusServiceImpl(
     private val oboTokenClient: BoundedOnBehalfOfTokenClient,
     private val unleashService: UnleashService,
+    private val tjenestekallLogger: TjenestekallLogger,
     private val soknadsstatusApi: SoknadsstatusControllerApi =
         SoknadsstatusApiFactory.createSoknadsstatusApi(
             oboTokenClient,
             unleashService,
+            tjenestekallLogger,
         ),
 ) : SoknadsstatusService {
     @Cacheable
-    override fun hentHendelser(ident: String): List<Hendelse> {
-        return soknadsstatusApi.hentAlleHendelser(FnrRequest(ident)).orEmpty()
-    }
+    override fun hentHendelser(ident: String): List<Hendelse> = soknadsstatusApi.hentAlleHendelser(FnrRequest(ident)).orEmpty()
 
     @Cacheable
-    override fun hentBehandlinger(ident: String): List<Behandling> {
-        return soknadsstatusApi.hentAlleBehandlinger(FnrRequest(ident)).orEmpty()
-    }
+    override fun hentBehandlinger(ident: String): List<Behandling> = soknadsstatusApi.hentAlleBehandlinger(FnrRequest(ident)).orEmpty()
 
     @Cacheable
     override fun hentBehandlingerMedHendelser(ident: String): List<Behandling> {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusService.kt
@@ -2,13 +2,12 @@ package no.nav.modiapersonoversikt.service.soknadsstatus
 
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.apis.SoknadsstatusControllerApi
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.models.Behandling
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.models.FnrRequest
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.models.Hendelse
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
-import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
 
@@ -30,13 +29,11 @@ interface SoknadsstatusService {
 @CacheConfig(cacheNames = ["soknadsstatusCache"], keyGenerator = "userkeygenerator")
 open class SoknadsstatusServiceImpl(
     private val oboTokenClient: BoundedOnBehalfOfTokenClient,
-    private val unleashService: UnleashService,
-    private val tjenestekallLogger: TjenestekallLogger,
+    private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
     private val soknadsstatusApi: SoknadsstatusControllerApi =
         SoknadsstatusApiFactory.createSoknadsstatusApi(
             oboTokenClient,
-            unleashService,
-            tjenestekallLogger,
+            tjenestekallLoggingInterceptorFactory,
         ),
 ) : SoknadsstatusService {
     @Cacheable

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/unleash/Feature.kt
@@ -1,9 +1,12 @@
 package no.nav.modiapersonoversikt.service.unleash
 
-enum class Feature(val propertyKey: String) {
+enum class Feature(
+    val propertyKey: String,
+) {
     SAMPLE_FEATURE("feature.samplerfeature"),
     UTVIDET_UTBETALINGS_SPORRING("modiapersonoversikt.utvidet-utbetalings-sporring"),
     SKATTEETATEN_INNKREVING_API("modiapersonoversikt.skatteetaten-innkreving-api"),
     LOG_REQUEST_BODY("modiapersonoversikt.log-request-body"),
     LOG_RESPONSE_BODY("modiapersonoversikt.log-response-body"),
+    TJENESTEKALL_LOGGING("modiapersonoversikt.tjenestekall-logging"),
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceConfig.kt
@@ -1,6 +1,7 @@
 package no.nav.modiapersonoversikt.service.varsel
 
 import no.nav.modiapersonoversikt.consumer.brukernotifikasjon.Brukernotifikasjon
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -9,6 +10,8 @@ import org.springframework.context.annotation.Configuration
 @EnableCaching
 open class VarslerServiceConfig {
     @Bean
-    open fun varslerService(brukernotifikasjonService: Brukernotifikasjon.Service): VarslerService =
-        VarslerServiceImpl(brukernotifikasjonService)
+    open fun varslerService(
+        brukernotifikasjonService: Brukernotifikasjon.Service,
+        tjenestekallLogger: TjenestekallLogger,
+    ): VarslerService = VarslerServiceImpl(brukernotifikasjonService, tjenestekallLogger)
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceImpl.kt
@@ -2,31 +2,28 @@ package no.nav.modiapersonoversikt.service.varsel
 
 import no.nav.common.types.identer.Fnr
 import no.nav.modiapersonoversikt.consumer.brukernotifikasjon.Brukernotifikasjon
-import no.nav.personoversikt.common.logging.TjenestekallLogg
-import org.slf4j.LoggerFactory
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
 
 @CacheConfig(cacheNames = ["varslingCache"], keyGenerator = "userkeygenerator")
 open class VarslerServiceImpl(
     private val brukernotifikasjonService: Brukernotifikasjon.Service,
+    private val tjenestekallLogger: TjenestekallLogger,
 ) : VarslerService {
-    private val log = LoggerFactory.getLogger("VarslerService")
-
     @Cacheable
-    override fun hentAlleVarsler(fnr: Fnr): VarslerService.Result {
-        return try {
+    override fun hentAlleVarsler(fnr: Fnr): VarslerService.Result =
+        try {
             val varsler = brukernotifikasjonService.hentAlleBrukernotifikasjoner(fnr)
             VarslerService.Result(
                 feil = listOf(),
                 varsler = varsler,
             )
         } catch (e: Throwable) {
-            TjenestekallLogg.error("Feilet ved uthentig av varsler", fields = mapOf(), throwable = e)
+            tjenestekallLogger.error("Feilet ved uthentig av varsler", fields = mapOf(), throwable = e)
             VarslerService.Result(
                 feil = listOf("Feil ved uthenting av notifikasjoner"),
                 varsler = listOf(),
             )
         }
-    }
 }

--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="no/nav/common/log/logback-default.xml"/>
+    <include resource="no/nav/common/log/logback-stdout-json.xml"/>
+    <include resource="no/nav/common/log/logback-naudit.xml"/>
+    <include resource="no/nav/common/log/logback-securelogs.xml"/>
+    <include resource="no/nav/common/log/logback-cxf.xml"/>
 </configuration>

--- a/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
@@ -19,6 +19,7 @@ import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.Innkrevingskra
 import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.Krav
 import no.nav.modiapersonoversikt.service.unleash.Feature
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +37,7 @@ class SkatteetatenInnkrevingHttpClientTest {
     private val maskinportenClient = mockk<MaskinportenClient>()
     private val unleashService = mockk<UnleashService>()
 
-    private val httpClient = skatteetatenInnkrevingConfig.httpClient(maskinportenClient, unleashService)
+    private val httpClient = skatteetatenInnkrevingConfig.httpClient(maskinportenClient, unleashService, TjenestekallLogg)
     private val apiClient = skatteetatenInnkrevingConfig.apiClient(wm.baseUrl(), httpClient)
     private val kravdetaljerApi = skatteetatenInnkrevingConfig.kravdetaljerApi(apiClient)
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
@@ -12,6 +12,8 @@ import io.mockk.mockk
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
+import no.nav.modiapersonoversikt.infrastructure.http.LoggingInterceptor
 import no.nav.modiapersonoversikt.infrastructure.http.maskinporten.MaskinportenClient
 import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.Grunnlag
 import no.nav.modiapersonoversikt.service.skatteetaten.innkreving.Innkrevingskrav
@@ -36,8 +38,13 @@ class SkatteetatenInnkrevingHttpClientTest {
 
     private val maskinportenClient = mockk<MaskinportenClient>()
     private val unleashService = mockk<UnleashService>()
+    private val loggingInterceptor =
+        LoggingInterceptor(unleashService, "SkatteetatenInnkrevingHttpClient", TjenestekallLogg) { _ -> "" }
+    private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory =
+        { _, _ -> loggingInterceptor }
 
-    private val httpClient = skatteetatenInnkrevingConfig.httpClient(maskinportenClient, unleashService, TjenestekallLogg)
+    private val httpClient =
+        skatteetatenInnkrevingConfig.httpClient(maskinportenClient, tjenestekallLoggingInterceptorFactory)
     private val apiClient = skatteetatenInnkrevingConfig.apiClient(wm.baseUrl(), httpClient)
     private val kravdetaljerApi = skatteetatenInnkrevingConfig.kravdetaljerApi(apiClient)
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/consumer/skatteetaten/innkreving/SkatteetatenInnkrevingHttpClientTest.kt
@@ -39,7 +39,7 @@ class SkatteetatenInnkrevingHttpClientTest {
     private val maskinportenClient = mockk<MaskinportenClient>()
     private val unleashService = mockk<UnleashService>()
     private val loggingInterceptor =
-        LoggingInterceptor(unleashService, "SkatteetatenInnkrevingHttpClient", TjenestekallLogg) { _ -> "" }
+        LoggingInterceptor(unleashService, TjenestekallLogg, "SkatteetatenInnkrevingHttpClient") { _ -> "" }
     private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory =
         { _, _ -> loggingInterceptor }
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/AdresseMappingTest.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.consumer.pdl.generated.hentpersondata.Vegadres
 import no.nav.modiapersonoversikt.consumer.pdl.generated.henttredjepartspersondata.Person
 import no.nav.modiapersonoversikt.rest.persondata.PersondataResult.InformasjonElement
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,7 +19,7 @@ import no.nav.modiapersonoversikt.consumer.pdl.generated.henttredjepartspersonda
 
 internal class AdresseMappingTest {
     val kodeverk: EnhetligKodeverk.Service = mockk()
-    val mapper = PersondataFletter(kodeverk)
+    val mapper = PersondataFletter(kodeverk, TjenestekallLogg)
 
     @BeforeEach
     fun setup() {
@@ -36,20 +37,21 @@ internal class AdresseMappingTest {
         val hovedperson =
             testPerson.copy(
                 bostedsadresse =
-                    adresse.copy(
-                        vegadresse =
-                            Vegadresse(
-                                matrikkelId = 1234L,
-                                husnummer = "12",
-                                husbokstav = "A",
-                                bruksenhetsnummer = "H0101",
-                                adressenavn = "fin veg",
-                                kommunenummer = "1234",
-                                postnummer = "6789",
-                                bydelsnummer = null,
-                                tilleggsnavn = null,
-                            ),
-                    ).asList(),
+                    adresse
+                        .copy(
+                            vegadresse =
+                                Vegadresse(
+                                    matrikkelId = 1234L,
+                                    husnummer = "12",
+                                    husbokstav = "A",
+                                    bruksenhetsnummer = "H0101",
+                                    adressenavn = "fin veg",
+                                    kommunenummer = "1234",
+                                    postnummer = "6789",
+                                    bydelsnummer = null,
+                                    tilleggsnavn = null,
+                                ),
+                        ).asList(),
             )
         val tredjepartsPerson =
             gittTredjepartsperson().copy(
@@ -97,7 +99,10 @@ internal class AdresseMappingTest {
                 clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
             )
 
-        val harSammeAdresse = persondata.person.forelderBarnRelasjon.find { it.ident == barnFnr }?.harSammeAdresse
+        val harSammeAdresse =
+            persondata.person.forelderBarnRelasjon
+                .find { it.ident == barnFnr }
+                ?.harSammeAdresse
         Assertions.assertTrue(harSammeAdresse ?: false)
     }
 
@@ -106,16 +111,17 @@ internal class AdresseMappingTest {
         val person =
             testPerson.copy(
                 kontaktadresse =
-                    kontaktadresseData.copy(
-                        coAdressenavn = null,
-                        vegadresse = null,
-                        postboksadresse =
-                            Postboksadresse(
-                                postbokseier = "C/O Fornavn Etternavn",
-                                postboks = "123",
-                                postnummer = "9750",
-                            ),
-                    ).asList(),
+                    kontaktadresseData
+                        .copy(
+                            coAdressenavn = null,
+                            vegadresse = null,
+                            postboksadresse =
+                                Postboksadresse(
+                                    postbokseier = "C/O Fornavn Etternavn",
+                                    postboks = "123",
+                                    postnummer = "9750",
+                                ),
+                        ).asList(),
             )
 
         val persondata =
@@ -139,20 +145,21 @@ internal class AdresseMappingTest {
         val hovedperson =
             testPerson.copy(
                 bostedsadresse =
-                    adresse.copy(
-                        vegadresse =
-                            Vegadresse(
-                                matrikkelId = 1234L,
-                                husnummer = "   12",
-                                husbokstav = "A    ",
-                                bruksenhetsnummer = "  H0101",
-                                adressenavn = "fin veg",
-                                kommunenummer = "1234",
-                                postnummer = "6789",
-                                bydelsnummer = null,
-                                tilleggsnavn = null,
-                            ),
-                    ).asList(),
+                    adresse
+                        .copy(
+                            vegadresse =
+                                Vegadresse(
+                                    matrikkelId = 1234L,
+                                    husnummer = "   12",
+                                    husbokstav = "A    ",
+                                    bruksenhetsnummer = "  H0101",
+                                    adressenavn = "fin veg",
+                                    kommunenummer = "1234",
+                                    postnummer = "6789",
+                                    bydelsnummer = null,
+                                    tilleggsnavn = null,
+                                ),
+                        ).asList(),
             )
         val tredjepartsPerson =
             gittTredjepartsperson().copy(
@@ -200,7 +207,10 @@ internal class AdresseMappingTest {
                 clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
             )
 
-        val harSammeAdresse = persondata.person.forelderBarnRelasjon.find { it.ident == barnFnr }?.harSammeAdresse
+        val harSammeAdresse =
+            persondata.person.forelderBarnRelasjon
+                .find { it.ident == barnFnr }
+                ?.harSammeAdresse
         Assertions.assertTrue(harSammeAdresse ?: false)
     }
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.modiapersonoversikt.consumer.pdl.generated.hentpersondata.Doedsfall
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.EnhetligKodeverk
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import no.nav.personoversikt.common.test.snapshot.SnapshotExtension
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,7 +19,7 @@ internal class PersondataFletterTest {
     val snapshot = SnapshotExtension()
 
     val kodeverk: EnhetligKodeverk.Service = mockk()
-    val mapper = PersondataFletter(kodeverk)
+    val mapper = PersondataFletter(kodeverk, TjenestekallLogg)
     val fnr = "12345678910"
 
     @BeforeEach
@@ -60,42 +61,44 @@ internal class PersondataFletterTest {
     @Test
     internal fun `skal filtrere ut egenAnsatt fra feiledeSystemer når veileder ikke har tilgang`() {
         snapshot.assertMatches(
-            mapper.flettSammenData(
-                data =
-                    testData.copy(
-                        personIdent = fnr,
-                        persondata = testPerson,
-                        krrData = PersondataResult.Failure(PersondataResult.InformasjonElement.DKIF, Throwable()),
-                        erEgenAnsatt =
-                            PersondataResult.Failure(
-                                PersondataResult.InformasjonElement.EGEN_ANSATT,
-                                Throwable(),
-                            ),
-                        harTilgangTilSkjermetPerson = false,
-                    ),
-                clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
-            ).feilendeSystemer,
+            mapper
+                .flettSammenData(
+                    data =
+                        testData.copy(
+                            personIdent = fnr,
+                            persondata = testPerson,
+                            krrData = PersondataResult.Failure(PersondataResult.InformasjonElement.DKIF, Throwable()),
+                            erEgenAnsatt =
+                                PersondataResult.Failure(
+                                    PersondataResult.InformasjonElement.EGEN_ANSATT,
+                                    Throwable(),
+                                ),
+                            harTilgangTilSkjermetPerson = false,
+                        ),
+                    clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
+                ).feilendeSystemer,
         )
     }
 
     @Test
     internal fun `skal ikke filtrere ut egenAnsatt fra feiledeSystemer når veileder har tilgang`() {
         snapshot.assertMatches(
-            mapper.flettSammenData(
-                data =
-                    testData.copy(
-                        personIdent = fnr,
-                        persondata = testPerson,
-                        krrData = PersondataResult.Failure(PersondataResult.InformasjonElement.DKIF, Throwable()),
-                        erEgenAnsatt =
-                            PersondataResult.Failure(
-                                PersondataResult.InformasjonElement.EGEN_ANSATT,
-                                Throwable(),
-                            ),
-                        harTilgangTilSkjermetPerson = true,
-                    ),
-                clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
-            ).feilendeSystemer,
+            mapper
+                .flettSammenData(
+                    data =
+                        testData.copy(
+                            personIdent = fnr,
+                            persondata = testPerson,
+                            krrData = PersondataResult.Failure(PersondataResult.InformasjonElement.DKIF, Throwable()),
+                            erEgenAnsatt =
+                                PersondataResult.Failure(
+                                    PersondataResult.InformasjonElement.EGEN_ANSATT,
+                                    Throwable(),
+                                ),
+                            harTilgangTilSkjermetPerson = true,
+                        ),
+                    clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
+                ).feilendeSystemer,
         )
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataServiceImplTest.kt
@@ -5,8 +5,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.common.types.identer.EnhetId
 import no.nav.modiapersonoversikt.consumer.norg.NorgApi
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.junit.Test
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertTrue
 
 internal class PersondataServiceImplTest {
     private val ugyldigGT = "0301"
@@ -24,6 +25,7 @@ internal class PersondataServiceImplTest {
             policyEnforcementPoint = mockk(),
             kodeverk = mockk(),
             pdlFullmakt = mockk(),
+            tjenestekallLogger = TjenestekallLogg,
         )
 
     @Test

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
@@ -11,6 +11,7 @@ import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.Kod
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.MutableClock
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.*
@@ -141,7 +142,8 @@ internal class EnhetligKodeverkServiceImplTest {
         val oppgaveApi: KodeverkApi = mockk()
         val unleashService: UnleashService = mockk()
         val machineToMachineTokenClient: MachineToMachineTokenClient = mockk()
-        val provider = OppgaveKodeverk.Provider(machineToMachineTokenClient, unleashService, oppgaveApi)
+        val provider =
+            OppgaveKodeverk.Provider(machineToMachineTokenClient, unleashService, TjenestekallLogg, oppgaveApi)
         every { provider.oppgaveKodeverk.hentInterntKodeverk(any()) } returns
             listOf(
                 KodeverkkombinasjonDTO(

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/EnhetligKodeverkServiceImplTest.kt
@@ -9,9 +9,7 @@ import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.OppgavetypeD
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.TemaDTO
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.KodeverkProviders
 import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.MutableClock
-import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.*
@@ -140,10 +138,9 @@ internal class EnhetligKodeverkServiceImplTest {
     @Test
     internal fun `skal overstyre oppgavekodeverk på frister og prioriteter`() {
         val oppgaveApi: KodeverkApi = mockk()
-        val unleashService: UnleashService = mockk()
         val machineToMachineTokenClient: MachineToMachineTokenClient = mockk()
         val provider =
-            OppgaveKodeverk.Provider(machineToMachineTokenClient, unleashService, TjenestekallLogg, oppgaveApi)
+            OppgaveKodeverk.Provider(machineToMachineTokenClient, mockk(), oppgaveApi)
         every { provider.oppgaveKodeverk.hentInterntKodeverk(any()) } returns
             listOf(
                 KodeverkkombinasjonDTO(

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/krr/KrrServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/krr/KrrServiceImplTest.kt
@@ -1,10 +1,11 @@
 package no.nav.modiapersonoversikt.service.krr
 
-import KrrServiceImpl
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import no.nav.modiapersonoversikt.consumer.krr.KrrServiceImpl
 import no.nav.modiapersonoversikt.utils.WireMockUtils.get
 import no.nav.modiapersonoversikt.utils.WireMockUtils.json
 import no.nav.modiapersonoversikt.utils.WireMockUtils.status
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -45,7 +46,7 @@ internal class KrrServiceImplTest {
             status(200)
             json(jsonResponse)
         }
-        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient)
+        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient, TjenestekallLogg)
         val response = krrDirRestService.hentDigitalKontaktinformasjon("10108000398")
         assertThat(response.personident).isEqualTo("10108000398")
         assertThat(response.epostadresse?.value).isEqualTo("noreply@nav.no")
@@ -55,7 +56,7 @@ internal class KrrServiceImplTest {
     @Test
     fun `trigg feil ved henting av kontaktinformasjon fra KrrRestApi`() {
         wiremock.get { status(404) }
-        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient)
+        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient, TjenestekallLogg)
 
         val response = krrDirRestService.hentDigitalKontaktinformasjon("10108000123")
         assertThat(response.personident).isNull()
@@ -67,7 +68,7 @@ internal class KrrServiceImplTest {
     @Test
     fun `trigg server-feil ved henting av kontaktinformasjon fra KrrRestApi`() {
         wiremock.get { status(500) }
-        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient)
+        val krrDirRestService = KrrServiceImpl("http://localhost:${wiremock.port}", httpClient, TjenestekallLogg)
         val response = krrDirRestService.hentDigitalKontaktinformasjon("10108000123")
         assertThat(response.personident).isNull()
         assertThat(response.reservasjon).isEqualTo("")

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -17,6 +17,7 @@ import no.nav.modiapersonoversikt.testutils.AuthContextTestUtils
 import no.nav.modiapersonoversikt.utils.BoundedMachineToMachineTokenClient
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import no.nav.personoversikt.common.kabac.Decision
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.*
@@ -46,6 +47,7 @@ class RestOppgaveBehandlingServiceImplTest {
             oboTokenClient,
             machineToMachineTokenClient,
             unleashService,
+            TjenestekallLogg,
             apiClient,
             systemApiClient,
             fixedClock,
@@ -767,19 +769,16 @@ class RestOppgaveBehandlingServiceImplTest {
     private fun <T> withIdent(
         ident: String,
         fn: () -> T,
-    ): T {
-        return AuthContextTestUtils.withIdent(ident, fn)
-    }
+    ): T = AuthContextTestUtils.withIdent(ident, fn)
 
     private fun OppgaveJsonDTO.nybeskrivelse(
         ident: NavIdent,
         navn: String,
         enhet: String,
         tekst: String,
-    ): String {
-        return Utils.leggTilBeskrivelse(
+    ): String =
+        Utils.leggTilBeskrivelse(
             this.beskrivelse,
             Utils.beskrivelseInnslag(ident, navn, enhet, tekst, fixedClock),
         )
-    }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -4,6 +4,7 @@ import io.mockk.*
 import no.nav.common.types.identer.NavIdent
 import no.nav.modiapersonoversikt.commondomain.Temagruppe
 import no.nav.modiapersonoversikt.commondomain.Veileder
+import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.apis.OppgaveApi
 import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.*
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
@@ -17,7 +18,6 @@ import no.nav.modiapersonoversikt.testutils.AuthContextTestUtils
 import no.nav.modiapersonoversikt.utils.BoundedMachineToMachineTokenClient
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import no.nav.personoversikt.common.kabac.Decision
-import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.*
@@ -38,6 +38,7 @@ class RestOppgaveBehandlingServiceImplTest {
     private val oboTokenClient: BoundedOnBehalfOfTokenClient = mockk()
     private val machineToMachineTokenClient: BoundedMachineToMachineTokenClient = mockk()
     private val fixedClock = Clock.fixed(Instant.parse("2021-01-25T10:15:30Z"), ZoneId.systemDefault())
+    private val tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory = mockk()
 
     private val oppgaveBehandlingService =
         RestOppgaveBehandlingServiceImpl(
@@ -46,8 +47,7 @@ class RestOppgaveBehandlingServiceImplTest {
             tilgangskontroll,
             oboTokenClient,
             machineToMachineTokenClient,
-            unleashService,
-            TjenestekallLogg,
+            tjenestekallLoggingInterceptorFactory,
             apiClient,
             systemApiClient,
             fixedClock,

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusServiceTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusServiceTest.kt
@@ -5,17 +5,14 @@ import io.mockk.mockk
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.apis.SoknadsstatusControllerApi
 import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.models.Behandling
 import no.nav.modiapersonoversikt.service.soknadsstatus.BehandlingMockUtils.createBehandling
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
-import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class SoknadsstatusServiceTest {
     private val soknadsstatusApi = mockk<SoknadsstatusControllerApi>()
     private val oboTokenClient: BoundedOnBehalfOfTokenClient = mockk()
-    private val unleashService: UnleashService = mockk()
-    private val service = SoknadsstatusServiceImpl(oboTokenClient, unleashService, TjenestekallLogg, soknadsstatusApi)
+    private val service = SoknadsstatusServiceImpl(oboTokenClient, mockk(), soknadsstatusApi)
 
     @Test
     fun `tre behandlinger skal gi liste med tre elementer`() {

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusServiceTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/soknadsstatus/SoknadsstatusServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.modiapersonoversikt.consumer.modiaSoknadsstatusApi.generated.model
 import no.nav.modiapersonoversikt.service.soknadsstatus.BehandlingMockUtils.createBehandling
 import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -14,14 +15,18 @@ class SoknadsstatusServiceTest {
     private val soknadsstatusApi = mockk<SoknadsstatusControllerApi>()
     private val oboTokenClient: BoundedOnBehalfOfTokenClient = mockk()
     private val unleashService: UnleashService = mockk()
-    private val service = SoknadsstatusServiceImpl(oboTokenClient, unleashService, soknadsstatusApi)
+    private val service = SoknadsstatusServiceImpl(oboTokenClient, unleashService, TjenestekallLogg, soknadsstatusApi)
 
     @Test
     fun `tre behandlinger skal gi liste med tre elementer`() {
         val behandlinger =
             listOf(
                 createBehandling(),
-                createBehandling().copy(behandlingId = "beha", sakstema = "123456", status = Behandling.Status.UNDER_BEHANDLING),
+                createBehandling().copy(
+                    behandlingId = "beha",
+                    sakstema = "123456",
+                    status = Behandling.Status.UNDER_BEHANDLING,
+                ),
                 createBehandling().copy(behandlingId = "hsfe", sakstema = "4321"),
             )
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/varsel/VarslerServiceImplTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import jakarta.xml.soap.SOAPFault
 import no.nav.common.types.identer.Fnr
 import no.nav.modiapersonoversikt.consumer.brukernotifikasjon.Brukernotifikasjon
+import no.nav.personoversikt.common.logging.TjenestekallLogg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -17,7 +18,7 @@ class VarslerServiceImplTest {
     private val brukernotifikasjonService = mockk<Brukernotifikasjon.Service>()
     private val soapfault = mockk<SOAPFault>()
     private val varselService: VarslerService =
-        VarslerServiceImpl(brukernotifikasjonService)
+        VarslerServiceImpl(brukernotifikasjonService, TjenestekallLogg)
 
     @Test
     internal fun `skal rapportere om feil i system`() {


### PR DESCRIPTION
Tilgjengeligjør en implementasjon av TjenestekallLogger som bønne i appen. Denne loggeren ser på Unleash-flagget `modiapersonoversikt.tjenestekall-logging`. Når flagget er satt slippes alle loggnivåer gjennom. Når flagget ikke er satt så slippes ikke loggnivået INFO gjennom. Regner med mesteparten av støyen kommer fra INFO-logging.

Lager også en TjenestekallLoggingInterceptorFactory bønne så vi slipper å ta inn Unleash og TjenestekallLoggeren så mange steder der vi lager Http-klienter.

Venter litt med å redusere ressursbruk i prod til vi kan se litt mer tydelig den faktiske bruken uten alle disse zombiepoddene.