### PR TITLE
Filtrer ut generelle saker fra SAF og generer liste med generell saker i egen kilde

### DIFF
--- a/proxy/src/main/java/no/nav/modiapersonoversikt/consumer/arena/sakVedtakService/JournalforingSak.java
+++ b/proxy/src/main/java/no/nav/modiapersonoversikt/consumer/arena/sakVedtakService/JournalforingSak.java
@@ -1,6 +1,5 @@
 package no.nav.modiapersonoversikt.consumer.arena.sakVedtakService;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.joda.time.DateTime;
 
@@ -11,11 +10,9 @@ import java.util.function.Predicate;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JournalforingSak implements Serializable, Comparable<JournalforingSak> {
     public String fnr = null;
-    public String saksId = null;
     public String fagsystemSaksId = null;
     public String temaKode, temaNavn, fagsystemKode, fagsystemNavn, sakstype;
     public DateTime opprettetDato;
-    public Boolean finnesIGsak = false, finnesIPsak = false;
 
     public static final String TEMAKODE_OPPFOLGING = "OPP";
     public static final String TEMAKODE_KLAGE_ANKE = "KLA";
@@ -37,11 +34,7 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
 
     public static final List<String> GODKJENTE_FAGSYSTEMER_FOR_FAGSAKER = List.of(FAGSYSTEMKODE_BIDRAG, FAGSYSTEMKODE_ARENA, FAGSYSTEMKODE_PSAK, FAGSYSTEMKODE_ETTERLATTE, FAGSYSTEMKODE_BARNETRYGD, FAGSYSTEMKODE_NEESSI, "IT01", "OEBS", "V2", "AO11", "FS36", "FS38", "K9", "SUPSTONAD", ENSLIG_FORSORGER, FAGSYSTEMKODE_KOMPYS, FAGSYSTEMKODE_ARBEIDSOPPFOLGING);
 
-    public boolean isSakstypeForVisningGenerell() {
-        return SAKSTYPE_GENERELL.equals(sakstype);
-    }
-
-    public static final Predicate<JournalforingSak> IS_GENERELL_SAK = JournalforingSak::isSakstypeForVisningGenerell;
+    public static final Predicate<JournalforingSak> IS_GENERELL_SAK = sak -> SAKSTYPE_GENERELL.equals(sak.sakstype);
 
     public static Predicate<JournalforingSak> harTemaKode(final String temaKode) {
         return sak -> temaKode.equals(sak.temaKode);
@@ -50,13 +43,6 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
     public static final Predicate<JournalforingSak> IS_ARENA_OPPFOLGING = sak -> TEMAKODE_OPPFOLGING.equals(sak.temaKode)
             && FAGSYSTEMKODE_ARENA.equals(sak.fagsystemKode)
             && SAKSTYPE_MED_FAGSAK.equals(sak.sakstype);
-
-    @JsonGetter
-    public String getSaksIdVisning() {
-        if(fagsystemSaksId != null) return fagsystemSaksId;
-        else if (saksId != null) return saksId;
-        else return "";
-    }
 
     @Override
     public int compareTo(JournalforingSak other) {
@@ -73,7 +59,7 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
         }
 
         JournalforingSak sak = (JournalforingSak) obj;
-        if (saksId != null && saksId.equals(sak.saksId)) {
+        if (fagsystemSaksId != null && fagsystemSaksId.equals(sak.fagsystemSaksId)) {
             return true;
         } else {
             return temaKode != null && sak.temaKode != null
@@ -87,8 +73,8 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
 
     @Override
     public int hashCode() {
-        if (saksId != null) {
-            return saksId.hashCode();
+        if (fagsystemSaksId != null) {
+            return fagsystemSaksId.hashCode();
         } else if (temaKode != null
                 && fagsystemKode != null
                 && sakstype != null) {

--- a/proxy/src/main/java/no/nav/modiapersonoversikt/consumer/arena/sakVedtakService/SakVedtakServiceImpl.kt
+++ b/proxy/src/main/java/no/nav/modiapersonoversikt/consumer/arena/sakVedtakService/SakVedtakServiceImpl.kt
@@ -55,13 +55,11 @@ class SakVedtakServiceImpl(
     companion object {
         private val TIL_SAK = { arenaSak: no.nav.arena.services.lib.sakvedtak.SaksInfo ->
             JournalforingSak().apply {
-                saksId = arenaSak.saksId
                 fagsystemSaksId = arenaSak.saksId
                 fagsystemKode = JournalforingSak.FAGSYSTEMKODE_ARENA
                 sakstype = JournalforingSak.SAKSTYPE_MED_FAGSAK
                 temaKode = arenaSak.tema
                 opprettetDato = DateTime(arenaSak.sakOpprettet.toGregorianCalendar().time)
-                finnesIGsak = false
             }
         }
     }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/JournalforingController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/journalforing/JournalforingController.kt
@@ -42,7 +42,7 @@ class JournalforingController
             @RequestBody sak: JournalforingSak,
             @RequestParam(value = "enhet") enhet: String?,
         ) {
-            val auditIdentifier = arrayOf(FNR to sak.fnr, TRAAD_ID to traadId, SAK_ID to sak.saksId)
+            val auditIdentifier = arrayOf(FNR to sak.fnr, TRAAD_ID to traadId, SAK_ID to sak.fagsystemSaksId)
             return tilgangskontroll
                 .check(tilgangTilBruker(Fnr.of(sak.fnr)))
                 .check(henvendelseTilhorerBruker(Fnr.of(sak.fnr), traadId))

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
@@ -177,7 +177,6 @@ class SakerController
             val saker =
                 this.saker.map {
                     Sak()
-                        .withSaksId(it.saksId)
                         .withFagsaksnummer(it.fagsystemSaksId)
                         .withTemakode(it.temaKode)
                         .withBaksystem(Baksystem.SAF)

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
@@ -177,6 +177,7 @@ class SakerController
             val saker =
                 this.saker.map {
                     Sak()
+                        .withSaksId(it.fagsystemSaksId)
                         .withFagsaksnummer(it.fagsystemSaksId)
                         .withTemakode(it.temaKode)
                         .withBaksystem(Baksystem.SAF)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.joda.time.DateTime;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -22,7 +23,7 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
 
     public static final String FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK = "FS22";
 
-    public static final Set<String> GODKJENTE_TEMA_FOR_GENERELL_SAK = Set.of("AAP", "AGR", "BAR", "BIL", "BID", "DAG", "ENF", "ERS", "EYO", "FEI", "FOR", "FOS", "FUL", "GEN", "GRA", "GRU", "HEL", "HJE", "IND", "KON", "KTR", "MED", "MOB", "OMS", "REH", "RVE", "RPO", "SAK", "SAP", "SER", "STO", "SUP", "SYK", "SYM", "TRK", "TRY", "TSR", "TSO", "UFM", "VEN", "YRA", "YRK", "FRI", TEMAKODE_OPPFOLGING, "POI", "PAI", "UNG", "OLJ", "BBF");
+    public static final List<String> GODKJENTE_TEMA_FOR_GENERELL_SAK = List.of("AAP", "AGR", "BAR", "BIL", "BID", "DAG", "ENF", "ERS", "EYO", "FEI", "FOR", "FOS", "FUL", "GEN", "GRA", "GRU", "HEL", "HJE", "IND", "KON", "KTR", "MED", "MOB", "OMS", "REH", "RVE", "RPO", "SAK", "SAP", "SER", "STO", "SUP", "SYK", "SYM", "TRK", "TRY", "TSR", "TSO", "UFM", "VEN", "YRA", "YRK", "FRI", TEMAKODE_OPPFOLGING, "POI", "PAI", "UNG", "OLJ", "BBF");
 
     public static final Predicate<JournalforingSak> IS_GENERELL_SAK = sak -> SAKSTYPE_GENERELL.equals(sak.sakstype);
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
@@ -5,7 +5,6 @@ import org.joda.time.DateTime;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSak.java
@@ -1,21 +1,18 @@
 package no.nav.modiapersonoversikt.service.journalforingsaker;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.joda.time.DateTime;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JournalforingSak implements Serializable, Comparable<JournalforingSak> {
     public String fnr = null;
-    public String saksId = "-";
-    public String fagsystemSaksId = "-";
+    public String fagsystemSaksId = null;
     public String temaKode, temaNavn, fagsystemKode, fagsystemNavn, sakstype;
     public DateTime opprettetDato = DateTime.now();
-    public Boolean finnesIGsak = false, finnesIPsak = false;
 
     public static final String TEMAKODE_OPPFOLGING = "OPP";
     public static final String SAKSTYPE_GENERELL = "GEN";
@@ -25,14 +22,9 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
 
     public static final String FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK = "FS22";
 
-    public static final List<String> GODKJENTE_TEMA_FOR_GENERELL_SAK = List.of("AAP", "AGR", "BAR", "BIL", "BID", "DAG", "ENF", "ERS", "EYO", "FEI", "FOR", "FOS", "FUL", "GEN", "GRA", "GRU", "HEL", "HJE", "IND", "KON", "KTR", "MED", "MOB", "OMS", "REH", "RVE", "RPO", "SAK", "SAP", "SER", "STO", "SUP", "SYK", "SYM", "TRK", "TRY", "TSR", "TSO", "UFM", "VEN", "YRA", "YRK", "FRI", TEMAKODE_OPPFOLGING, "POI", "PAI", "UNG", "OLJ", "BBF");
+    public static final Set<String> GODKJENTE_TEMA_FOR_GENERELL_SAK = Set.of("AAP", "AGR", "BAR", "BIL", "BID", "DAG", "ENF", "ERS", "EYO", "FEI", "FOR", "FOS", "FUL", "GEN", "GRA", "GRU", "HEL", "HJE", "IND", "KON", "KTR", "MED", "MOB", "OMS", "REH", "RVE", "RPO", "SAK", "SAP", "SER", "STO", "SUP", "SYK", "SYM", "TRK", "TRY", "TSR", "TSO", "UFM", "VEN", "YRA", "YRK", "FRI", TEMAKODE_OPPFOLGING, "POI", "PAI", "UNG", "OLJ", "BBF");
 
-
-    public boolean isSakstypeForVisningGenerell() {
-        return SAKSTYPE_GENERELL.equals(sakstype);
-    }
-
-    public static final Predicate<JournalforingSak> IS_GENERELL_SAK = JournalforingSak::isSakstypeForVisningGenerell;
+    public static final Predicate<JournalforingSak> IS_GENERELL_SAK = sak -> SAKSTYPE_GENERELL.equals(sak.sakstype);
 
     public static Predicate<JournalforingSak> harTemaKode(final String temaKode) {
         return sak -> temaKode.equals(sak.temaKode);
@@ -41,13 +33,6 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
     public static final Predicate<JournalforingSak> IS_ARENA_OPPFOLGING = sak -> TEMAKODE_OPPFOLGING.equals(sak.temaKode)
             && FAGSYSTEMKODE_ARENA.equals(sak.fagsystemKode)
             && SAKSTYPE_MED_FAGSAK.equals(sak.sakstype);
-
-    @JsonGetter
-    public String getSaksIdVisning() {
-        if(fagsystemSaksId != null && !fagsystemSaksId.equals("-")) return fagsystemSaksId;
-        else if (saksId != null && !saksId.equals("-")) return saksId;
-        else return "-";
-    }
 
     @Override
     public int compareTo(JournalforingSak other) {
@@ -64,7 +49,7 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
         }
 
         JournalforingSak sak = (JournalforingSak) obj;
-        if (saksId != null && !saksId.equals("-") && saksId.equals(sak.saksId)) {
+        if (fagsystemSaksId != null && fagsystemSaksId.equals(sak.fagsystemSaksId)) {
             return true;
         } else {
             return temaKode != null && sak.temaKode != null
@@ -78,8 +63,8 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
 
     @Override
     public int hashCode() {
-        if (saksId != null && !saksId.equals("-")) {
-            return saksId.hashCode();
+        if (fagsystemSaksId != null) {
+            return fagsystemSaksId.hashCode();
         } else if (temaKode != null
                 && fagsystemKode != null
                 && sakstype != null) {
@@ -89,3 +74,4 @@ public class JournalforingSak implements Serializable, Comparable<JournalforingS
         }
     }
 }
+

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/BidragSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/BidragSaker.kt
@@ -12,6 +12,7 @@ internal class BidragSaker : SakerKilde {
     ) {
         val bidragSak =
             JournalforingSak().apply {
+                fagsystemSaksId = "-"
                 temaKode = "BID"
                 temaNavn = "Bidrag"
                 fagsystemKode = JournalforingSak.FAGSYSTEMKODE_BIDRAG

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/BidragSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/BidragSaker.kt
@@ -12,16 +12,12 @@ internal class BidragSaker : SakerKilde {
     ) {
         val bidragSak =
             JournalforingSak().apply {
-                saksId = "-"
-                fagsystemSaksId = "-"
                 temaKode = "BID"
                 temaNavn = "Bidrag"
                 fagsystemKode = JournalforingSak.FAGSYSTEMKODE_BIDRAG
                 fagsystemNavn = "Kopiert inn i Bisys"
                 sakstype = JournalforingSak.SAKSTYPE_MED_FAGSAK
                 opprettetDato = null
-                finnesIGsak = false
-                finnesIPsak = false
             }
 
         saker.add(bidragSak)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/GenerelleSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/GenerelleSaker.kt
@@ -13,24 +13,11 @@ internal class GenerelleSaker : SakerKilde {
         saker: MutableList<JournalforingSak>,
     ) {
         val generelleSaker =
-            saker
-                .filter { obj: JournalforingSak -> obj.isSakstypeForVisningGenerell }
-
-        val manglendeGenerelleSaker =
-            JournalforingSak.GODKJENTE_TEMA_FOR_GENERELL_SAK
-                .filter { temakode: String ->
-                    harIngenSakerMedTemakode(temakode, generelleSaker) && JournalforingSak.TEMAKODE_OPPFOLGING != temakode
-                }.map { temakode: String -> lagGenerellSakMedTema(temakode) }
-
-        saker.addAll(manglendeGenerelleSaker)
+            JournalforingSak.GODKJENTE_TEMA_FOR_GENERELL_SAK.map { temakode: String -> lagGenerellSakMedTema(temakode) }
+        saker.addAll(generelleSaker)
     }
 
     companion object {
-        private fun harIngenSakerMedTemakode(
-            temakode: String,
-            generelleSaker: List<JournalforingSak>,
-        ): Boolean = generelleSaker.none { it.temaKode == temakode }
-
         private fun lagGenerellSakMedTema(temakode: String): JournalforingSak =
             JournalforingSak().apply {
                 temaKode = temakode

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/GenerelleSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/GenerelleSaker.kt
@@ -21,7 +21,6 @@ internal class GenerelleSaker : SakerKilde {
         private fun lagGenerellSakMedTema(temakode: String): JournalforingSak =
             JournalforingSak().apply {
                 temaKode = temakode
-                finnesIGsak = false
                 fagsystemKode = JournalforingSak.FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK
                 sakstype = JournalforingSak.SAKSTYPE_GENERELL
                 opprettetDato = DateTime.now()

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/OppfolgingsSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/OppfolgingsSaker.kt
@@ -24,7 +24,6 @@ internal class OppfolgingsSaker : SakerKilde {
             saker.add(
                 JournalforingSak().apply {
                     temaKode = JournalforingSak.TEMAKODE_OPPFOLGING
-                    finnesIGsak = false
                     fagsystemKode = JournalforingSak.FAGSYSTEM_FOR_OPPRETTELSE_AV_GENERELL_SAK
                     sakstype = JournalforingSak.SAKSTYPE_GENERELL
                     opprettetDato = DateTime.now()

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
@@ -24,20 +24,15 @@ class SafSaker(
                 ?.saker
                 ?.filterNotNull()
                 ?.filter {
-                    // Generelle saker håndteres av GenerelleSaker-kilden, og skal derfor ikke inkluderes her
-                    it.sakstype != Sakstype.GENERELL_SAK
+                    // Generelle saker håndteres av GenerelleSaker-kilden, og skal derfor ikke inkluderes her. Vi tar kun i mot fagsaker.
+                    it.sakstype == Sakstype.FAGSAK
                 }?.map {
                     JournalforingSak().apply {
                         opprettetDato = it.datoOpprettet?.let { convertJavaDateTimeToJoda(it) }
                         fagsystemSaksId = it.fagsakId
                         temaKode = it.tema?.name ?: ""
                         fagsystemKode = it.fagsaksystem ?: ""
-                        sakstype =
-                            when (it.sakstype) {
-                                Sakstype.FAGSAK -> "MFS"
-                                Sakstype.GENERELL_SAK -> "GEN"
-                                else -> throw IllegalStateException("Ukjent sakstype: ${it.sakstype}")
-                            }
+                        sakstype = "MFS"
                     }
                 }
                 ?: emptyList()

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
@@ -29,7 +29,6 @@ class SafSaker(
                 }?.map {
                     JournalforingSak().apply {
                         opprettetDato = it.datoOpprettet?.let { convertJavaDateTimeToJoda(it) }
-                        saksId = it.arkivsaksnummer
                         fagsystemSaksId = it.fagsakId
                         temaKode = it.tema?.name ?: ""
                         fagsystemKode = it.fagsaksystem ?: ""

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/journalforingsaker/kilder/SafSaker.kt
@@ -17,13 +17,16 @@ class SafSaker(
         fnr: String,
         saker: MutableList<JournalforingSak>,
     ) {
-        val resultat =
+        val fagSaker =
             service
                 .hentSaker(fnr)
                 .data
                 ?.saker
                 ?.filterNotNull()
-                ?.map {
+                ?.filter {
+                    // Generelle saker håndteres av GenerelleSaker-kilden, og skal derfor ikke inkluderes her
+                    it.sakstype != Sakstype.GENERELL_SAK
+                }?.map {
                     JournalforingSak().apply {
                         opprettetDato = it.datoOpprettet?.let { convertJavaDateTimeToJoda(it) }
                         saksId = it.arkivsaksnummer
@@ -40,7 +43,7 @@ class SafSaker(
                 }
                 ?: emptyList()
 
-        saker.addAll(resultat)
+        saker.addAll(fagSaker)
     }
 
     companion object {

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -173,13 +173,12 @@ class SfHenvendelseServiceImpl(
     ) {
         val callId = getCallId()
         val fixKjedeId = kjedeId.fixKjedeId()
-        val rensetSaksId = if (saksId == "-") null else saksId
 
         val fagsaksystem =
-            if (rensetSaksId != null) {
+            if (saksId != null) {
                 JournalRequestDTO.Fagsaksystem.valueOf(
                     requireNotNull(fagsakSystem) {
-                        "Ved journalføring mot $rensetSaksId er det påkrevd å sende med fagsakSystem saken kommer fra"
+                        "Ved journalføring mot $saksId er det påkrevd å sende med fagsakSystem saken kommer fra"
                     },
                 )
             } else {
@@ -193,7 +192,7 @@ class SfHenvendelseServiceImpl(
                     journalforendeEnhet = enhet,
                     kjedeId = fixKjedeId,
                     temakode = saksTema,
-                    fagsakId = if (saksTema == "BID") null else rensetSaksId,
+                    fagsakId = if (saksTema == "BID") null else saksId,
                     fagsaksystem = if (saksTema == "BID") null else fagsaksystem,
                 ),
             )

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sfhenvendelse/SfHenvendelseService.kt
@@ -173,12 +173,13 @@ class SfHenvendelseServiceImpl(
     ) {
         val callId = getCallId()
         val fixKjedeId = kjedeId.fixKjedeId()
+        val rensetSaksId = if (saksId == "-") null else saksId
 
         val fagsaksystem =
-            if (saksId != null) {
+            if (rensetSaksId != null) {
                 JournalRequestDTO.Fagsaksystem.valueOf(
                     requireNotNull(fagsakSystem) {
-                        "Ved journalføring mot $saksId er det påkrevd å sende med fagsakSystem saken kommer fra"
+                        "Ved journalføring mot $rensetSaksId er det påkrevd å sende med fagsakSystem saken kommer fra"
                     },
                 )
             } else {
@@ -192,7 +193,7 @@ class SfHenvendelseServiceImpl(
                     journalforendeEnhet = enhet,
                     kjedeId = fixKjedeId,
                     temakode = saksTema,
-                    fagsakId = if (saksTema == "BID") null else saksId,
+                    fagsakId = if (saksTema == "BID") null else rensetSaksId,
                     fagsaksystem = if (saksTema == "BID") null else fagsaksystem,
                 ),
             )

--- a/web/src/test/java/no/nav/modiapersonoversikt/rest/journalforing/JournalforingControllerTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/rest/journalforing/JournalforingControllerTest.kt
@@ -130,6 +130,6 @@ internal class JournalforingControllerTest {
             .post("/rest/journalforing/saker/") {
                 content = "{\"fnr\": \"10108000398\"}"
                 contentType = MediaType.APPLICATION_JSON
-            }.andExpect { jsonPath("$.saker[0].saksIdVisning", `is`(sak.fagsystemSaksId)) }
+            }.andExpect { jsonPath("$.saker[0].fagsystemSaksId", `is`(sak.fagsystemSaksId)) }
     }
 }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSakTest.java
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/JournalforingSakTest.java
@@ -8,53 +8,12 @@ import static org.hamcrest.Matchers.not;
 
 public class JournalforingSakTest {
 
-    private static final String FAGSYSTEM_SAKS_ID = "fagsystemSaksId";
-    private static final String SAKS_ID = "saksId";
     private static final String TEMAKODE = "temakode";
     private static final String FAGSYSTEMKODE = "fagsystemkode";
     private static final String SAKSTYPE = "sakstype";
 
     @Test
-    public void returnererFagsystemSaksIdDersomDenneErSatt() {
-        JournalforingSak sak = new JournalforingSak();
-        sak.fagsystemSaksId = FAGSYSTEM_SAKS_ID;
-        sak.saksId = SAKS_ID;
-
-        assertThat(sak.getSaksIdVisning(), is(FAGSYSTEM_SAKS_ID));
-    }
-
-    @Test
-    public void returnererSaksIdDersomDenneErSattOgIkkeFagsystemSaksIdErSatt() {
-        JournalforingSak sak = new JournalforingSak();
-        sak.saksId = SAKS_ID;
-
-        assertThat(sak.getSaksIdVisning(), is(SAKS_ID));
-    }
-
-    @Test
-    public void returnererTomStrengDersomFagsystemSaksIdOgSaksIdIkkeErSatt() {
-        assertThat(new JournalforingSak().getSaksIdVisning(), is("-"));
-    }
-
-    @Test
-    public void sammenlignerSakerBaertPaaSaksIdDersomDenneErSatt() {
-        JournalforingSak sak1 = new JournalforingSak();
-        sak1.saksId = SAKS_ID;
-
-        JournalforingSak sak2 = new JournalforingSak();
-        sak2.saksId = SAKS_ID;
-
-        JournalforingSak sak3 = new JournalforingSak();
-
-        assertThat(sak1.equals(sak2), is(true));
-        assertThat(sak1.hashCode(), is(sak2.hashCode()));
-
-        assertThat(sak1.equals(sak3), is(false));
-        assertThat(sak1.hashCode(), is(not(sak3.hashCode())));
-    }
-
-    @Test
-    public void sammenlignerSakerBaertPaaAndreFelterDersomSaksIdIkkeErSatt() {
+    public void sammenlignerSaker() {
         JournalforingSak sak1 = new JournalforingSak();
         sak1.temaKode = TEMAKODE;
         sak1.fagsystemKode = FAGSYSTEMKODE;
@@ -93,3 +52,4 @@ public class JournalforingSakTest {
         assertThat(sak1.hashCode(), is(not(sak5.hashCode())));
     }
 }
+

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
@@ -68,7 +68,7 @@ class SakerServiceImplTest {
         val saksliste: List<JournalforingSak> = sakerService.hentSaker(FNR).saker
 
         assertThat(saksliste[0].saksId, `is`(SakId_1))
-        assertThat(saksliste[3].fagsystemKode, `is`(""))
+        assertThat(saksliste[3].fagsystemKode, `is`("FS22"))
         assertThat(saksliste[saksliste.size - 1].sakstype, `is`(SAKSTYPE_MED_FAGSAK))
         assertThat(saksliste[saksliste.size - 1].temaKode, `is`("BID"))
         assertThat(saksliste[saksliste.size - 1].fagsystemKode, `is`("BISYS"))
@@ -81,10 +81,9 @@ class SakerServiceImplTest {
         val saksliste: List<JournalforingSak> = sakerService.hentSaker(FNR).saker
 
         val ungSaker = saksliste.filter { it.temaKode == Tema.UNG.toString() }
-        assertThat(ungSaker.size, `is`(2))
+        assertThat(ungSaker.size, `is`(1))
 
-        assertThat(ungSaker[0].saksId, `is`(SakId_6))
-        assertThat(ungSaker[1].saksId, `is`(SakId_7))
+        assertThat(ungSaker[0].saksId, `is`("-"))
 
         val paiSak = saksliste.find { it.temaKode == Tema.PAI.toString() }
         assertThat(paiSak, notNullValue())
@@ -92,6 +91,22 @@ class SakerServiceImplTest {
 
         assertThat(saksliste.find { it.temaKode == Tema.BBF.toString() }, notNullValue())
         assertThat(saksliste.find { it.temaKode == Tema.POI.toString() }, notNullValue())
+    }
+
+    @Test
+    fun `oppretter noyaktig en generell sak per tema`() {
+        every { safService.hentSaker(any()) } returns GenericGraphQlResponse()
+
+        val generelleSaker =
+            sakerService
+                .hentSaker(FNR)
+                .saker
+                .filter { it.sakstype == SAKSTYPE_GENERELL }
+
+        val sakerPerTema = generelleSaker.groupBy { it.temaKode }
+        sakerPerTema.forEach { (tema, saker) ->
+            assertThat("Tema $tema skal ha nøyaktig én generell sak", saker.size, `is`(1))
+        }
     }
 
     @Test

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
@@ -104,6 +104,7 @@ class SakerServiceImplTest {
                 .filter { it.sakstype == SAKSTYPE_GENERELL }
 
         val sakerPerTema = generelleSaker.groupBy { it.temaKode }
+        assertThat(sakerPerTema.keys.filterNotNull().toList(), `is`(JournalforingSak.GODKJENTE_TEMA_FOR_GENERELL_SAK))
         sakerPerTema.forEach { (tema, saker) ->
             assertThat("Tema $tema skal ha nøyaktig én generell sak", saker.size, `is`(1))
         }

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/journalforingsaker/SakerServiceImplTest.kt
@@ -25,6 +25,7 @@ import no.nav.modiapersonoversikt.testutils.AuthContextExtension
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.joda.time.DateTime
 import org.joda.time.LocalDate
@@ -67,7 +68,7 @@ class SakerServiceImplTest {
 
         val saksliste: List<JournalforingSak> = sakerService.hentSaker(FNR).saker
 
-        assertThat(saksliste[0].saksId, `is`(SakId_1))
+        assertThat(saksliste[0].fagsystemSaksId, `is`(FagsystemSakId_1))
         assertThat(saksliste[3].fagsystemKode, `is`("FS22"))
         assertThat(saksliste[saksliste.size - 1].sakstype, `is`(SAKSTYPE_MED_FAGSAK))
         assertThat(saksliste[saksliste.size - 1].temaKode, `is`("BID"))
@@ -77,17 +78,16 @@ class SakerServiceImplTest {
     @Test
     fun `transformerer response til saksliste nye temakoder`() {
         every { safService.hentSaker(any()) } returns createSaksliste()
-
         val saksliste: List<JournalforingSak> = sakerService.hentSaker(FNR).saker
 
         val ungSaker = saksliste.filter { it.temaKode == Tema.UNG.toString() }
         assertThat(ungSaker.size, `is`(1))
 
-        assertThat(ungSaker[0].saksId, `is`("-"))
+        assertThat(ungSaker[0].fagsystemSaksId, nullValue())
 
         val paiSak = saksliste.find { it.temaKode == Tema.PAI.toString() }
         assertThat(paiSak, notNullValue())
-        assertThat(paiSak?.saksId, `is`("-"))
+        assertThat(paiSak?.fagsystemSaksId, nullValue())
 
         assertThat(saksliste.find { it.temaKode == Tema.BBF.toString() }, notNullValue())
         assertThat(saksliste.find { it.temaKode == Tema.POI.toString() }, notNullValue())
@@ -147,13 +147,11 @@ class SakerServiceImplTest {
 
         every { arenaInfotrygdApi.hentOppfolgingssakFraArena(any()) } answers {
             JournalforingSak().apply {
-                saksId = sakId
-                fagsystemSaksId = saksId
+                fagsystemSaksId = sakId
                 fagsystemKode = JournalforingSak.FAGSYSTEMKODE_ARENA
                 sakstype = JournalforingSak.SAKSTYPE_MED_FAGSAK
                 temaKode = TEMAKODE_OPPFOLGING
                 opprettetDato = DateTime(xmlDato.toGregorianCalendar().time)
-                finnesIGsak = false
             }
         }
 
@@ -165,10 +163,9 @@ class SakerServiceImplTest {
                 .filter(harTemaKode(TEMAKODE_OPPFOLGING))
                 .toList()
         assertThat(saker.size, `is`(1))
-        assertThat(saker[0].saksIdVisning, `is`(sakId))
+        assertThat(saker[0].fagsystemSaksId, `is`(sakId))
         assertThat(saker[0].opprettetDato, `is`(dato.toDateTimeAtStartOfDay()))
         assertThat(saker[0].fagsystemKode, `is`(FAGSYSTEMKODE_ARENA))
-        assertThat(saker[0].finnesIGsak, `is`(false))
     }
 
     @Test


### PR DESCRIPTION
Generelle saker fra SAF kommer uten fagsaksid. Ved å journalfore på generelle saker så vil det i teorien bli håndtert uten id. Joark krever kun team for journalføring på generelle saker så det er ikke vits å skille på ulike generelle saker med samme tema.

Frå Saf så er me no kun interesserte i fagsakene, så me filtrerer ut generelle saker. Dei generelle sakene blir generert ut frå ei hardkoda liste. Det kan diskuteres om dette er den beste måten, men me legger til temaer der etterkvart som det er behov. 

I tillegg har eg refaktorert litt. Det var ein del ubrukte felter på journalføringssak. For alle journalføringsaker er det no sørget for at saken har ein fagsystemsakId eller ingen fagsystemsakId dersom det skal vera ein generell sak. Derfor trenger me ikkje lenger å bruke dei andre feltene for id på sakene då det fører til meir forvirring.

