### PR TITLE
Logg warnings fra graphQL

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
@@ -74,6 +74,21 @@ class LoggingGraphqlClient(
                 tjenestekallLogger.error("$name-response: $callId ($requestId)", tjenestekallFelt)
             }
 
+            (response.extensions?.get("warnings") as? List<*>)
+                ?.filterIsInstance<Map<*, *>>()
+                ?.forEach { w ->
+                    tjenestekallLogger.warn(
+                        "$name-warning: ${w["message"]}: $callId ($requestId)",
+                        mapOf(
+                            "query" to w["query"],
+                            "id" to w["id"],
+                            "code" to w["code"],
+                            "message" to w["message"],
+                            "details" to w["details"],
+                        ),
+                    )
+                }
+
             response
         } catch (exception: Exception) {
             log.error("Feilet ved oppslag mot $name (ID: $callId)", exception)

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
@@ -87,7 +87,7 @@ class LoggingGraphqlClient(
                             "details" to w["details"],
                         ),
                     )
-                    // Custom sjekk for PDL for å registrere om vi mangler opplysningstyper i behandlingskatalogen
+                    // Custom sjekk for å registrere om vi mangler opplysningstyper i behandlingskatalogen
                     val missing = (w["details"] as? Map<*, *>)?.get("missing") as? List<*>
                     if (!missing.isNullOrEmpty()) {
                         log.warn("Mangler opplysningstyper for {} (ID: {}): {}", name, callId, missing)

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/LoggingGraphqlClient.kt
@@ -87,6 +87,11 @@ class LoggingGraphqlClient(
                             "details" to w["details"],
                         ),
                     )
+                    // Custom sjekk for PDL for å registrere om vi mangler opplysningstyper i behandlingskatalogen
+                    val missing = (w["details"] as? Map<*, *>)?.get("missing") as? List<*>
+                    if (!missing.isNullOrEmpty()) {
+                        log.warn("Mangler opplysningstyper for {} (ID: {}): {}", name, callId, missing)
+                    }
                 }
 
             response


### PR DESCRIPTION
I hovedsak for å logge warnings som kjem når me manglar opplysningstyper i behandlingskatalogen frå PDL, men plukkar også opp warnings frå SAF.

Dette printes til tjenestekallloggen (team logs), men har også lagt til print til grafana for dette spesifikke tilfelle slik at me kan lage alert melding til slack.