### PR TITLE
Fikse naming konflikt for Enhet

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/enhet/EnhetController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/enhet/EnhetController.kt
@@ -17,6 +17,7 @@ import no.nav.modiapersonoversikt.service.arbeidsfordeling.ArbeidsfordelingServi
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 
+@Deprecated("Bruk v2")
 @RestController
 @RequestMapping("/rest/enheter")
 class EnhetController

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/Persondata.kt
@@ -22,7 +22,7 @@ object Persondata {
         val bostedAdresse: List<Adresse>,
         val kontaktAdresse: List<Adresse>,
         val oppholdsAdresse: List<Adresse>,
-        val navEnhet: Enhet?,
+        val navEnhet: PersonDataEnhet?,
         val statsborgerskap: List<Statsborgerskap>,
         val adressebeskyttelse: List<KodeBeskrivelse<AdresseBeskyttelse>>,
         val sikkerhetstiltak: List<Sikkerhetstiltak>,
@@ -162,7 +162,7 @@ object Persondata {
         val apningstider: List<Apningstid>,
     )
 
-    data class Enhet(
+    data class PersonDataEnhet(
         val id: String,
         val navn: String,
         val publikumsmottak: List<Publikumsmottak>,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletter.kt
@@ -550,13 +550,13 @@ class PersondataFletter(
         gyldighetsPeriode = gyldighetsPeriode,
     )
 
-    private fun hentNavEnhet(navEnhet: PersondataResult<NorgDomain.EnhetKontaktinformasjon?>): Persondata.Enhet? =
+    private fun hentNavEnhet(navEnhet: PersondataResult<NorgDomain.EnhetKontaktinformasjon?>): Persondata.PersonDataEnhet? =
         navEnhet
             .map {
                 if (it == null) {
                     null
                 } else {
-                    Persondata.Enhet(it.enhet.enhetId, it.enhet.enhetNavn, hentPublikumsmottak(it.publikumsmottak))
+                    Persondata.PersonDataEnhet(it.enhet.enhetId, it.enhet.enhetNavn, hentPublikumsmottak(it.publikumsmottak))
                 }
             }.getOrNull()
 

--- a/web/src/test/java/no/nav/modiapersonoversikt/LocalBeans.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/LocalBeans.kt
@@ -7,6 +7,8 @@ import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.modiapersonoversikt.consumer.kontoregister.generated.apis.KontoregisterV1Api
 import no.nav.modiapersonoversikt.consumer.norg.NorgApi
+import no.nav.modiapersonoversikt.consumer.tiltakspenger.TiltakspengerService
+import no.nav.modiapersonoversikt.consumer.veilarboppfolging.VeilarbvedtaksstotteService
 import org.springframework.context.support.beans
 
 val localBeans =
@@ -22,5 +24,7 @@ val localBeans =
                     every { isEnabled(any()) } returns true
                 }
             }
+            bean<VeilarbvedtaksstotteService>(isPrimary = true) { mockk() }
+            bean<TiltakspengerService>(isPrimary = true) { mockk() }
         }
     }

--- a/web/src/test/java/no/nav/modiapersonoversikt/MainTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/MainTest.kt
@@ -2,7 +2,6 @@ package no.nav.modiapersonoversikt
 
 import no.nav.common.nais.NaisYamlUtils
 import no.nav.common.rest.client.RestClient
-import no.nav.common.test.SystemProperties
 import no.nav.common.test.ssl.SSLTestUtils
 import no.nav.common.test.ssl.TrustAllSSLSocketFactory
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -16,8 +15,7 @@ object MainTest {
         System.setProperty("NAIS_CLUSTER_NAME", "dev-gcp")
         System.setProperty("UNLEASH_SERVER_API_URL", "https://unleash-api.dev-gcp.nais.io/api")
         System.setProperty("UNLEASH_SERVER_API_TOKEN", "test")
-        SystemProperties.setFrom(".vault.properties")
-        NaisYamlUtils.loadFromYaml(".nais/dev.yml")
+        NaisYamlUtils.loadFromYaml("web/.nais/dev.yml")
         SSLTestUtils.disableCertificateChecks()
     }
 


### PR DESCRIPTION
Springdoc tar kun utgangspunkt i navn på klasser ved schema generation,
som gjør at klasser med samme navn, men forskjellig innhold bare blir
generert en gang. Renamer Enhet i persondata slik at det kun er ett sted
Enhet blir brukt.
