### PR TITLE
Paginert kall til sf henvendelser

### DIFF
--- a/tjenestespesifikasjoner/sf-henvendelse-api/pom.xml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/pom.xml
@@ -50,7 +50,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/navikt/crm-henvendelse/refs/heads/henvendelselist_pagination/Api/henvendelse_api.json</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/navikt/crm-henvendelse/refs/heads/main/Api/henvendelse_api.json</inputSpec>
                             <generatorName>kotlin</generatorName>
                             <library>jvm-okhttp4</library>
                             <packageName>no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated</packageName>

--- a/tjenestespesifikasjoner/sf-henvendelse-api/pom.xml
+++ b/tjenestespesifikasjoner/sf-henvendelse-api/pom.xml
@@ -50,7 +50,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/navikt/crm-henvendelse/refs/heads/main/Api/henvendelse_api.json</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/navikt/crm-henvendelse/refs/heads/henvendelselist_pagination/Api/henvendelse_api.json</inputSpec>
                             <generatorName>kotlin</generatorName>
                             <library>jvm-okhttp4</library>
                             <packageName>no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated</packageName>

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -127,13 +127,13 @@ class SfHenvendelseServiceImpl(
         val callId = getCallId()
 
         val allHenvendelser = mutableListOf<HenvendelseDTO>()
-        var currentPage = 0
+        var page = 1
         var hasNextPage = true
         val pageSize = 100
 
         while (hasNextPage) {
             val res =
-                henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(aktorId, callId, currentPage, pageSize)
+                henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(aktorId, callId, page, pageSize)
                     ?: throw ResponseStatusException(
                         HttpStatus.BAD_REQUEST,
                         "Feil ved henting av paginerte henvendelser",
@@ -141,7 +141,7 @@ class SfHenvendelseServiceImpl(
 
             allHenvendelser.addAll(res.data)
             hasNextPage = res.hasNextPage
-            currentPage++
+            page = res.currentPage + 1
         }
 
         return loggFeilSomErSpesialHandtert(bruker, allHenvendelser)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -1,6 +1,5 @@
 package no.nav.modiapersonoversikt.service.sfhenvendelse
 
-import no.nav.common.types.identer.EnhetId
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import no.nav.modiapersonoversikt.consumer.norg.NorgApi
 import no.nav.modiapersonoversikt.consumer.sfhenvendelse.generated.apis.*
@@ -121,30 +120,37 @@ class SfHenvendelseServiceImpl(
         bruker: EksternBruker,
         enhet: String,
     ): List<HenvendelseDTO> {
-        val enhetOgGTListe =
-            norgApi
-                .runCatching {
-                    hentGeografiskTilknyttning(EnhetId(enhet))
-                }.onFailure { logger.error("Kunne ikke hente geografisk tilknyttning", it) }
-                .getOrDefault(emptyList())
-                .mapNotNull { it.geografiskOmraade }
-                .plus(enhet)
         val tematilganger =
             ansattService.hentAnsattFagomrader(AuthContextUtils.requireIdent())
 
         val aktorId = bruker.aktorId()
         val callId = getCallId()
 
-        return henvendelseInfoApi
-            .henvendelseinfoHenvendelselisteGet(aktorId, callId)
-            ?.let { loggFeilSomErSpesialHandtert(bruker, it) }
-            ?.asSequence()
-            ?.map(kassertInnhold(OffsetDateTime.now()))
-            ?.map(journalfortTemaTilgang(tematilganger))
-            ?.map(::sorterMeldinger)
-            ?.map(::unikeJournalposter)
-            ?.toList()
-            .orEmpty()
+        val allHenvendelser = mutableListOf<HenvendelseDTO>()
+        var currentPage = 0
+        var hasNextPage = true
+        val pageSize = 100
+
+        while (hasNextPage) {
+            val res =
+                henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(aktorId, callId, currentPage, pageSize)
+                    ?: throw ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Feil ved henting av paginerte henvendelser",
+                    )
+
+            allHenvendelser.addAll(res.data)
+            hasNextPage = res.hasNextPage
+            currentPage++
+        }
+
+        return loggFeilSomErSpesialHandtert(bruker, allHenvendelser)
+            .asSequence()
+            .map(kassertInnhold(OffsetDateTime.now()))
+            .map(journalfortTemaTilgang(tematilganger))
+            .map(::sorterMeldinger)
+            .map(::unikeJournalposter)
+            .toList()
     }
 
     override fun hentHenvendelse(kjedeId: String): HenvendelseDTO {

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceImplTest.kt
@@ -67,10 +67,17 @@ internal class SfHenvendelseServiceImplTest {
                     geografiskOmraade = "005678",
                 ),
             )
-        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns
-            listOf(
-                dummyHenvendelse.medJournalpost("DAG"),
-                dummyHenvendelse.medJournalpost("SYK"),
+
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any(), any(), any()) } returns
+            PaginertHenvendelseListeDTO(
+                listOf(
+                    dummyHenvendelse.medJournalpost("DAG"),
+                    dummyHenvendelse.medJournalpost("SYK"),
+                ),
+                1,
+                10,
+                100,
+                false,
             )
 
         val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")
@@ -91,9 +98,13 @@ internal class SfHenvendelseServiceImplTest {
                     geografiskOmraade = "005678",
                 ),
             )
-        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns
-            listOf(
-                dummyHenvendelse.somKassert(),
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any(), any(), any()) } returns
+            PaginertHenvendelseListeDTO(
+                listOf(dummyHenvendelse.somKassert()),
+                1,
+                10,
+                100,
+                false,
             )
 
         val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")
@@ -111,11 +122,18 @@ internal class SfHenvendelseServiceImplTest {
                     geografiskOmraade = "005678",
                 ),
             )
-        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns
-            listOf(
-                dummyHenvendelse.medJournalpost("DAG"),
-                dummyHenvendelse.copy(meldinger = emptyList()),
-                dummyHenvendelse.medJournalpost("SYK"),
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any(), any(), any()) } returns
+            PaginertHenvendelseListeDTO(
+                data =
+                    listOf(
+                        dummyHenvendelse.medJournalpost("DAG"),
+                        dummyHenvendelse.copy(meldinger = emptyList()),
+                        dummyHenvendelse.medJournalpost("SYK"),
+                    ),
+                1,
+                10,
+                100,
+                false,
             )
 
         val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")
@@ -137,33 +155,39 @@ internal class SfHenvendelseServiceImplTest {
                     geografiskOmraade = "005678",
                 ),
             )
-        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any()) } returns
-            listOf(
-                dummyHenvendelse.copy(
-                    meldinger =
-                        listOf(
-                            MeldingDTO(
-                                meldingsId = UUID.randomUUID().toString(),
-                                fritekst = "Andre melding",
-                                sendtDato = OffsetDateTime.of(2021, 2, 2, 12, 37, 37, 0, ZoneOffset.UTC),
-                                fra =
-                                    MeldingFraDTO(
-                                        identType = MeldingFraDTO.IdentType.NAVIDENT,
-                                        ident = "Z123456",
-                                    ),
+        every { henvendelseInfoApi.henvendelseinfoHenvendelselisteGet(any(), any(), any(), any()) } returns
+            PaginertHenvendelseListeDTO(
+                listOf(
+                    dummyHenvendelse.copy(
+                        meldinger =
+                            listOf(
+                                MeldingDTO(
+                                    meldingsId = UUID.randomUUID().toString(),
+                                    fritekst = "Andre melding",
+                                    sendtDato = OffsetDateTime.of(2021, 2, 2, 12, 37, 37, 0, ZoneOffset.UTC),
+                                    fra =
+                                        MeldingFraDTO(
+                                            identType = MeldingFraDTO.IdentType.NAVIDENT,
+                                            ident = "Z123456",
+                                        ),
+                                ),
+                                MeldingDTO(
+                                    meldingsId = UUID.randomUUID().toString(),
+                                    fritekst = "Første melding",
+                                    sendtDato = OffsetDateTime.of(2021, 2, 1, 12, 37, 37, 0, ZoneOffset.UTC),
+                                    fra =
+                                        MeldingFraDTO(
+                                            identType = MeldingFraDTO.IdentType.NAVIDENT,
+                                            ident = "Z123456",
+                                        ),
+                                ),
                             ),
-                            MeldingDTO(
-                                meldingsId = UUID.randomUUID().toString(),
-                                fritekst = "Første melding",
-                                sendtDato = OffsetDateTime.of(2021, 2, 1, 12, 37, 37, 0, ZoneOffset.UTC),
-                                fra =
-                                    MeldingFraDTO(
-                                        identType = MeldingFraDTO.IdentType.NAVIDENT,
-                                        ident = "Z123456",
-                                    ),
-                            ),
-                        ),
+                    ),
                 ),
+                1,
+                10,
+                100,
+                false,
             )
 
         val henvendelser = sfHenvendelseServiceImpl.hentHenvendelser(EksternBruker.AktorId("00012345678910"), "0101")

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceIntegrationTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseServiceIntegrationTest.kt
@@ -48,7 +48,7 @@ internal class SfHenvendelseServiceIntegrationTest {
             AuthContextUtils.withContext(testSubject) {
                 val api = SfHenvendelseApiFactory.createHenvendelseInfoApi(httpClient)
                 val result = api.henvendelseinfoHenvendelselisteGet("aktorid", "coorId")
-                assertThat(result).hasSize(1)
+                assertThat(result?.data).hasSize(1)
             }
         }
     }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/mock-sf-meldinger.json
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/sfhenvendelse/mock-sf-meldinger.json
@@ -1,45 +1,51 @@
-[
-  {
-    "tilknyttetEnhet": null,
-    "opprinneligGT": "0101",
-    "opprinneligEnhet": null,
-    "opprettetDato": "2021-08-28T16:49:23.000+0200",
-    "meldinger": [
-      {
-        "meldingsId": "random1",
-        "sendtDato": "2021-08-28T16:49:23.000+0200",
-        "lestDato": null,
-        "kanal": "DIGITAL",
-        "henvendelseId": null,
-        "fritekst": "Vi skriver ett nytt spørsmål 28.08 16:48",
-        "fra": {
-          "navEnhet": null,
-          "identType": "NAVIDENT",
-          "ident": "Z990351"
+{
+  "data": [
+    {
+      "tilknyttetEnhet": null,
+      "opprinneligGT": "0101",
+      "opprinneligEnhet": null,
+      "opprettetDato": "2021-08-28T16:49:23.000+0200",
+      "meldinger": [
+        {
+          "meldingsId": "random1",
+          "sendtDato": "2021-08-28T16:49:23.000+0200",
+          "lestDato": null,
+          "kanal": "DIGITAL",
+          "henvendelseId": null,
+          "fritekst": "Vi skriver ett nytt spørsmål 28.08 16:48",
+          "fra": {
+            "navEnhet": null,
+            "identType": "NAVIDENT",
+            "ident": "Z990351"
+          }
         }
-      }
-    ],
-    "markeringer": null,
-    "kjedeId": "ABBA1001",
-    "kasseringsDato": "2046-08-28T16:49:23.000+02:00",
-    "journalposter": [
-      {
-        "journalpostId": "510849595",
-        "journalfortTema": "PEN",
-        "journalfortDato": "2021-08-28T14:49:23.000+0000",
-        "journalforerNavIdent": "Z990351",
-        "journalforendeEnhet": "0239",
-        "fagsaksystem": null,
-        "fagsakId": null
-      }
-    ],
-    "henvendelseType": "MELDINGSKJEDE",
-    "henvendelseId": "70009278",
-    "gjeldendeTemagruppe": "PENS",
-    "gjeldendeTema": "PEN",
-    "fnr": "10108000398",
-    "feilsendt": null,
-    "avsluttetDato": null,
-    "aktorId": "1000096233942"
-  }
-]
+      ],
+      "markeringer": null,
+      "kjedeId": "ABBA1001",
+      "kasseringsDato": "2046-08-28T16:49:23.000+02:00",
+      "journalposter": [
+        {
+          "journalpostId": "510849595",
+          "journalfortTema": "PEN",
+          "journalfortDato": "2021-08-28T14:49:23.000+0000",
+          "journalforerNavIdent": "Z990351",
+          "journalforendeEnhet": "0239",
+          "fagsaksystem": null,
+          "fagsakId": null
+        }
+      ],
+      "henvendelseType": "MELDINGSKJEDE",
+      "henvendelseId": "70009278",
+      "gjeldendeTemagruppe": "PENS",
+      "gjeldendeTema": "PEN",
+      "fnr": "10108000398",
+      "feilsendt": null,
+      "avsluttetDato": null,
+      "aktorId": "1000096233942"
+    }
+  ],
+  "currentPage": 1,
+  "totalPages": 1,
+  "pageSize": 10,
+  "hasNextPage": false
+}


### PR DESCRIPTION
Sidan me ikkje kan sende søk og filtrering til sf APIet så må me hente alle pages og deretter returnere det fulle resultatet. Me har caching i frontend, så det vil kun bli litt ventetid ved initiellt kall på ein person. 
Har testa md Aremark i dev som har 14 pages (x100), og det tok litt under fem sekunder å hente. Ein vanleg brukar har nok ikkje meir enn 1 page (100 henvendelsar).