### PR TITLE
Bugfix logging krr

### DIFF
--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrServiceImpl.kt
@@ -37,7 +37,7 @@ class KrrServiceImpl(
                         )
                     }.map { data ->
                         val dto = data?.personer?.get(fnr)
-                        if (data?.feil !== null) {
+                        if (!data?.feil.isNullOrEmpty()) {
                             tjenestekallLogger.warn(
                                 header = "Feil ved henting av digital kontaktinformasjon fra krr",
                                 fields =

--- a/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrServiceImpl.kt
+++ b/web/src/main/java/no/nav/modiapersonoversikt/consumer/krr/KrrServiceImpl.kt
@@ -45,18 +45,10 @@ class KrrServiceImpl(
                                         "feilmelding" to data.feil,
                                     ),
                             )
-                            Krr.INGEN_KONTAKTINFO
                         }
                         if (dto != null) {
                             mapToDigitalKontaktInformasjon(dto)
                         } else {
-                            tjenestekallLogger.warn(
-                                header = "Feil ved henting av digital kontaktinformasjon fra krr: Tom respons for bruker",
-                                fields =
-                                    mapOf(
-                                        "fnr" to fnr,
-                                    ),
-                            )
                             Krr.INGEN_KONTAKTINFO
                         }
                     }.getOrElse {


### PR DESCRIPTION
Det blei ikkje sjekka om feilobjektet faktisk var tomt, så alle requests til krr blei logga som feil.
I tillegg - Dersom resultatet var tomt for ein bruker så blei det logga dobbel feil. Fjerna dette. No fungerer det slik at om resultatet inneheld eit feilobjekt som ikkje er tomt så blir det logga kun 1 warning, og denne inneheld feilmelding så derfor treng ein ikkje separat melding om at responsen er tom. Dersom det finnes data på personen vil denne bli returnert. Slik som før så blir det kasta ein feil dersom endepunktet feiler også. 