### PR TITLE
Småfikser i oppgave APIer

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogOppgaveController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/dialog/DialogOppgaveController.kt
@@ -126,7 +126,7 @@ class DialogOppgaveController
 data class OpprettOppgaveRequestDTO(
     val fnr: String,
     val opprettetavenhetsnummer: String,
-    val valgtEnhetId: Int,
+    val valgtEnhetId: String,
     val behandlingskjedeId: String,
     val dagerFrist: Int,
     val ansvarligEnhetId: String,
@@ -135,7 +135,7 @@ data class OpprettOppgaveRequestDTO(
     val temaKode: String,
     val underkategoriKode: String?,
     val oppgaveTypeKode: String,
-    val prioritetKode: String,
+    val prioritetKode: OppgaveKodeverk.Prioritet.PrioritetKode,
 )
 
 data class OpprettSkjermetOppgaveDTO(
@@ -145,7 +145,7 @@ data class OpprettSkjermetOppgaveDTO(
     val temaKode: String,
     val underkategoriKode: String?,
     val oppgaveTypeKode: String,
-    val prioritetKode: String,
+    val prioritetKode: OppgaveKodeverk.Prioritet.PrioritetKode,
 )
 
 data class OpprettOppgaveResponseDTO(

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/LokalOverstyring.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/LokalOverstyring.kt
@@ -2,7 +2,7 @@ package no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.op
 
 import kotlin.properties.Delegates
 
-private typealias Prioriteter = List<OppgaveKodeverk.Prioritet>
+private typealias Prioriteter = List<OppgaveKodeverk.Prioritet.PrioritetKode>
 private typealias Frist = Int
 
 object LokalOverstyring {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveKodeverk.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveKodeverk.kt
@@ -1,6 +1,6 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave
 
-import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
 import no.nav.common.rest.client.RestClient
 import no.nav.common.token_client.client.MachineToMachineTokenClient
 import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
@@ -52,14 +52,20 @@ object OppgaveKodeverk {
         val dagerFrist: Int,
     )
 
-    @JsonFormat(shape = JsonFormat.Shape.OBJECT)
-    enum class Prioritet(
-        val kode: String,
-        val tekst: String,
+    data class Prioritet(
+        val kode: PrioritetKode,
     ) {
-        HOY("HOY", "Høy"),
-        NORM("NORM", "Normal"),
-        LAV("LAV", "Lav"),
+        val tekst by lazy { kode.tekst }
+
+        @Schema(enumAsRef = true)
+        enum class PrioritetKode(
+            val kode: String,
+            val tekst: String,
+        ) {
+            HOY("HOY", "Høy"),
+            NORM("NORM", "Normal"),
+            LAV("LAV", "Lav"),
+        }
     }
 
     data class Underkategori(
@@ -107,8 +113,10 @@ object OppgaveKodeverk {
             .associateBy { it.kode }
 
     private fun hentPrioriteter(oppgaveKodeverk: KodeverkkombinasjonDTO): List<Prioritet> =
-        OppgaveOverstyring.overstyrtKodeverk.tema[oppgaveKodeverk.tema.tema]?.prioriteter
-            ?: OppgaveOverstyring.overstyrtKodeverk.prioriteter
+        OppgaveOverstyring.overstyrtKodeverk.tema[oppgaveKodeverk.tema.tema]
+            ?.prioriteter
+            ?.map { Prioritet(it) }
+            ?: OppgaveOverstyring.overstyrtKodeverk.prioriteter.map { Prioritet(it) }
 
     private fun hentUnderkategorier(gjelderverdier: List<GjelderDTO>?): List<Underkategori> =
         gjelderverdier

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveOverstyring.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/enhetligkodeverk/kodeverkproviders/oppgave/OppgaveOverstyring.kt
@@ -1,6 +1,6 @@
 package no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave
 
-import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk.Prioritet.*
+import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk.Prioritet.PrioritetKode.*
 
 object OppgaveOverstyring {
     private const val VURD_HENV = "VURD_HENV"

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OpprettOppgaveRest.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/OpprettOppgaveRest.kt
@@ -1,5 +1,6 @@
 package no.nav.modiapersonoversikt.service.oppgavebehandling
 
+import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import java.time.LocalDate
 
 data class OpprettOppgaveResponse(
@@ -14,7 +15,7 @@ data class OpprettOppgaveRequest(
     val tema: String,
     val oppgavetype: String,
     val behandlingstype: String,
-    val prioritet: String,
+    val prioritet: OppgaveKodeverk.Prioritet.PrioritetKode,
     val underkategoriKode: String?,
     val opprettetavenhetsnummer: String,
     val oppgaveFrist: LocalDate,
@@ -33,7 +34,7 @@ data class OpprettSkjermetOppgaveRequest(
     val tema: String,
     val oppgavetype: String,
     val behandlingstype: String,
-    val prioritet: String,
+    val prioritet: OppgaveKodeverk.Prioritet.PrioritetKode,
     val underkategoriKode: String?,
     val opprettetavenhetsnummer: String,
     val oppgaveFrist: LocalDate,

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImpl.kt
@@ -15,6 +15,7 @@ import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Policies
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
+import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import no.nav.modiapersonoversikt.service.oppgavebehandling.OppgaveBehandlingService.AlleredeTildeltAnnenSaksbehandler
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.OPPGAVE_MAX_LIMIT
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.SPORSMAL_OG_SVAR
@@ -86,7 +87,7 @@ class RestOppgaveBehandlingServiceImpl(
                         behandlingstype = behandling?.behandlingstype,
                         aktivDato = LocalDate.now(clock),
                         fristFerdigstillelse = request.oppgaveFrist,
-                        prioritet = PostOppgaveRequestJsonDTO.Prioritet.valueOf(stripTemakode(request.prioritet)),
+                        prioritet = request.prioritet.toPostOppgavePrioritet(),
                         metadata =
                             request.behandlingskjedeId
                                 .coerceBlankToNull()
@@ -131,7 +132,7 @@ class RestOppgaveBehandlingServiceImpl(
                         behandlingstype = behandling?.behandlingstype,
                         aktivDato = LocalDate.now(clock),
                         fristFerdigstillelse = request.oppgaveFrist,
-                        prioritet = PostOppgaveRequestJsonDTO.Prioritet.valueOf(stripTemakode(request.prioritet)),
+                        prioritet = request.prioritet.toPostOppgavePrioritet(),
                     ),
             ) ?: throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
@@ -430,7 +431,12 @@ class RestOppgaveBehandlingServiceImpl(
 
     private fun correlationId() = getCallId()
 
-    private fun stripTemakode(prioritet: String) = prioritet.substringBefore("_")
+    fun OppgaveKodeverk.Prioritet.PrioritetKode.toPostOppgavePrioritet() =
+        when (this) {
+            OppgaveKodeverk.Prioritet.PrioritetKode.HOY -> PostOppgaveRequestJsonDTO.Prioritet.HOY
+            OppgaveKodeverk.Prioritet.PrioritetKode.NORM -> PostOppgaveRequestJsonDTO.Prioritet.NORM
+            OppgaveKodeverk.Prioritet.PrioritetKode.LAV -> PostOppgaveRequestJsonDTO.Prioritet.LAV
+        }
 
     private fun String?.coerceBlankToNull() = if (this.isNullOrBlank()) null else this
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/oppgavebehandling/RestOppgaveBehandlingServiceImplTest.kt
@@ -10,6 +10,7 @@ import no.nav.modiapersonoversikt.consumer.oppgave.generated.models.*
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.Tilgangskontroll
 import no.nav.modiapersonoversikt.infrastructure.tilgangskontroll.TilgangskontrollMock
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
+import no.nav.modiapersonoversikt.service.enhetligkodeverk.kodeverkproviders.oppgave.OppgaveKodeverk
 import no.nav.modiapersonoversikt.service.oppgavebehandling.OppgaveBehandlingService.AlleredeTildeltAnnenSaksbehandler
 import no.nav.modiapersonoversikt.service.oppgavebehandling.Utils.SPORSMAL_OG_SVAR
 import no.nav.modiapersonoversikt.service.pdl.PdlOppslagService
@@ -103,7 +104,7 @@ class RestOppgaveBehandlingServiceImplTest {
                             tema = "KNA",
                             oppgavetype = "SPM_OG_SVR",
                             behandlingstype = "",
-                            prioritet = "NORM",
+                            prioritet = OppgaveKodeverk.Prioritet.PrioritetKode.NORM,
                             underkategoriKode = "",
                             opprettetavenhetsnummer = "4100",
                             oppgaveFrist = now(fixedClock),
@@ -157,7 +158,7 @@ class RestOppgaveBehandlingServiceImplTest {
                             tema = "KNA",
                             oppgavetype = "SPM_OG_SVR",
                             behandlingstype = "",
-                            prioritet = OppgaveJsonDTO.Prioritet.NORM.value,
+                            prioritet = OppgaveKodeverk.Prioritet.PrioritetKode.NORM,
                             underkategoriKode = "",
                             opprettetavenhetsnummer = "4100",
                             oppgaveFrist = now(fixedClock),


### PR DESCRIPTION
I opprett oppgave DTOer:
- valgtEnhetId som string. Den blir gjort om til string senere uansett.
- Prioritet som enum.

I kodeverk api for oppgaver:
- Bruke data class for DTO med enum som underliggende dataklasse. Det
  gjør at OpenAPI docs klarer å serialisere riktig (som et objekt med
  kode som en enum).
