### PR TITLE
Bruker personnavn istedenfor identifikasjonnummer på kontaktperson for dødsbo

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/service/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/persondata/PersondataFletter.kt
@@ -851,7 +851,10 @@ class PersondataFletter(
         val adressatPerson = tredjepartsPerson.map { it[adressat.identifikasjonsnummer] }.getOrNull()
         return Persondata.PersonSomAdressat(
             fnr = adressat.identifikasjonsnummer,
-            navn = adressatPerson?.navn ?: emptyList(),
+            navn =
+                adressatPerson?.navn
+                    ?: adressat.personnavn?.let { listOf(hentNavn(it)) }
+                    ?: emptyList(),
             fodselsdato = adressat.foedselsdato,
         )
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/persondata/PersondataFletter.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/persondata/PersondataFletter.kt
@@ -852,7 +852,7 @@ class PersondataFletter(
         return Persondata.PersonSomAdressat(
             fnr = adressat.identifikasjonsnummer,
             navn =
-                adressatPerson?.navn
+                adressatPerson?.navn?.takeIf { it.isNotEmpty() }
                     ?: adressat.personnavn?.let { listOf(hentNavn(it)) }
                     ?: emptyList(),
             fodselsdato = adressat.foedselsdato,

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataFletterTest.kt
@@ -11,6 +11,8 @@ import no.nav.modiapersonoversikt.service.persondata.PersondataFletter
 import no.nav.modiapersonoversikt.service.persondata.PersondataResult
 import no.nav.personoversikt.common.logging.TjenestekallLogg
 import no.nav.personoversikt.common.test.snapshot.SnapshotExtension
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -188,5 +190,30 @@ internal class PersondataFletterTest {
             )
 
         snapshot.assertMatches(result)
+    }
+
+    @Test
+    internal fun `skal bruke personnavn fra adressat når identifikasjonsnummer mangler`() {
+        val result =
+            mapper.flettSammenData(
+                data =
+                    testData.copy(
+                        personIdent = fnr,
+                        persondata =
+                            testPerson.copy(
+                                kontaktinformasjonForDoedsbo = listOf(kontaktinformasjonDodsboUtenIdentifikasjonsnummer),
+                            ),
+                    ),
+                clock = Clock.fixed(Instant.parse("2021-10-10T12:00:00.000Z"), ZoneId.systemDefault()),
+            )
+
+        val personSomAdressat =
+            result.person.dodsbo
+                .first()
+                .adressat.personSomAdressat
+        assertNull(personSomAdressat?.fnr, "fnr skal være null når identifikasjonsnummer mangler")
+        assertEquals(1, personSomAdressat?.navn?.size, "Navn skal hentes fra personnavn-feltet")
+        assertEquals("Ola", personSomAdressat?.navn?.first()?.fornavn)
+        assertEquals("Nordmann", personSomAdressat?.navn?.first()?.etternavn)
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/persondata/PersondataTestdata.kt
@@ -284,6 +284,34 @@ internal val kontaktinformasjonDodsbo =
             ),
     )
 
+internal val kontaktinformasjonDodsboUtenIdentifikasjonsnummer =
+    KontaktinformasjonForDoedsbo(
+        skifteform = KontaktinformasjonForDoedsboSkifteform.OFFENTLIG,
+        attestutstedelsesdato = gittDato("2014-05-02"),
+        personSomKontakt =
+            KontaktinformasjonForDoedsboPersonSomKontakt(
+                identifikasjonsnummer = null,
+                foedselsdato = gittDato("1960-01-01"),
+                personnavn =
+                    Personnavn(
+                        fornavn = "Ola",
+                        mellomnavn = null,
+                        etternavn = "Nordmann",
+                    ),
+            ),
+        advokatSomKontakt = null,
+        organisasjonSomKontakt = null,
+        metadata = metadata,
+        adresse =
+            KontaktinformasjonForDoedsboAdresse(
+                adresselinje1 = "Gateveien",
+                adresselinje2 = null,
+                poststedsnavn = "Poststed",
+                postnummer = "9988",
+                landkode = null,
+            ),
+    )
+
 internal val digitalKontaktinformasjon =
     Krr.DigitalKontaktinformasjon(
         personident = "12345678910",


### PR DESCRIPTION
I dag gjøres det en ekstra lookup etter tredjepartsperson med identifikasjonsnummer, men i de tilfellene hvor det ikke foreligger noe slikt nummer vil det ikke returneres noe navn på kontaktpersonen. Men i flere av disse tilfellene har vi allerede fått denne infoen fra PDL, og det er ikke behov for noe ekstra lookup.

Den nye logikken benytter derfor seg av denne informasjonen i de tilfellene hvor vi ikke har noe identifikasjonsnummer på kontaktpersonen.