### PR TITLE
Map tilgangsmasking response til string før mapping

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/tilgangsmaskinen/Tilgangsmaskinen.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/tilgangsmaskinen/Tilgangsmaskinen.kt
@@ -53,7 +53,7 @@ open class TilgangsmaskinenImpl(
                     response.isSuccessful -> TilgangsMaskinResponse(harTilgang = true)
                     response.isClientError -> {
                         val errorObject =
-                            objectMapper.readValue(response.body as String, ProblemDetailResponse::class.java)
+                            objectMapper.readValue(response.body?.string(), ProblemDetailResponse::class.java)
                         tjenestekallLogger.error(
                             header = "ClientException ved tilgang sjekking fra tilgangsmaskin",
                             fields =


### PR DESCRIPTION
"As string" vil aldri fungere på responsbodyen, så om nav ansatt ikkje har tilgang så har APIet vårt alltid catchet feil istaden for å returnere årsaken i responsen frå Tilgangsmaskinen.