### PR TITLE
Fjern saksid fra sak-klasse

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
@@ -62,7 +62,6 @@ object SakerApi {
 
     data class Sak(
         val temakode: String,
-        val saksid: String,
         val fagsaksnummer: String?,
         val avsluttet: LocalDateTime?,
         val fagsystem: String,
@@ -80,7 +79,6 @@ object SakerApi {
     data class SaksDokumenter(
         val temakode: String,
         val temanavn: String,
-        val saksid: String,
         val fagsaksnummer: String?,
         val tilhorendeDokumenter: List<Dokumentmetadata> = listOf(),
         val avsluttet: LocalDateTime?,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
@@ -91,12 +91,10 @@ object SakerApiMapper {
                         val harTilgang = tematilgang[sak.temakode] == true
                         val tilhorendeDokumenter =
                             resultatWrapper.resultat.dokumenter.filter {
-                                (it.tilhorendeSakid == sak.saksId && it.tilhorendeSakid != null) ||
-                                    (it.tilhorendeFagsakId == sak.fagsaksnummer && it.tilhorendeFagsakId != null)
+                                (it.tilhorendeFagsakId == sak.fagsaksnummer && it.tilhorendeFagsakId != null)
                             }
                         val sakstema = resultatWrapper.resultat.temaer.find { it.temakode == sak.temakode }
                         SakerApi.SaksDokumenter(
-                            saksid = sak.saksId,
                             temakode = sak.temakode,
                             temanavn = sakstema?.temanavn ?: "",
                             tilhorendeDokumenter = tilhorendeDokumenter.map(::mapTilDokumentMetadata),
@@ -153,7 +151,6 @@ object SakerApiMapper {
         private fun mapTilTilhorendeSak(sak: Sak) =
             SakerApi.Sak(
                 temakode = sak.temakode,
-                saksid = sak.saksId,
                 fagsaksnummer = sak.fagsaksnummer,
                 avsluttet = sak.avsluttet.map { it.toJavaDateTime() }.orElse(null),
                 fagsystem = sak.fagsystem,

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerController.kt
@@ -177,7 +177,6 @@ class SakerController
             val saker =
                 this.saker.map {
                     Sak()
-                        .withSaksId(it.fagsystemSaksId)
                         .withFagsaksnummer(it.fagsystemSaksId)
                         .withTemakode(it.temaKode)
                         .withBaksystem(Baksystem.SAF)

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/SakstemaServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/SakstemaServiceImpl.kt
@@ -240,14 +240,7 @@ class SakstemaServiceImpl
                             .filter { it != null }
                             .toList()
 
-                    val saksIds =
-                        tilhorendeSaker
-                            .stream()
-                            .map { obj: Sak -> obj.saksId }
-                            .filter { it != null }
-                            .toList()
-
-                    (fagsakIds.contains(dm.tilhorendeFagsakId) || saksIds.contains(dm.tilhorendeSakid)) && dm.temakode == temakode
+                    (fagsakIds.contains(dm.tilhorendeFagsakId) && dm.temakode == temakode)
                 }
 
             private fun tilhorendeFraHenvendelse(temakode: String): Predicate<DokumentMetadata> =

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/domain/Sak.java
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/domain/Sak.java
@@ -9,7 +9,7 @@ import static java.util.Optional.empty;
 
 public class Sak {
     private String temakode;
-    private String saksId;
+    private Optional<String> saksId;
     private String fagsaksnummer;
     private Optional<DateTime> avsluttet = empty();
     private String fagsystem;
@@ -41,20 +41,12 @@ public class Sak {
         return temakode;
     }
 
-    public String getSaksId() {
-        return saksId;
-    }
-
     public String temakode() {
         return this.temakode;
     }
 
     public String getFagsaksnummer() {
         return fagsaksnummer;
-    }
-
-    public String saksId() {
-        return this.saksId;
     }
 
     public Optional<DateTime> avsluttet() {
@@ -67,11 +59,6 @@ public class Sak {
 
     public Sak withTemakode(final String temakode) {
         this.temakode = temakode;
-        return this;
-    }
-
-    public Sak withSaksId(final String saksId) {
-        this.saksId = saksId;
         return this;
     }
 


### PR DESCRIPTION
Tidlegere blei det gjort ein antagelse om at alle saker frå Saf som er av typen FAGSAK har ein fagsaksid, dette viste seg å ikkje stemme i alle tilfeller. Saksid blir mappet til fagsaksid og derfor satt til null for visse saker. Dette førte til nullpointerexception. Me bruker ikkje saksid i frontenden, så tar heller å fjerner feltet.