### PR TITLE
Filtrer utbetalingsdato på alle datoer

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/utbetaling/UtbetalingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/utbetaling/UtbetalingServiceImpl.kt
@@ -55,18 +55,13 @@ open class UtbetalingServiceImpl(
         start: LocalDate,
         slutt: LocalDate,
     ) = { utbetaling: UtbetalingDTO ->
-        val dato =
+        val datoer =
             listOfNotNull(
                 utbetaling.posteringsdato,
                 utbetaling.forfallsdato,
                 utbetaling.utbetalingsdato,
-            ).firstOrNull()
-
-        if (dato == null) {
-            false
-        } else {
-            dato in start..slutt
-        }
+            )
+        datoer.any { it in start..slutt }
     }
 
     private fun mapTilDTO(utbetaling: RsUtbetaling): UtbetalingDomain.Utbetaling =


### PR DESCRIPTION
[Henvendelse](https://jira.adeo.no/browse/FAGSYSTEM-396398) fra veileder om at ikkje utbetalingen viste i "siste 30 dager", dette var fordi utbetaling var filtrert på posteringsdato og ikkje utbetalingsdato. No sjekker den om nokon av datoane finnast i datointervallet. 

