### PR TITLE
Fjern baksystem filter på dokumenttema og returner tema med tilgang

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
@@ -70,23 +70,15 @@ object SakerApi {
     )
 
     data class ResultatSaksDokumenter(
-        val saker: List<SaksDokumenter>,
         val dokumenter: List<Dokumentmetadata>,
         val temaer: List<Sakstema>,
         val feilendeSystemer: List<Baksystem> = listOf(),
     )
 
-    data class SaksDokumenter(
+    data class Sakstema(
         val temakode: String,
         val temanavn: String,
-        val fagsaksnummer: String?,
-        val tilhorendeDokumenter: List<Dokumentmetadata> = listOf(),
-        val avsluttet: LocalDateTime?,
-        val opprettet: LocalDateTime?,
-        val fagsystem: String,
-        val fagsystemNavn: String?,
-        val baksystem: Baksystem,
-        val harTilgang: Boolean,
-        var feilendeSystemer: List<Baksystem> = listOf(),
+        val harTilgang: Boolean? = false,
+        val nyesteDokumentDato: LocalDateTime?,
     )
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApi.kt
@@ -78,7 +78,7 @@ object SakerApi {
     data class Sakstema(
         val temakode: String,
         val temanavn: String,
-        val harTilgang: Boolean? = false,
+        val harTilgang: Boolean = false,
         val nyesteDokumentDato: LocalDateTime?,
     )
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/rest/saker/SakerApiMapper.kt
@@ -86,31 +86,25 @@ object SakerApiMapper {
 
         fun mapTilResultatSaksDokumenter(resultatWrapper: ResultatWrapper<SaksData>) =
             SakerApi.ResultatSaksDokumenter(
-                saker =
-                    resultatWrapper.resultat.saker.map { sak ->
-                        val harTilgang = tematilgang[sak.temakode] == true
-                        val tilhorendeDokumenter =
-                            resultatWrapper.resultat.dokumenter.filter {
-                                (it.tilhorendeFagsakId == sak.fagsaksnummer && it.tilhorendeFagsakId != null)
-                            }
-                        val sakstema = resultatWrapper.resultat.temaer.find { it.temakode == sak.temakode }
-                        SakerApi.SaksDokumenter(
-                            temakode = sak.temakode,
-                            temanavn = sakstema?.temanavn ?: "",
-                            tilhorendeDokumenter = tilhorendeDokumenter.map(::mapTilDokumentMetadata),
-                            harTilgang = harTilgang,
-                            fagsaksnummer = sak.fagsaksnummer,
-                            fagsystemNavn = sak.fagsystemNavn.orElse(null),
-                            opprettet = sak.opprettetDato.map { it.toJavaDateTime() }.orElse(null),
-                            avsluttet = sak.avsluttet.map { it.toJavaDateTime() }.orElse(null),
-                            fagsystem = sak.fagsystem,
-                            baksystem = sak.baksystem,
-                        )
-                    },
-                temaer = resultatWrapper.resultat.temaer,
+                temaer = hentTemaerMedTilgangOgDato(resultatWrapper.resultat.temaer, resultatWrapper.resultat.dokumenter),
                 dokumenter = resultatWrapper.resultat.dokumenter.map(::mapTilDokumentMetadata),
                 feilendeSystemer = resultatWrapper.feilendeSystemer.toList(),
             )
+
+        private fun hentTemaerMedTilgangOgDato(
+            temaer: List<Sakstema>,
+            dokumenter: List<DokumentMetadata>,
+        ): List<SakerApi.Sakstema> {
+            val dokumenterGruppertEtterTema = dokumenter.groupBy { it.temakode }
+            return temaer.map { tema ->
+                SakerApi.Sakstema(
+                    temakode = tema.temakode,
+                    temanavn = tema.temanavn,
+                    harTilgang = tematilgang[tema.temakode] == true,
+                    nyesteDokumentDato = dokumenterGruppertEtterTema[tema.temakode]?.maxByOrNull { it.dato }?.dato,
+                )
+            }
+        }
 
         private fun mapTilDokumentMetadata(behandlingskjede: DokumentMetadata) =
             SakerApi.Dokumentmetadata(

--- a/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/SakstemaServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/service/sakstema/SakstemaServiceImpl.kt
@@ -216,7 +216,7 @@ class SakstemaServiceImpl
                     ).run({
                         val soknadsstatusTema = soknadsstatuser.keys
                         val dokumentTema =
-                            dokumentMetadata.filter { it.baksystem.contains(Baksystem.HENVENDELSE) }.map { it.temakode }
+                            dokumentMetadata.map { it.temakode }
                         val temaer = (sakerTema + dokumentTema + soknadsstatusTema).toSet()
                         LOG.info("Dokument soknadsstatuser tema", temaer)
                         temaer


### PR DESCRIPTION
Gamle modia tar no også i mot dokumenter og temaer frå endepunktet som er brukt i nye modia. Det er lagt til harTilgang og nyesteDokumentDato på kvart tema sidan det var attributter brukt i gamle modia. Det kan sikkert vera nyttig for nye modia i framtida også.

Har også fjerna filteret som var på temaer som filtrere på typen baksystem. Denne filtreringa har me ikkje på dokumenter, så det er ingen grunn til å fjerne temaene heller. 

Saker i endepunktet har aldri blitt brukt, så fjerna det.