### PR TITLE
Tar i mot tags fra spokelse-api og filtrerer ut perioder fra Infotrygd

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/spokelse/SpokelseClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/spokelse/SpokelseClient.kt
@@ -66,7 +66,12 @@ open class SpokelseClientImpl(
         val perioder = objectMapper.readValue(body, Utbetalingsperioder::class.java)
 
         return Utbetalingsperioder(
-            utbetaltePerioder = perioder.utbetaltePerioder.sortedByDescending { it.fom },
+            utbetaltePerioder =
+                perioder.utbetaltePerioder
+                    // Infotrygd-perioder filtreres ut fordi de allerede hentes fra Infotrygd direkte via
+                    // /rest/ytelse/sykepenger.
+                    .filter { "Infotrygd" !in it.tags }
+                    .sortedByDescending { it.fom },
         )
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/spokelse/SpokelseClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/spokelse/SpokelseClient.kt
@@ -21,6 +21,7 @@ data class Utbetalingsperiode(
     val fom: LocalDate,
     val tom: LocalDate,
     val grad: Double,
+    val tags: Set<String> = emptySet(),
 )
 
 interface SpokelseClient {

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/ytelse/YtelseController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/ytelse/YtelseController.kt
@@ -50,7 +50,13 @@ class YtelseController
         ): SykepengerResponse =
             tilgangskontroll
                 .check(Policies.tilgangTilBruker(Fnr(fnrRequest.fnr)))
-                .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Sykepenger, AuditIdentifier.FNR to fnrRequest.fnr)) {
+                .get(
+                    Audit.describe(
+                        Audit.Action.READ,
+                        AuditResources.Person.Sykepenger,
+                        AuditIdentifier.FNR to fnrRequest.fnr,
+                    ),
+                ) {
                     arenaInfotrygdApi.hentSykepenger(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
                 }
 
@@ -60,8 +66,15 @@ class YtelseController
         ): Utbetalingsperioder =
             tilgangskontroll
                 .check(Policies.tilgangTilBruker(Fnr(fnrRequest.fnr)))
-                .get(Audit.describe(Audit.Action.READ, AuditResources.Person.SpokelseSykepenger, AuditIdentifier.FNR to fnrRequest.fnr)) {
-                    spokelseClient.hentUtbetalingsperiode(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
+                .get(
+                    Audit.describe(
+                        Audit.Action.READ,
+                        AuditResources.Person.SpokelseSykepenger,
+                        AuditIdentifier.FNR to fnrRequest.fnr,
+                    ),
+                ) {
+                    val perioder = spokelseClient.hentUtbetalingsperiode(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
+                    perioder.copy(utbetaltePerioder = perioder.utbetaltePerioder.filter { "Infotrygd" !in it.tags })
                 }
 
         @PostMapping("foreldrepenger")
@@ -70,7 +83,13 @@ class YtelseController
         ): ForeldrepengerResponse =
             tilgangskontroll
                 .check(Policies.tilgangTilBruker(Fnr(fnrRequest.fnr)))
-                .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Foreldrepenger, AuditIdentifier.FNR to fnrRequest.fnr)) {
+                .get(
+                    Audit.describe(
+                        Audit.Action.READ,
+                        AuditResources.Person.Foreldrepenger,
+                        AuditIdentifier.FNR to fnrRequest.fnr,
+                    ),
+                ) {
                     arenaInfotrygdApi.hentForeldrepenger(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
                 }
 
@@ -80,7 +99,13 @@ class YtelseController
         ): PleiepengerResponse =
             tilgangskontroll
                 .check(Policies.tilgangTilBruker(Fnr(fnrRequest.fnr)))
-                .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Pleiepenger, AuditIdentifier.FNR to fnrRequest.fnr)) {
+                .get(
+                    Audit.describe(
+                        Audit.Action.READ,
+                        AuditResources.Person.Pleiepenger,
+                        AuditIdentifier.FNR to fnrRequest.fnr,
+                    ),
+                ) {
                     arenaInfotrygdApi.hentPleiepenger(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
                 }
 
@@ -90,7 +115,13 @@ class YtelseController
         ): List<VedtakDTO> =
             tilgangskontroll
                 .check(Policies.tilgangTilBruker(Fnr(fnrRequest.fnr)))
-                .get(Audit.describe(Audit.Action.READ, AuditResources.Person.Tiltakspenger, AuditIdentifier.FNR to fnrRequest.fnr)) {
+                .get(
+                    Audit.describe(
+                        Audit.Action.READ,
+                        AuditResources.Person.Tiltakspenger,
+                        AuditIdentifier.FNR to fnrRequest.fnr,
+                    ),
+                ) {
                     tiltakspengerService.hentVedtakPerioder(Fnr(fnrRequest.fnr), fnrRequest.fom, fnrRequest.tom)
                 }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/ytelse/YtelseController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/ytelse/YtelseController.kt
@@ -73,8 +73,7 @@ class YtelseController
                         AuditIdentifier.FNR to fnrRequest.fnr,
                     ),
                 ) {
-                    val perioder = spokelseClient.hentUtbetalingsperiode(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
-                    perioder.copy(utbetaltePerioder = perioder.utbetaltePerioder.filter { "Infotrygd" !in it.tags })
+                    spokelseClient.hentUtbetalingsperiode(fnrRequest.fnr, fnrRequest.fom, fnrRequest.tom)
                 }
 
         @PostMapping("foreldrepenger")


### PR DESCRIPTION
Team Bømlo har endret på spokelse-api og gjør det nå mulig for oss å differensiere hvilke perioder som kommer fra Infotrygd/Speil. I denne PR-en gjøres følgende:

- "Tags" er blitt lagt til i datamodellen.
- Perioder som kommer fra Infotrygd filtreres vekk fra responsen i endepunktet "/spokelse_sykepenger"

Ved prodsettting må feature-flagget i prod skrus på.