### PR TITLE
Fjern team log marker filter på team log appender

### DIFF
--- a/proxy/src/main/resources/logback-stdout-fixed.xml
+++ b/proxy/src/main/resources/logback-stdout-fixed.xml
@@ -42,17 +42,6 @@
         </encoder>
     </appender>
 
-    <appender name="default-json" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>TEAM_LOGS</marker>
-            </evaluator>
-            <OnMatch>DENY</OnMatch>
-            <OnMismatch>ACCEPT</OnMismatch>
-        </filter>
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="team-logs" />
         <appender-ref ref="default-json" />

--- a/proxy/src/main/resources/logback-stdout-fixed.xml
+++ b/proxy/src/main/resources/logback-stdout-fixed.xml
@@ -54,8 +54,8 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="default-json" />
         <appender-ref ref="team-logs" />
+        <appender-ref ref="default-json" />
     </root>
 
     <logger name="TeamLog" level="INFO" additivity="false">

--- a/proxy/src/main/resources/logback-stdout-fixed.xml
+++ b/proxy/src/main/resources/logback-stdout-fixed.xml
@@ -40,13 +40,6 @@
             <customFields>{"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}</customFields>
             <includeContext>false</includeContext>
         </encoder>
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-                <marker>TEAM_LOGS</marker>
-            </evaluator>
-            <OnMatch>ACCEPT</OnMatch>
-            <OnMismatch>DENY</OnMismatch>
-        </filter>
     </appender>
 
     <appender name="default-json" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Viss eg tar rett no, så vil alle logger i proxyen gå til team log. Då er me sikre på at ingenting havnar i consolen,