### PR TITLE
🤖 Bruk veilarboppfolging sitt graphql-api 🤖

### DIFF
--- a/tjenestespesifikasjoner/pom.xml
+++ b/tjenestespesifikasjoner/pom.xml
@@ -47,6 +47,7 @@
         <module>tilgangsmaskinen</module>
         <module>aap-api-intern</module>
         <module>dagpenger-api</module>
+        <module>veilarboppfolging-api</module>
     </modules>
 
     <dependencyManagement>

--- a/tjenestespesifikasjoner/veilarboppfolging-api/pom.xml
+++ b/tjenestespesifikasjoner/veilarboppfolging-api/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>modiabrukerdialog</artifactId>
+        <groupId>no.nav.sbl.dialogarena</groupId>
+        <version>dev</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>veilarboppfolging-api</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.expediagroup</groupId>
+            <artifactId>graphql-kotlin-ktor-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.expediagroup</groupId>
+                <artifactId>graphql-kotlin-maven-plugin</artifactId>
+                <version>${graphql-kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-client</id>
+                        <goals>
+                            <goal>generate-client</goal>
+                        </goals>
+                        <configuration>
+                            <schemaFile>${project.basedir}/src/main/resources/veilarboppfolging/schema.graphql</schemaFile>
+                            <packageName>no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated</packageName>
+                            <serializer>KOTLINX</serializer>
+                            <queryFileDirectory>src/main/resources/veilarboppfolging/queries</queryFileDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                                <sourceDir>${project.build.directory}/generated-sources/graphql</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/.graphqlconfig
+++ b/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/.graphqlconfig
@@ -1,0 +1,15 @@
+{
+  "name": "veilarboppfolging-api",
+  "schemaPath": "schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "Veilarboppfolging GraphQL Endpoint": {
+        "url": "https://veilarboppfolging.intern.dev.nav.no/api/graphql",
+        "headers": {
+          "user-agent": "srvmodiabrukerdialog"
+        },
+        "introspect": false
+      }
+    }
+  }
+}

--- a/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/queries/hentOppfolgingStatus.graphql
+++ b/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/queries/hentOppfolgingStatus.graphql
@@ -1,0 +1,10 @@
+query HentOppfolgingStatus($fnr: String!) {
+    oppfolging(fnr: $fnr) {
+        erUnderOppfolging
+    }
+    brukerStatus(fnr: $fnr) {
+        manuell {
+            erManuell
+        }
+    }
+}

--- a/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/queries/hentOppfolgingsEnhetOgVeileder.graphql
+++ b/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/queries/hentOppfolgingsEnhetOgVeileder.graphql
@@ -1,0 +1,13 @@
+query HentOppfolgingsEnhetOgVeileder($fnr: String!) {
+    oppfolgingsEnhet(fnr: $fnr) {
+        enhet {
+            id
+            navn
+        }
+    }
+    brukerStatus(fnr: $fnr) {
+        veilederTilordning {
+            veilederIdent
+        }
+    }
+}

--- a/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/schema.graphql
+++ b/tjenestespesifikasjoner/veilarboppfolging-api/src/main/resources/veilarboppfolging/schema.graphql
@@ -1,0 +1,151 @@
+type Query {
+    oppfolgingsEnhet(fnr: String): OppfolgingsEnhetsInfo
+    oppfolging(fnr: String): OppfolgingDto
+    brukerStatus(fnr: String!): BrukerStatusDto
+    oppfolgingsPerioder(fnr: String!): [Oppfolgingsperiode]
+    veilederTilgang(fnr: String!): VeilederTilgang
+    gjeldendeOppfolgingsperiode: Oppfolgingsperiode
+    utmeldingskandidatTag(fnr: String!): UtmeldingskandidatTag
+}
+
+type VeilederTilgang {
+    harTilgang: Boolean
+    harVeilederLeseTilgangTilBruker: Boolean!
+    harVeilederLeseTilgangTilBrukersKontorsperre: Boolean
+    harVeilederTilgangFlytteBrukerTilEgetKontor: Boolean!
+    tilgang: TilgangResultat
+    harAktiveTiltaksdeltakelserVedFlyttingTilEgetKontor: Boolean
+}
+
+enum UtmeldingskandidatTag {
+    ARBEIDSSOKERPERIODE_AVSLUTTET_IKKE_LEVERT_MELDEKORT
+    ARBEIDSSOKERPERIODE_AVSLUTTET_SVARTE_NEI_I_BEKREFTELSE
+    ARBEIDSSOKERPERIODE_AVSLUTTET_ANNET
+}
+
+enum TilgangResultat {
+    HAR_TILGANG
+    IKKE_TILGANG_FORTROLIG_ADRESSE
+    IKKE_TILGANG_STRENGT_FORTROLIG_ADRESSE
+    IKKE_TILGANG_EGNE_ANSATTE
+    IKKE_TILGANG_ENHET
+    IKKE_TILGANG_MODIA
+}
+
+type OppfolgingsEnhetsInfo {
+    enhet: EnhetDto
+}
+
+type EnhetDto {
+    id: String!
+    navn: String!
+    kilde: Kilde!
+}
+
+enum Kilde {
+    ARENA
+    NORG
+}
+
+enum KanStarteOppfolging {
+    JA
+    JA_MED_MANUELL_GODKJENNING_PGA_UNDER_18
+    JA_MED_MANUELL_GODKJENNING_PGA_IKKE_BOSATT
+    JA_MED_MANUELL_GODKJENNING_PGA_IKKE_BOSATT_UNDER_18
+    JA_MED_MANUELL_GODKJENNING_PGA_DNUMMER_IKKE_EOS
+    JA_MED_MANUELL_GODKJENNING_PGA_DNUMMER_IKKE_EOS_UNDER_18
+    ALLEREDE_UNDER_OPPFOLGING
+    ALLEREDE_UNDER_OPPFOLGING_MEN_INAKTIVERT
+    ALLEREDE_UNDER_OPPFOLGING_MEN_INAKTIVERT_MEN_KREVER_MANUELL_GODKJENNING_PGA_IKKE_BOSATT
+    ALLEREDE_UNDER_OPPFOLGING_MEN_INAKTIVERT_MEN_KREVER_MANUELL_GODKJENNING_PGA_DNUMMER_IKKE_EOS
+    IKKE_TILGANG_FORTROLIG_ADRESSE
+    IKKE_TILGANG_STRENGT_FORTROLIG_ADRESSE
+    IKKE_TILGANG_EGNE_ANSATTE
+    IKKE_TILGANG_ENHET
+    IKKE_TILGANG_MODIA
+    DOD
+    IKKE_LOVLIG_OPPHOLD
+    UKJENT_STATUS_FOLKEREGISTERET
+    INGEN_STATUS_FOLKEREGISTERET
+}
+
+enum KanStarteOppfolgingEkstern {
+    JA
+    JA_MED_MANUELL_GODKJENNING_PGA_UNDER_18
+    JA_MED_MANUELL_GODKJENNING_PGA_IKKE_BOSATT
+    JA_MED_MANUELL_GODKJENNING_PGA_DNUMMER_IKKE_EOS
+    ALLEREDE_UNDER_OPPFOLGING
+    DOD
+    IKKE_LOVLIG_OPPHOLD
+    UKJENT_STATUS_FOLKEREGISTERET
+    INGEN_STATUS_FOLKEREGISTERET
+}
+
+type OppfolgingDto {
+    erUnderOppfolging: Boolean
+    kanStarteOppfolging: KanStarteOppfolging
+    kanStarteOppfolgingEkstern: KanStarteOppfolgingEkstern
+}
+
+type VeilederTilordningDto {
+    veilederIdent: String
+}
+
+type KrrStatusDto {
+    reservertIKrr: Boolean!
+    kanVarsles: Boolean!
+    registrertIKrr: Boolean!
+}
+
+type KontorSperre {
+    kontorId: String!
+}
+
+type BrukerStatusDto {
+    manuell: BrukerStatusManuellDto
+    erKontorsperret: Boolean!
+    kontorSperre: KontorSperre
+    krr: KrrStatusDto
+    arena: BrukerStatusArenaDto
+    veilederTilordning: VeilederTilordningDto
+    harAktiveTiltaksdeltakelser: Boolean!
+    ident: String!
+}
+
+type BrukerStatusArenaDto {
+    inaktivIArena: Boolean!
+    kanReaktiveres: Boolean
+    inaktiveringsdato: String
+    kvalifiseringsgruppe: String
+    formidlingsgruppe: String
+}
+
+type BrukerStatusManuellDto {
+    erManuell: Boolean
+    opprettetTidspunkt: String
+    begrunnelse: String
+    endretAvType: String
+    endretAvIdent: String
+}
+
+enum OppfolgingStartetBegrunnelse {
+    ARBEIDSSOKER_REGISTRERING
+    ARENA_SYNC_ARBS
+    ARENA_SYNC_IARBS
+    REAKTIVERT_OPPFOLGING
+    MANUELL_REGISTRERING_VEILEDER
+}
+
+type Oppfolgingsperiode {
+    startTidspunkt: String!
+    sluttTidspunkt: String
+    id: String!
+    startetBegrunnelse: OppfolgingStartetBegrunnelse
+    avsluttetAv: String
+    kvpPerioder: [KvpPeriode]
+}
+
+type KvpPeriode {
+    startTidspunkt: String!
+    sluttTidspunkt: String
+}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -239,6 +239,11 @@
         </dependency>
         <dependency>
             <groupId>no.nav.sbl.dialogarena</groupId>
+            <artifactId>veilarboppfolging-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.sbl.dialogarena</groupId>
             <artifactId>krr-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingConfig.kt
@@ -1,21 +1,22 @@
 package no.nav.modiapersonoversikt.consumer.veilarboppfolging
 
-import no.nav.common.rest.client.RestClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import no.nav.common.token_client.client.OnBehalfOfTokenClient
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import no.nav.modiapersonoversikt.config.interceptor.TjenestekallLoggingInterceptorFactory
-import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
-import no.nav.modiapersonoversikt.infrastructure.http.AuthorizationInterceptor
-import no.nav.modiapersonoversikt.infrastructure.http.XCorrelationIdInterceptor
+import no.nav.modiapersonoversikt.infrastructure.http.LoggingGraphqlClient
 import no.nav.modiapersonoversikt.infrastructure.ping.ConsumerPingable
 import no.nav.modiapersonoversikt.infrastructure.ping.Pingable
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.utils.DownstreamApi
 import no.nav.modiapersonoversikt.utils.bindTo
+import no.nav.personoversikt.common.logging.TjenestekallLogger
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import java.net.URL
 
 @Configuration
 @EnableCaching
@@ -29,28 +30,34 @@ open class ArbeidsrettetOppfolgingConfig {
         ansattService: AnsattService,
         onBehalfOfTokenClient: OnBehalfOfTokenClient,
         tjenestekallLoggingInterceptorFactory: TjenestekallLoggingInterceptorFactory,
+        tjenestekallLogger: TjenestekallLogger,
     ): ArbeidsrettetOppfolging.Service {
-        val httpClient =
-            RestClient
-                .baseClient()
-                .newBuilder()
-                .addInterceptor(XCorrelationIdInterceptor())
-                .addInterceptor(
-                    tjenestekallLoggingInterceptorFactory("Oppfolging") {
-                        requireNotNull(it.header("X-Correlation-ID")) {
-                            "Kall uten \"X-Correlation-ID\" er ikke lov"
-                        }
-                    },
-                ).addInterceptor(
-                    AuthorizationInterceptor {
-                        AuthContextUtils.requireBoundedClientOboToken(onBehalfOfTokenClient.bindTo(downstreamApi))
-                    },
-                ).build()
+        val gqlHttpClient =
+            HttpClient(engineFactory = OkHttp) {
+                engine {
+                    addInterceptor(
+                        tjenestekallLoggingInterceptorFactory("veilarboppfolging-gql") { request ->
+                            requireNotNull(request.header("X-Correlation-ID")) {
+                                "Kall uten \"X-Correlation-ID\" er ikke lov"
+                            }
+                        },
+                    )
+                }
+            }
+
+        val graphQLClient =
+            LoggingGraphqlClient(
+                "Veilarboppfolging",
+                URL("$url/api/graphql"),
+                gqlHttpClient,
+                tjenestekallLogger,
+            )
 
         return ArbeidsrettetOppfolgingServiceImpl(
             apiUrl = url,
             ansattService = ansattService,
-            httpClient = httpClient,
+            graphQLClient = graphQLClient,
+            oboTokenClient = onBehalfOfTokenClient.bindTo(downstreamApi),
         )
     }
 

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
@@ -48,15 +48,16 @@ open class ArbeidsrettetOppfolgingServiceImpl(
     }
 
     @Cacheable
-    override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status {
-        val result =
+override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status {
+        val data =
             runBlocking {
-                graphQLClient.execute(
-                    HentOppfolgingStatus(HentOppfolgingStatus.Variables(fnr = fodselsnummer.get())),
-                    userTokenAuthorizationHeaders,
-                )
-            }
-        val data = requireNotNull(result.data) { "Mangler data i HentOppfolgingStatus-respons" }
+                no.nav.modiapersonoversikt.infrastructure.http.assertNoErrors(
+                    graphQLClient.execute(
+                        HentOppfolgingStatus(HentOppfolgingStatus.Variables(fnr = fodselsnummer.get())),
+                        userTokenAuthorizationHeaders,
+                    ),
+                ).data
+            } ?: error("Mangler data i HentOppfolgingStatus-respons")
         return ArbeidsrettetOppfolging.Status(
             underOppfolging = data.oppfolging?.erUnderOppfolging ?: false,
             erManuell = data.brukerStatus?.manuell?.erManuell ?: false,

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
@@ -1,25 +1,28 @@
 package no.nav.modiapersonoversikt.consumer.veilarboppfolging
 
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
+import io.ktor.client.request.header
+import kotlinx.coroutines.runBlocking
 import no.nav.common.rest.client.RestClient
 import no.nav.common.types.identer.Fnr
 import no.nav.common.types.identer.NavIdent
-import no.nav.modiapersonoversikt.infrastructure.http.OkHttpUtils.objectMapper
-import no.nav.modiapersonoversikt.rest.common.FnrRequest
+import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfolgingStatus
+import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfolgingsEnhetOgVeileder
+import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
+import no.nav.modiapersonoversikt.infrastructure.http.HeadersBuilder
+import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
+import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
-import kotlin.reflect.KClass
 
 @CacheConfig(cacheNames = ["oppfolgingsinfoCache"], keyGenerator = "userkeygenerator")
 open class ArbeidsrettetOppfolgingServiceImpl(
     apiUrl: String,
     private val ansattService: AnsattService,
-    private val httpClient: OkHttpClient,
+    private val graphQLClient: GraphQLKtorClient,
+    private val oboTokenClient: BoundedOnBehalfOfTokenClient,
 ) : ArbeidsrettetOppfolging.Service {
     private val url = apiUrl.removeSuffix("/")
 
@@ -45,11 +48,20 @@ open class ArbeidsrettetOppfolgingServiceImpl(
     }
 
     @Cacheable
-    override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status =
-        httpClient.fetchJson(
-            url = "$url/underoppfolging?fnr=${fodselsnummer.get()}",
-            type = ArbeidsrettetOppfolging.Status::class,
+    override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status {
+        val result =
+            runBlocking {
+                graphQLClient.execute(
+                    HentOppfolgingStatus(HentOppfolgingStatus.Variables(fnr = fodselsnummer.get())),
+                    userTokenAuthorizationHeaders,
+                )
+            }
+        val data = requireNotNull(result.data) { "Mangler data i HentOppfolgingStatus-respons" }
+        return ArbeidsrettetOppfolging.Status(
+            underOppfolging = data.oppfolging?.erUnderOppfolging ?: false,
+            erManuell = data.brukerStatus?.manuell?.erManuell ?: false,
         )
+    }
 
     override fun ping() {
         val request =
@@ -66,37 +78,34 @@ open class ArbeidsrettetOppfolgingServiceImpl(
             ?.string()
     }
 
-    private fun hentOppfolgingsEnhetOgVeileder(fodselsnummer: Fnr): ArbeidsrettetOppfolging.EnhetOgVeileder =
-        httpClient.fetchJson(
-            url = "$url/v2/person/hent-oppfolgingsstatus",
-            requestBody = FnrRequest(fnr = fodselsnummer.get()).toRequestBody(),
-            type = ArbeidsrettetOppfolging.EnhetOgVeileder::class,
+    private fun hentOppfolgingsEnhetOgVeileder(fodselsnummer: Fnr): ArbeidsrettetOppfolging.EnhetOgVeileder {
+        val result =
+            runBlocking {
+                graphQLClient.execute(
+                    HentOppfolgingsEnhetOgVeileder(
+                        HentOppfolgingsEnhetOgVeileder.Variables(fnr = fodselsnummer.get()),
+                    ),
+                    userTokenAuthorizationHeaders,
+                )
+            }
+        val data = requireNotNull(result.data) { "Mangler data i HentOppfolgingsEnhetOgVeileder-respons" }
+        return ArbeidsrettetOppfolging.EnhetOgVeileder(
+            oppfolgingsenhet =
+                data.oppfolgingsEnhet?.enhet?.let {
+                    ArbeidsrettetOppfolging.OppfolgingsEnhet(
+                        enhetId = it.id,
+                        navn = it.navn,
+                    )
+                },
+            veilederId = data.brukerStatus?.veilederTilordning?.veilederIdent,
         )
+    }
 
-    private fun <T : Any> OkHttpClient.fetchJson(
-        url: String,
-        requestBody: RequestBody? = null,
-        type: KClass<T>,
-    ): T {
-        val request =
-            Request
-                .Builder()
-                .url(url)
-                .apply {
-                    requestBody?.let {
-                        this.post(it)
-                    }
-                }.build()
-        val response = this.newCall(request).execute()
-        val statusCode = response.code
-        val body = response.body?.string()
-
-        if (statusCode in 200 until 300) {
-            return objectMapper.readValue(body, type.java)
-        } else {
-            throw IllegalStateException("Forventet 200-range svar og body fra oppfolging-api, men fikk: $statusCode\n$body")
-        }
+    private val userTokenAuthorizationHeaders: HeadersBuilder = {
+        val token = AuthContextUtils.requireBoundedClientOboToken(oboTokenClient)
+        val callId = getCallId()
+        header("Authorization", "Bearer $token")
+        header("Content-Type", "application/json")
+        header("X-Correlation-ID", callId)
     }
 }
-
-fun FnrRequest.toRequestBody(): RequestBody = objectMapper.writeValueAsString(this).toRequestBody("application/json".toMediaType())

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
@@ -10,7 +10,6 @@ import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfo
 import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfolgingsEnhetOgVeileder
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersBuilder
-import no.nav.modiapersonoversikt.infrastructure.http.getCallId
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import okhttp3.Request
@@ -104,9 +103,7 @@ override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.S
 
     private val userTokenAuthorizationHeaders: HeadersBuilder = {
         val token = AuthContextUtils.requireBoundedClientOboToken(oboTokenClient)
-        val callId = getCallId()
         header("Authorization", "Bearer $token")
         header("Content-Type", "application/json")
-        header("X-Correlation-ID", callId)
     }
 }

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/veilarboppfolging/ArbeidsrettetOppfolgingServiceImpl.kt
@@ -10,6 +10,7 @@ import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfo
 import no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.HentOppfolgingsEnhetOgVeileder
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.infrastructure.http.HeadersBuilder
+import no.nav.modiapersonoversikt.infrastructure.http.assertNoErrors
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
 import okhttp3.Request
@@ -47,16 +48,15 @@ open class ArbeidsrettetOppfolgingServiceImpl(
     }
 
     @Cacheable
-override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status {
-        val data =
-            runBlocking {
-                no.nav.modiapersonoversikt.infrastructure.http.assertNoErrors(
-                    graphQLClient.execute(
-                        HentOppfolgingStatus(HentOppfolgingStatus.Variables(fnr = fodselsnummer.get())),
-                        userTokenAuthorizationHeaders,
-                    ),
-                ).data
-            } ?: error("Mangler data i HentOppfolgingStatus-respons")
+    override fun hentOppfolgingStatus(fodselsnummer: Fnr): ArbeidsrettetOppfolging.Status {
+        val data = runBlocking {
+            graphQLClient.execute(
+                HentOppfolgingStatus(HentOppfolgingStatus.Variables(fnr = fodselsnummer.get())),
+                userTokenAuthorizationHeaders,
+            )
+                .assertNoErrors()
+                .data
+        } ?: error("Mangler data i HentOppfolgingStatus-respons")
         return ArbeidsrettetOppfolging.Status(
             underOppfolging = data.oppfolging?.erUnderOppfolging ?: false,
             erManuell = data.brukerStatus?.manuell?.erManuell ?: false,

--- a/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/infrastructure/http/OkHttpUtils.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.ktor.util.toLowerCasePreservingASCIIRules
 import no.nav.common.log.MDCConstants
 import no.nav.common.utils.IdUtils
 import no.nav.modiapersonoversikt.service.unleash.Feature
@@ -105,7 +106,7 @@ class LoggingInterceptor(
             "$name-request: $callId ($requestId)",
             mapOf(
                 "url" to request.url.toString(),
-                "headers" to requestHeaders,
+                "headers" to requestHeaders.filterKeys { it.toLowerCasePreservingASCIIRules() != "authorization" },
                 "body" to requestBody,
             ),
         )

--- a/web/src/test/java/no/nav/modiapersonoversikt/service/oppfolgingsinfo/ArbeidsrettetOppfolgingImplTest.kt
+++ b/web/src/test/java/no/nav/modiapersonoversikt/service/oppfolgingsinfo/ArbeidsrettetOppfolgingImplTest.kt
@@ -1,12 +1,16 @@
 package no.nav.modiapersonoversikt.service.oppfolgingsinfo
 
-import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
-import com.marcinziolo.kotlin.wiremock.post
-import com.marcinziolo.kotlin.wiremock.returns
-import com.marcinziolo.kotlin.wiremock.returnsJson
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.PlainJWT
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -20,17 +24,12 @@ import no.nav.modiapersonoversikt.consumer.veilarboppfolging.ArbeidsrettetOppfol
 import no.nav.modiapersonoversikt.consumer.veilarboppfolging.ArbeidsrettetOppfolgingServiceImpl
 import no.nav.modiapersonoversikt.infrastructure.AuthContextUtils
 import no.nav.modiapersonoversikt.service.ansattservice.AnsattService
-import no.nav.modiapersonoversikt.service.unleash.Feature
-import no.nav.modiapersonoversikt.service.unleash.UnleashService
 import no.nav.modiapersonoversikt.utils.BoundedOnBehalfOfTokenClient
-import no.nav.modiapersonoversikt.utils.WireMockUtils.get
-import no.nav.modiapersonoversikt.utils.WireMockUtils.json
-import no.nav.modiapersonoversikt.utils.WireMockUtils.status
-import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.net.URL
 
 class ArbeidsrettetOppfolgingImplTest {
     companion object {
@@ -38,7 +37,6 @@ class ArbeidsrettetOppfolgingImplTest {
         @RegisterExtension
         val wiremock = WireMockExtension.newInstance().build()
 
-        private val httpClient = OkHttpClient()
         private const val FNR = "12345678910"
         private val testSubject =
             AuthContext(
@@ -80,12 +78,10 @@ class ArbeidsrettetOppfolgingImplTest {
     }
 
     private fun setup(underOppfolging: Boolean): Pair<ArbeidsrettetOppfolging.Service, AnsattService> {
-        gittUnderOppfolging(underOppfolging)
-        gittOppfolgingStatus()
-
-        val unleashService = mockk<UnleashService>()
-        every { unleashService.isEnabled(Feature.LOG_REQUEST_BODY.propertyKey) } returns true
-        every { unleashService.isEnabled(Feature.LOG_REQUEST_BODY.propertyKey) } returns true
+        gittOppfolgingStatusResponse(underOppfolging)
+        if (underOppfolging) {
+            gittOppfolgingsEnhetOgVeilederResponse()
+        }
 
         val ansattService = mockk<AnsattService>()
         every { ansattService.hentVeileder(eq(NavIdent("Z999999"))) } returns
@@ -98,51 +94,71 @@ class ArbeidsrettetOppfolgingImplTest {
         val oboTokenProvider = mockk<BoundedOnBehalfOfTokenClient>()
         every { oboTokenProvider.exchangeOnBehalfOfToken(testSubject.idToken.serialize()) } returns "OBO-TOKEN"
 
+        val gqlClient =
+            GraphQLKtorClient(
+                url = URL("http://localhost:${wiremock.port}/api/graphql"),
+                httpClient = HttpClient(OkHttp),
+            )
+
         val apiClient =
             ArbeidsrettetOppfolgingServiceImpl(
                 apiUrl = "http://localhost:${wiremock.port}",
                 ansattService = ansattService,
-                httpClient = httpClient,
+                graphQLClient = gqlClient,
+                oboTokenClient = oboTokenProvider,
             )
         return Pair(apiClient, ansattService)
     }
 
-    private fun gittOppfolgingStatus() {
-        @Language("json")
-        val returnbody =
-            """
-            {
-                "oppfolgingsenhet": {
-                  "navn": "NAV Enhet",
-                  "enhetId": "1234"
-                },
-                "veilederId": "Z999999",
-                "formidlingsgruppe": "IARBS"
-            }
-            """.trimIndent()
-
-        wiremock
-            .post {
-                urlMatching("/v2/person/hent-oppfolgingsstatus")
-            }.returnsJson {
-                status(200)
-                body = returnbody
-            }
-    }
-
-    private fun gittUnderOppfolging(underOppfolging: Boolean) {
+    private fun gittOppfolgingStatusResponse(underOppfolging: Boolean) {
         @Language("json")
         val body =
             """
             {
-                "erManuell": true,
-                "underOppfolging": $underOppfolging
+                "data": {
+                    "oppfolging": { "erUnderOppfolging": $underOppfolging },
+                    "brukerStatus": { "manuell": { "erManuell": true } }
+                }
             }
             """.trimIndent()
 
-        wiremock.get(urlMatching("/underoppfolging\\?fnr.*")) {
-            status(200)
-            json(body)
-        }
+        wiremock.stubFor(
+            post(urlEqualTo("/api/graphql"))
+                .withRequestBody(matchingJsonPath("$.operationName", equalTo("HentOppfolgingStatus")))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(body),
+                ),
+        )
+    }
+
+    private fun gittOppfolgingsEnhetOgVeilederResponse() {
+        @Language("json")
+        val body =
+            """
+            {
+                "data": {
+                    "oppfolgingsEnhet": {
+                        "enhet": { "id": "1234", "navn": "NAV Enhet" }
+                    },
+                    "brukerStatus": {
+                        "veilederTilordning": { "veilederIdent": "Z999999" }
+                    }
+                }
+            }
+            """.trimIndent()
+
+        wiremock.stubFor(
+            post(urlEqualTo("/api/graphql"))
+                .withRequestBody(matchingJsonPath("$.operationName", equalTo("HentOppfolgingsEnhetOgVeileder")))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(body),
+                ),
+        )
     }
 }


### PR DESCRIPTION
Replaces the two REST calls in ArbeidsrettetOppfolgingServiceImpl with GraphQL queries against veilarboppfolging's /api/graphql endpoint, following the same
   pattern already used by PDL and SAF.

  What changed 

   - New Maven module tjenestespesifikasjoner/veilarboppfolging-api using graphql-kotlin-maven-plugin with a local schema.graphql (no SDL download step,     
  unlike pdl-api/saf-api which pull from GitHub Pages). Generates client classes into no.nav.modiapersonoversikt.consumer.veilarboppfolging.generated.
   - Two queries:
   - HentOppfolgingStatus — replaces GET /underoppfolging?fnr=.... Fetches oppfolging.erUnderOppfolging and brukerStatus.manuell.erManuell.
   - HentOppfolgingsEnhetOgVeileder — replaces POST /v2/person/hent-oppfolgingsstatus. Fetches oppfolgingsEnhet.enhet.{id,navn} and 
  brukerStatus.veilederTilordning.veilederIdent.
   - ArbeidsrettetOppfolgingConfig now builds a LoggingGraphqlClient backed by a Ktor/OkHttp HttpClient (same wiring as SafConfig/PdlOppslagServiceConfig).   
  The OBO token is attached per-request in userTokenAuthorizationHeaders rather than via an OkHttp interceptor.
   - ArbeidsrettetOppfolgingServiceImpl constructor signature changed: httpClient: OkHttpClient → graphQLClient: GraphQLKtorClient + oboTokenClient: 
  BoundedOnBehalfOfTokenClient. The ping() method still uses RestClient.baseClient() directly against $url/ping — unchanged.
   - FnrRequest.toRequestBody() extension removed (was only used here).
   - Test rewritten to stub POST /api/graphql via WireMock, distinguishing the two queries by operationName (HentOppfolgingStatus / 
  HentOppfolgingsEnhetOgVeileder). Uses GraphQLKtorClient directly rather than the logging wrapper to keep test setup simple.

Mapping mellom gamle og nye felter:
| Old field | New GraphQL field |
|--------|--------|
| underOppfolging | oppfolging.erUnderOppfolging |
| erManuell | brukerStatus.manuell.erManuell |
| veilederId | brukerStatus.veilederTilordning.veilederIdent |
| oppfolgingsenhet.enhetId | oppfolgingsEnhet.enhet.id |
| oppfolgingsenhet.navn | oppfolgingsEnhet.enhet.navn | 

