### PR TITLE
Legg til cacheConfig for fullmakt & endre defaults

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/cache/CacheConfig.kt
@@ -1,6 +1,7 @@
 package no.nav.modiapersonoversikt.infrastructure.cache
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.CaffeineSpec
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.caffeine.CaffeineCacheManager
@@ -17,6 +18,15 @@ open class CacheConfig {
     @Bean
     open fun cacheManager(): CacheManager =
         CaffeineCacheManager().apply {
+            this.setCaffeineSpec(
+                CaffeineSpec.parse(
+                    """
+                    expireAfterWrite=60m,
+                    maximumSize=10000
+                    """.trimIndent(),
+                ),
+            )
+
             cache("endpointCache", 3, 10000)
             cache("pleiePengerCache", 300)
             cache("oppfolgingsinfoCache", 300)
@@ -25,6 +35,7 @@ open class CacheConfig {
             cache("sykePengerCache", 300)
             cache("utbetalingCache", 1800, 10000)
             cache("pdlCache", 3600, 100000)
+            cache("pdlFullmaktCache", 3600, 10000)
             cache("azureAdCache", 3600, 20000)
             cache("varslingCache", 180, 10000)
         }


### PR DESCRIPTION
Vi har ikke noe default spec når det gjelder caches som ikke er
konfigurert eksplisitt. Har lagt til en default på 1t og maks str. 10000
entries.
Helst vil man sikre at hver enkelt cache er konfigurert best mulig, men
det er greit i det tilfelle at det blir glemt at defaulten i alle fall
er nogenlunde meningsfull.
